### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -13,7 +13,7 @@ if (CMAKE_SYSTEM_NAME STREQUAL "Windows")    # WIN32 and similar checks are soft
     #         mt.exe: general error c101008d: Failed to write the updated manifest to the resource of file...
     #set (CMAKE_EXE_LINKER_FLAGS "/MANIFEST:NO")
     set (CMAKE_CXX_FLAGS "/DWIN32 /D_WINDOWS /W3 /GR /EHsc /bigobj")
-elseif (NOT CMAKE_HOST_SYSTEM_NAME MATCHES "Android")
+elseif (NOT CMAKE_SYSTEM_NAME MATCHES "Android")
     set (CMAKE_CXX_FLAGS "-pthread")
     if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
         #static linkage


### PR DESCRIPTION
Previous type of **Android** detector doesn't work on **Termux**'s autobuilder **CI** machine (https://github.com/termux/termux-packages/pull/10444) so I propose following change in [**CMakeLists.txt**](https://github.com/netxs-group/vtm/blob/master/src/CMakeLists.txt):
 * Change <kbd>CMAKE_HOST_SYSTEM_NAME</kbd> to <kbd>CMAKE_SYSTEM_NAME</kbd>
Hopefully this fixes issue with **CI**.

> **NOTE!**
> This change doesn't affect on-build as no-matter of each type of **CMAKE_\*SYSTEM_NAME** it still builds on **Android** device

 - [x] Works and Tested