### PR TITLE
Tooltips and Terminal scrollback search

### DIFF
--- a/.resources/status/freebsd.svg
+++ b/.resources/status/freebsd.svg
@@ -18,8 +18,8 @@
     <text x="1000" y="140" transform="scale(.1)" text-anchor="end"
     >FreeBSD amd64</text>
     <text x="1230" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" text-anchor="start"
-    >v0.7.4</text>
+    >v0.7.5</text>
     <text x="1230" y="140" transform="scale(.1)" text-anchor="start"
-    >v0.7.4</text>
+    >v0.7.5</text>
   </g>
 </svg>

--- a/.resources/status/linux.svg
+++ b/.resources/status/linux.svg
@@ -18,8 +18,8 @@
     <text x="1000" y="140" transform="scale(.1)" text-anchor="end"
     >Linux amd64</text>
     <text x="1230" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" text-anchor="start"
-    >v0.7.4</text>
+    >v0.7.5</text>
     <text x="1230" y="140" transform="scale(.1)" text-anchor="start"
-    >v0.7.4</text>
+    >v0.7.5</text>
   </g>
 </svg>

--- a/.resources/status/macos.svg
+++ b/.resources/status/macos.svg
@@ -18,8 +18,8 @@
     <text x="1000" y="140" transform="scale(.1)" text-anchor="end"
     >macOS any</text>
     <text x="1230" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" text-anchor="start"
-    >v0.7.4</text>
+    >v0.7.5</text>
     <text x="1230" y="140" transform="scale(.1)" text-anchor="start"
-    >v0.7.4</text>
+    >v0.7.5</text>
   </g>
 </svg>

--- a/.resources/status/netbsd.svg
+++ b/.resources/status/netbsd.svg
@@ -18,8 +18,8 @@
     <text x="1000" y="140" transform="scale(.1)" text-anchor="end"
     >NetBSD amd64</text>
     <text x="1230" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" text-anchor="start"
-    >v0.7.4</text>
+    >v0.7.5</text>
     <text x="1230" y="140" transform="scale(.1)" text-anchor="start"
-    >v0.7.4</text>
+    >v0.7.5</text>
   </g>
 </svg>

--- a/.resources/status/openbsd.svg
+++ b/.resources/status/openbsd.svg
@@ -18,8 +18,8 @@
     <text x="1000" y="140" transform="scale(.1)" text-anchor="end"
     >OpenBSD amd64</text>
     <text x="1230" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" text-anchor="start"
-    >v0.7.4</text>
+    >v0.7.5</text>
     <text x="1230" y="140" transform="scale(.1)" text-anchor="start"
-    >v0.7.4</text>
+    >v0.7.5</text>
   </g>
 </svg>

--- a/.resources/status/windows.svg
+++ b/.resources/status/windows.svg
@@ -18,8 +18,8 @@
     <text x="1000" y="140" transform="scale(.1)" text-anchor="end"
     >Windows amd64</text>
     <text x="1230" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" text-anchor="start"
-    >v0.7.4</text>
+    >v0.7.5</text>
     <text x="1230" y="140" transform="scale(.1)" text-anchor="start"
-    >v0.7.4</text>
+    >v0.7.5</text>
   </g>
 </svg>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -11,14 +11,14 @@ if (CMAKE_SYSTEM_NAME STREQUAL "Windows")    # WIN32 and similar checks are soft
     # Disable manifest embedding for the windows builds.
     # Reason: Anti-virus program (Windows Defender) may lock and scan `vtm(d).exe` file before embedding the manifest.
     #         mt.exe: general error c101008d: Failed to write the updated manifest to the resource of file...
-    #set (CMAKE_EXE_LINKER_FLAGS "/MANIFEST:NO")
-    set (CMAKE_CXX_FLAGS "/DWIN32 /D_WINDOWS /W3 /GR /EHsc /bigobj")
+    #set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /MANIFEST:NO")
+    set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /DWIN32 /D_WINDOWS /W3 /GR /EHsc /bigobj")
 elseif (NOT CMAKE_SYSTEM_NAME MATCHES "Android")
-    set (CMAKE_CXX_FLAGS "-pthread")
+    set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread")
     if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
         #static linkage
-        #set (CMAKE_CXX_FLAGS "-static-libstdc++ -static-libgcc -pthread -s")
-        #set (CMAKE_CXX_FLAGS "-pthread -s")
+        #set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -static-libstdc++ -static-libgcc -pthread -s")
+        #set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread -s")
     endif ()
 endif ()
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -13,7 +13,7 @@ if (CMAKE_SYSTEM_NAME STREQUAL "Windows")    # WIN32 and similar checks are soft
     #         mt.exe: general error c101008d: Failed to write the updated manifest to the resource of file...
     #set (CMAKE_EXE_LINKER_FLAGS "/MANIFEST:NO")
     set (CMAKE_CXX_FLAGS "/DWIN32 /D_WINDOWS /W3 /GR /EHsc /bigobj")
-elseif (NOT CMAKE_HOST_SYSTEM_NAME MATCHES "Android")
+elseif (NOT CMAKE_SYSTEM_NAME MATCHES "Android")
     set (CMAKE_CXX_FLAGS "-pthread")
     if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
         #static linkage

--- a/src/netxs/apps.hpp
+++ b/src/netxs/apps.hpp
@@ -58,6 +58,9 @@ namespace netxs::app::shared
     #undef X
     #undef TYPE_LIST
 
+    using menu_item_type = std::tuple<text, text, std::function<void(ui::pads&)>>;
+    using menu_list_type = std::list<menu_item_type>;
+
     //static si32 max_count = 20;// 50;
     static si32 max_vtm = 3;
     static si32 vtm_count = 0;
@@ -72,6 +75,7 @@ namespace netxs::app::shared
     auto const action_color      = tint::greenlt ;
     auto background_color = cell{}.fgc(whitedk).bgc(0xFF000000 /* blackdk */);
 
+    const static auto c9 = cell{}.bgc(0xFFffffff).fgc(0xFF000000);
     const static auto c8 = cell{}.bgc(0x00).fgc(highlight_color);
     const static auto x8 = cell{ c8 }.bga(0x00).fga(0x00);
     const static auto c7 = cell{}.bgc(whitedk).fgc(blackdk);
@@ -108,7 +112,7 @@ namespace netxs::app::shared
         };
         boss->SUBMIT_BYVAL(tier::release, e2::form::upon::vtree::attached, parent)
         {
-            parent->base::riseup<tier::preview>(e2::form::prop::header, title);
+            parent->base::riseup<tier::preview>(e2::form::prop::ui::header, title);
         };
     };
     const auto scroll_bars = [](auto master)
@@ -154,7 +158,7 @@ namespace netxs::app::shared
     };
 
     // Menu bar (shrinkable on right-click).
-    const auto custom_menu = [](bool full_size, std::list<std::pair<text, std::function<void(ui::pads&)>>> menu_items)
+    const auto custom_menu = [](bool full_size, std::list<std::tuple<text, text, std::function<void(ui::pads&)>>> menu_items)
     {
         auto menu_area = ui::fork::ctor()
                         ->active();
@@ -163,6 +167,7 @@ namespace netxs::app::shared
                                         
                 menu_list->attach(slot::_1, ui::pads::ctor(inner_pads, dent{ 0 }))
                          ->plugin<pro::fader>(x3, c3, 150ms)
+                         ->plugin<pro::notes>(" Maximize/restore window ")
                          ->invoke([&](ui::pads& boss)
                          {
                              boss.SUBMIT(tier::release, hids::events::mouse::button::click::left, gear)
@@ -184,10 +189,12 @@ namespace netxs::app::shared
 
             for (auto& body : menu_items) scrl_list->attach(ui::pads::ctor(inner_pads, dent{ 1 }))
                                                    ->plugin<pro::fader>(x3, c3, 150ms)
-                                                   ->invoke(body.second)
-                                                   ->attach(ui::item::ctor(body.first, faux, true));
+                                                   ->plugin<pro::notes>(std::get<1>(body))
+                                                   ->invoke(std::get<2>(body))
+                                                   ->attach(ui::item::ctor(std::get<0>(body), faux, true));
             menu_area->attach(slot::_2, ui::pads::ctor(dent{ 2,2,1,1 }, dent{}))
                      ->plugin<pro::fader>(x1, c1, 150ms)
+                     ->plugin<pro::notes>(" Close window ")
                      ->invoke([&](auto& boss)
                      {
                          boss.SUBMIT(tier::release, hids::events::mouse::button::click::left, gear)
@@ -273,13 +280,13 @@ namespace netxs::app::shared
 
     const auto main_menu = []()
     {
-        auto items = std::list
+        auto items = app::shared::menu_list_type
         {
-            std::pair<text, std::function<void(ui::pads&)>>{ ansi::und(true).add("F").nil().add("ile"), [&](auto& boss){ } },
-            std::pair<text, std::function<void(ui::pads&)>>{ ansi::und(true).add("E").nil().add("dit"), [&](auto& boss){ } },
-            std::pair<text, std::function<void(ui::pads&)>>{ ansi::und(true).add("V").nil().add("iew"), [&](auto& boss){ } },
-            std::pair<text, std::function<void(ui::pads&)>>{ ansi::und(true).add("D").nil().add("ata"), [&](auto& boss){ } },
-            std::pair<text, std::function<void(ui::pads&)>>{ ansi::und(true).add("H").nil().add("elp"), [&](auto& boss){ } },
+            { ansi::und(true).add("F").nil().add("ile"), " File menu item ", [&](auto& boss){ } },
+            { ansi::und(true).add("E").nil().add("dit"), " Edit menu item ", [&](auto& boss){ } },
+            { ansi::und(true).add("V").nil().add("iew"), " View menu item ", [&](auto& boss){ } },
+            { ansi::und(true).add("D").nil().add("ata"), " Data menu item ", [&](auto& boss){ } },
+            { ansi::und(true).add("H").nil().add("elp"), " Help menu item ", [&](auto& boss){ } },
         };
         return custom_menu(true, items);
     };
@@ -417,6 +424,7 @@ namespace netxs::app::shared
         {
             auto window = ui::cake::ctor();
             auto strob = window->plugin<pro::focus>()
+                               ->plugin<pro::notes>(" Left+Right click to close ")
                                ->invoke([](auto& boss)
                                 {
                                     boss.keybd.accept(true);
@@ -441,6 +449,7 @@ namespace netxs::app::shared
             auto window = ui::cake::ctor();
             window->plugin<pro::focus>()
                   ->plugin<pro::cache>()
+                  ->plugin<pro::notes>(" Left+Right click to close ")
                   ->attach(ui::stem_rate<tier::general, decltype(e2::config::fps)>::ctor("Set frame rate limit", 1, 200, "fps"))
                   ->colors(0xFFFFFFFF, bluedk)
                   ->invoke([&](auto& boss)
@@ -456,6 +465,7 @@ namespace netxs::app::shared
             window->plugin<pro::focus>()
                   ->plugin<pro::track>()
                   ->plugin<pro::acryl>()
+                  ->plugin<pro::notes>(" Left+Right click to close ")
                   ->invoke([&](auto& boss)
                   {
                       boss.keybd.accept(true);
@@ -463,7 +473,7 @@ namespace netxs::app::shared
                       boss.SUBMIT(tier::release, e2::form::upon::vtree::attached, parent)
                       {
                           auto title = ansi::add("Empty Instance \nid: ", parent->id);
-                          boss.base::template riseup<tier::preview>(e2::form::prop::header, title);
+                          boss.base::template riseup<tier::preview>(e2::form::prop::ui::header, title);
                       };
                   });
             auto object = window->attach(ui::mock::ctor())
@@ -505,9 +515,16 @@ namespace netxs::app::shared
                         {
                             auto& parent = *parent_ptr;
                             closing_by_gesture(parent);
+
+                            //todo too hacky
+                            if (auto form_ptr = std::dynamic_pointer_cast<ui::cake>(parent_ptr))
+                            {
+                                form_ptr->plugin<pro::notes>(" Right click to set title from clipboard. Left+Right to close. ");
+                            }
+
                             static auto i = 0; i++;
                             auto title = ansi::add("View\nRegion ", i);
-                            boss.base::template riseup<tier::preview>(e2::form::prop::header, title);
+                            boss.base::template riseup<tier::preview>(e2::form::prop::ui::header, title);
                             
                             auto outer = dent{ 2,2,1,1 };
                             auto inner = dent{ -4,-4,-2,-2 };
@@ -519,8 +536,8 @@ namespace netxs::app::shared
                             {
                                 if (auto gate_ptr = bell::getref(gear.id))
                                 {
-                                    auto old_title = decltype(e2::form::prop::header)::type{};
-                                    boss.base::template riseup<tier::request>(e2::form::prop::header, old_title);
+                                    auto old_title = decltype(e2::form::prop::ui::header)::type{};
+                                    boss.base::template riseup<tier::request>(e2::form::prop::ui::header, old_title);
 
                                     auto data = decltype(e2::command::clipboard::get)::type{};
                                     gate_ptr->SIGNAL(tier::release, e2::command::clipboard::get, data);
@@ -528,11 +545,11 @@ namespace netxs::app::shared
                                     if (utf::is_plain(data)) // Reset aligning to the center if text is plain.
                                     {
                                         auto align = ansi::jet(bias::center);
-                                        boss.base::template riseup<tier::preview>(e2::form::prop::header, align);
+                                        boss.base::template riseup<tier::preview>(e2::form::prop::ui::header, align);
                                     }
                                     // Copy clipboard data to title.
-                                    auto title = decltype(e2::form::prop::header)::type{ data };
-                                    boss.base::template riseup<tier::preview>(e2::form::prop::header, title);
+                                    auto title = decltype(e2::form::prop::ui::header)::type{ data };
+                                    boss.base::template riseup<tier::preview>(e2::form::prop::ui::header, title);
                                     gear.dismiss();
 
                                     if (old_title.size()) // Copy old title to clipboard.

--- a/src/netxs/apps.hpp
+++ b/src/netxs/apps.hpp
@@ -835,6 +835,7 @@ namespace netxs::app::shared
             return ui::park::ctor()
                 ->branch(ui::snap::tail, ui::snap::tail, ui::item::ctor(MONOTTY_VER)
                 ->template plugin<pro::fader>(x8, c8, 0ms))
+                ->template plugin<pro::notes>(" About Environment ")
                 ->invoke([&](auto& boss)
                 {
                     auto shadow = ptr::shadow(boss.This());

--- a/src/netxs/apps.hpp
+++ b/src/netxs/apps.hpp
@@ -58,7 +58,7 @@ namespace netxs::app::shared
     #undef X
     #undef TYPE_LIST
 
-    using menu_item_type = std::tuple<text, text, std::function<void(ui::pads&)>>;
+    using menu_item_type = std::tuple<bool, text, text, std::function<void(ui::pads&)>>;
     using menu_list_type = std::list<menu_item_type>;
 
     //static si32 max_count = 20;// 50;
@@ -158,7 +158,7 @@ namespace netxs::app::shared
     };
 
     // Menu bar (shrinkable on right-click).
-    const auto custom_menu = [](bool full_size, std::list<std::tuple<text, text, std::function<void(ui::pads&)>>> menu_items)
+    const auto custom_menu = [](bool full_size, app::shared::menu_list_type menu_items)
     {
         auto menu_area = ui::fork::ctor()
                         ->active();
@@ -187,11 +187,29 @@ namespace netxs::app::shared
 
                 auto scrl_grip = scrl_area->attach(scroll_hint);
 
-            for (auto& body : menu_items) scrl_list->attach(ui::pads::ctor(inner_pads, dent{ 1 }))
-                                                   ->plugin<pro::fader>(x3, c3, 150ms)
-                                                   ->plugin<pro::notes>(std::get<1>(body))
-                                                   ->invoke(std::get<2>(body))
-                                                   ->attach(ui::item::ctor(std::get<0>(body), faux, true));
+            for (auto& body : menu_items)
+            {
+                auto& hover = std::get<0>(body);
+                auto& label = std::get<1>(body);
+                auto& notes = std::get<2>(body);
+                auto& setup = std::get<3>(body);
+                if (hover)
+                {
+                    scrl_list->attach(ui::pads::ctor(inner_pads, dent{ 1 }))
+                             ->plugin<pro::fader>(x3, c3, 150ms)
+                             ->plugin<pro::notes>(notes)
+                             ->invoke(setup)
+                             ->attach(ui::item::ctor(label, faux, true));
+                }
+                else
+                {
+                    scrl_list->attach(ui::pads::ctor(inner_pads, dent{ 1 }))
+                             ->colors(0,0) //todo for mouse tracking
+                             ->plugin<pro::notes>(notes)
+                             ->invoke(setup)
+                             ->attach(ui::item::ctor(label, faux, true));
+                }
+            }
             menu_area->attach(slot::_2, ui::pads::ctor(dent{ 2,2,1,1 }, dent{}))
                      ->plugin<pro::fader>(x1, c1, 150ms)
                      ->plugin<pro::notes>(" Close window ")
@@ -282,11 +300,11 @@ namespace netxs::app::shared
     {
         auto items = app::shared::menu_list_type
         {
-            { ansi::und(true).add("F").nil().add("ile"), " File menu item ", [&](auto& boss){ } },
-            { ansi::und(true).add("E").nil().add("dit"), " Edit menu item ", [&](auto& boss){ } },
-            { ansi::und(true).add("V").nil().add("iew"), " View menu item ", [&](auto& boss){ } },
-            { ansi::und(true).add("D").nil().add("ata"), " Data menu item ", [&](auto& boss){ } },
-            { ansi::und(true).add("H").nil().add("elp"), " Help menu item ", [&](auto& boss){ } },
+            { true, ansi::und(true).add("F").nil().add("ile"), " File menu item ", [&](auto& boss){ } },
+            { true, ansi::und(true).add("E").nil().add("dit"), " Edit menu item ", [&](auto& boss){ } },
+            { true, ansi::und(true).add("V").nil().add("iew"), " View menu item ", [&](auto& boss){ } },
+            { true, ansi::und(true).add("D").nil().add("ata"), " Data menu item ", [&](auto& boss){ } },
+            { true, ansi::und(true).add("H").nil().add("elp"), " Help menu item ", [&](auto& boss){ } },
         };
         return custom_menu(true, items);
     };

--- a/src/netxs/apps.hpp
+++ b/src/netxs/apps.hpp
@@ -501,11 +501,12 @@ namespace netxs::app::shared
                             auto fill = [&](cell& c) { c.fusefull(mark); };
                             parent_canvas.cage(area, dot_21, fill);
                         };
-                        boss.SUBMIT(tier::release, e2::form::upon::vtree::attached, parent)
+                        boss.SUBMIT(tier::release, e2::form::upon::vtree::attached, parent_ptr)
                         {
-                            if (parent) closing_by_gesture(*parent);
+                            auto& parent = *parent_ptr;
+                            closing_by_gesture(parent);
                             static auto i = 0; i++;
-                            auto title = ansi::jet(bias::center).add("View \n Region ", i);
+                            auto title = ansi::add("View\nRegion ", i);
                             boss.base::template riseup<tier::preview>(e2::form::prop::header, title);
                             
                             auto outer = dent{ 2,2,1,1 };
@@ -514,6 +515,32 @@ namespace netxs::app::shared
                             boss.base::template riseup<tier::release>(e2::config::plugins::sizer::inner, inner);
                             boss.base::template riseup<tier::release>(e2::config::plugins::align, faux);
                             boss.base::template riseup<tier::preview>(e2::form::prop::zorder, Z_order::backmost);
+                            parent.SUBMIT(tier::release, hids::events::mouse::button::click::right, gear)
+                            {
+                                if (auto gate_ptr = bell::getref(gear.id))
+                                {
+                                    auto old_title = decltype(e2::form::prop::header)::type{};
+                                    boss.base::template riseup<tier::request>(e2::form::prop::header, old_title);
+
+                                    auto data = decltype(e2::command::clipboard::get)::type{};
+                                    gate_ptr->SIGNAL(tier::release, e2::command::clipboard::get, data);
+
+                                    if (utf::is_plain(data)) // Reset aligning to the center if text is plain.
+                                    {
+                                        auto align = ansi::jet(bias::center);
+                                        boss.base::template riseup<tier::preview>(e2::form::prop::header, align);
+                                    }
+                                    // Copy clipboard data to title.
+                                    auto title = decltype(e2::form::prop::header)::type{ data };
+                                    boss.base::template riseup<tier::preview>(e2::form::prop::header, title);
+                                    gear.dismiss();
+
+                                    if (old_title.size()) // Copy old title to clipboard.
+                                    {
+                                        gate_ptr->SIGNAL(tier::release, e2::command::clipboard::set, old_title);
+                                    }
+                                }
+                            };
                         };
                     });
             return window;

--- a/src/netxs/apps/calc.hpp
+++ b/src/netxs/apps/calc.hpp
@@ -331,7 +331,7 @@ namespace netxs::app::calc
                       {
                           static auto i = 0; i++;
                           auto title = ansi::jet(bias::right).add("Spreadsheet\n ~/Untitled ", i, ".ods");
-                          boss.base::template riseup<tier::preview>(e2::form::prop::header, title);
+                          boss.base::template riseup<tier::preview>(e2::form::prop::ui::header, title);
                       };
                   });
             auto object = window->attach(ui::fork::ctor(axis::Y))

--- a/src/netxs/apps/desk.hpp
+++ b/src/netxs/apps/desk.hpp
@@ -204,7 +204,7 @@ namespace netxs::app::desk
                             });
                     auto list_pads = block->attach(slot::_2, ui::pads::ctor(dent{ 0,0,0,0 }, dent{ 0,0,0,0 }));
                     auto insts = list_pads->attach(ui::list::ctor())
-                                          ->attach_collection(e2::form::prop::header, inst_ptr_list, app_template);
+                                          ->attach_collection(e2::form::prop::ui::header, inst_ptr_list, app_template);
             }
             return apps;
         };

--- a/src/netxs/apps/desk.hpp
+++ b/src/netxs/apps/desk.hpp
@@ -36,6 +36,9 @@ namespace netxs::app::desk
 
             auto item_area = ui::pads::ctor(dent{ 1,0,1,0 }, dent{ 0,0,0,1 })
                     ->plugin<pro::fader>(x4, c4, 0ms)//150ms)
+                    ->plugin<pro::notes>(" Running instance:                          \n"
+                                         "   Left click to go to running instance     \n"
+                                         "   Right click to pull the running instance ")
                     ->invoke([&](auto& boss)
                     {
                         auto data_src_shadow = ptr::shadow(data_src);
@@ -119,6 +122,9 @@ namespace netxs::app::desk
                 auto obj_desc = app::shared::objs_config[class_id].label;
                 auto item_area = apps->attach(ui::pads::ctor(dent{ 0,0,0,1 }, dent{ 0,0,1,0 }))
                                      ->template plugin<pro::fader>(x3, c3, 0ms)
+                                     ->plugin<pro::notes>(" Menu item:                           \n"
+                                                          "   Left click to start a new instance \n"
+                                                          "   Right click to set default app     ")
                                      ->invoke([&](auto& boss)
                                      {
                                          boss.mouse.take_all_events(faux);
@@ -316,6 +322,8 @@ namespace netxs::app::desk
                                             });
                     auto taskbar = taskbar_viewport->attach(slot::_1, ui::fork::ctor(axis::Y))
                                         ->colors(whitedk, 0x60202020)
+                                        ->plugin<pro::notes>(" LeftDrag to adjust menu width                   \n"
+                                                             " RightDrag or scroll wheel to slide menu up/down ")
                                         ->plugin<pro::limit>(twod{ uibar_min_size,-1 }, twod{ uibar_min_size,-1 })
                                         ->plugin<pro::timer>()
                                         ->plugin<pro::acryl>()
@@ -392,13 +400,15 @@ namespace netxs::app::desk
                             {
                                 auto users_area = apps_users->attach(slot::_2, ui::fork::ctor(axis::Y));
                                 auto label_pads = users_area->attach(slot::_1, ui::pads::ctor(dent{ 0,0,1,1 }, dent{ 0,0,0,0 }))
-                                                            ->plugin<pro::fader>(x3, c3, 150ms);
+                                                            ->plugin<pro::fader>(x3, c3, 150ms)
+                                                            ->plugin<pro::notes>(" List of connected users ");
                                     auto label_bttn = label_pads->attach(ui::fork::ctor());
                                         auto label = label_bttn->attach(slot::_1,
                                             ui::item::ctor(ansi::fgc(whitelt).add("Users"), faux, faux));
                                         auto bttn_area = label_bttn->attach(slot::_2, ui::fork::ctor());
                                             auto bttn_pads = bttn_area->attach(slot::_2, ui::pads::ctor(dent{ 2,2,0,0 }, dent{ 0,0,1,1 }))
-                                                                      ->plugin<pro::fader>(x6, c6, 150ms);
+                                                                      ->plugin<pro::fader>(x6, c6, 150ms)
+                                                                      ->plugin<pro::notes>(" Show/hide users list ");
                                                 auto bttn = bttn_pads->attach(ui::item::ctor("<", faux));
                                 auto userlist_area = users_area->attach(slot::_2, ui::pads::ctor())
                                                                ->plugin<pro::limit>();
@@ -443,6 +453,7 @@ namespace netxs::app::desk
                                                    ->plugin<pro::limit>(twod{ uibar_full_size, 3 }, twod{ -1, 3 });
                                 auto disconnect_park = bttns->attach(slot::_1, ui::park::ctor())
                                                             ->plugin<pro::fader>(x2, c2, 150ms)
+                                                            ->plugin<pro::notes>(" Leave current session ")
                                                             ->invoke([&](auto& boss)
                                                             {
                                                                 boss.SUBMIT(tier::release, hids::events::mouse::button::click::left, gear)
@@ -458,6 +469,7 @@ namespace netxs::app::desk
                                 auto disconnect = disconnect_area->attach(ui::item::ctor("× Disconnect"));
                                 auto shutdown_park = bttns->attach(slot::_2, ui::park::ctor())
                                                           ->plugin<pro::fader>(x1, c1, 150ms)
+                                                          ->plugin<pro::notes>(" Disconnect all users and shutdown the server ")
                                                           ->invoke([&](auto& boss)
                                                           {
                                                               boss.SUBMIT(tier::release, hids::events::mouse::button::click::left, gear)

--- a/src/netxs/apps/desk.hpp
+++ b/src/netxs/apps/desk.hpp
@@ -122,9 +122,9 @@ namespace netxs::app::desk
                 auto obj_desc = app::shared::objs_config[class_id].label;
                 auto item_area = apps->attach(ui::pads::ctor(dent{ 0,0,0,1 }, dent{ 0,0,1,0 }))
                                      ->template plugin<pro::fader>(x3, c3, 0ms)
-                                     ->plugin<pro::notes>(" Menu item:                           \n"
-                                                          "   Left click to start a new instance \n"
-                                                          "   Right click to set default app     ")
+                                     ->template plugin<pro::notes>(" Menu item:                           \n"
+                                                                   "   Left click to start a new instance \n"
+                                                                   "   Right click to set default app     ")
                                      ->invoke([&](auto& boss)
                                      {
                                          boss.mouse.take_all_events(faux);

--- a/src/netxs/apps/logs.hpp
+++ b/src/netxs/apps/logs.hpp
@@ -263,7 +263,7 @@ namespace netxs::app::logs
                                 ->colors(whitelt, app::shared::term_menu_bg);
                 auto menu = object->attach(slot::_1, app::shared::custom_menu(true,
                     app::shared::menu_list_type{
-                            { "Codepoints", " Toggle button: Show or not codepoints ",
+                            { true, "Codepoints", " Toggle button: Show or not codepoints ",
                             [](ui::pads& boss)
                             {
                                 boss.SUBMIT(tier::release, hids::events::mouse::button::click::left, gear)
@@ -279,7 +279,7 @@ namespace netxs::app::logs
                                     boss.color(status == 1 ? 0xFF00ff00 : x3.fgc(), x3.bgc());
                                 };
                             }},
-                            { "Clear", " Clear scrollback ",
+                            { true, "Clear", " Clear scrollback ",
                             [](ui::pads& boss)
                             {
                                 boss.SUBMIT(tier::release, hids::events::mouse::button::click::left, gear)

--- a/src/netxs/apps/logs.hpp
+++ b/src/netxs/apps/logs.hpp
@@ -262,8 +262,8 @@ namespace netxs::app::logs
             auto object = window->attach(ui::fork::ctor(axis::Y))
                                 ->colors(whitelt, app::shared::term_menu_bg);
                 auto menu = object->attach(slot::_1, app::shared::custom_menu(true,
-                    std::list{
-                            std::pair<text, std::function<void(ui::pads&)>>{ "Codepoints",
+                    app::shared::menu_list_type{
+                            { "Codepoints", " Toggle button: Show or not codepoints ",
                             [](ui::pads& boss)
                             {
                                 boss.SUBMIT(tier::release, hids::events::mouse::button::click::left, gear)
@@ -279,7 +279,7 @@ namespace netxs::app::logs
                                     boss.color(status == 1 ? 0xFF00ff00 : x3.fgc(), x3.bgc());
                                 };
                             }},
-                            std::pair<text, std::function<void(ui::pads&)>>{ "Clear",
+                            { "Clear", " Clear scrollback ",
                             [](ui::pads& boss)
                             {
                                 boss.SUBMIT(tier::release, hids::events::mouse::button::click::left, gear)

--- a/src/netxs/apps/term.hpp
+++ b/src/netxs/apps/term.hpp
@@ -213,7 +213,7 @@ namespace netxs::app::term
             [](ui::pads& boss)
             {
             }},
-            { true, "Clear", " Clear viewport ",
+            { true, "Clear", " Clear TTY viewport ",
             [](ui::pads& boss)
             {
                 boss.SUBMIT(tier::release, hids::events::mouse::button::click::left, gear)

--- a/src/netxs/apps/term.hpp
+++ b/src/netxs/apps/term.hpp
@@ -52,7 +52,7 @@ namespace netxs::app::term
         auto items = app::shared::menu_list_type
         {
         #ifdef DEMO
-            { "T1", " Exec `ls /bin` ",
+            { true, "T1", " Exec `ls /bin` ",
             [](ui::pads& boss)
             {
                 boss.SUBMIT(tier::release, hids::events::mouse::button::click::left, gear)
@@ -62,7 +62,7 @@ namespace netxs::app::term
                     gear.dismiss(true);
                 };
             }},
-            { "T2", " Exec `ping -c 3 127.0.0.1 | ccze -A` ",
+            { true, "T2", " Exec `ping -c 3 127.0.0.1 | ccze -A` ",
             [](ui::pads& boss)
             {
                 boss.SUBMIT(tier::release, hids::events::mouse::button::click::left, gear)
@@ -72,7 +72,7 @@ namespace netxs::app::term
                     gear.dismiss(true);
                 };
             }},
-            { "T3", " Exec `curl wttr.in` ",
+            { true, "T3", " Exec `curl wttr.in` ",
             [](ui::pads& boss)
             {
                 boss.SUBMIT(tier::release, hids::events::mouse::button::click::left, gear)
@@ -83,27 +83,8 @@ namespace netxs::app::term
                 };
             }},
         #endif
-        #ifdef PROD
-            { "Clear", " Clear viewport ",
-            [](ui::pads& boss)
-            {
-                boss.SUBMIT(tier::release, hids::events::mouse::button::click::left, gear)
-                {
-                    boss.SIGNAL(tier::anycast, app::term::events::cmd, ui::term::commands::ui::clear);
-                    gear.dismiss(true);
-                };
-            }},
-        #endif
-            { "Reset", " Clear scroolback and reset attributes ",
-            [](ui::pads& boss)
-            {
-                boss.SUBMIT(tier::release, hids::events::mouse::button::click::left, gear)
-                {
-                    boss.SIGNAL(tier::anycast, app::term::events::cmd, ui::term::commands::ui::reset);
-                    gear.dismiss(true);
-                };
-            }},
-            { "=─", " Align text lines on left side ",
+            { true, "=─", " Align text lines on left side   \n"
+                          " - applied to selection if it is ",
             [](ui::pads& boss)
             {
                 boss.SUBMIT(tier::release, hids::events::mouse::button::click::left, gear)
@@ -117,7 +98,8 @@ namespace netxs::app::term
                     boss.color(align == bias::left ? 0xFF00ff00 : x3.fgc(), x3.bgc());
                 };
             }},
-            { "─=─", " Center text lines ",
+            { true, "─=─", " Center text lines               \n"
+                           " - applied to selection if it is ",
             [](ui::pads& boss)
             {
                 boss.SUBMIT(tier::release, hids::events::mouse::button::click::left, gear)
@@ -131,7 +113,8 @@ namespace netxs::app::term
                     boss.color(align == bias::center ? 0xFF00ff00 : x3.fgc(), x3.bgc());
                 };
             }},
-            { "─=", " Align text lines on right side ",
+            { true, "─=", " Align text lines on right side  \n"
+                          " - applied to selection if it is ",
             [](ui::pads& boss)
             {
                 boss.SUBMIT(tier::release, hids::events::mouse::button::click::left, gear)
@@ -145,7 +128,8 @@ namespace netxs::app::term
                     boss.color(align == bias::right ? 0xFF00ff00 : x3.fgc(), x3.bgc());
                 };
             }},
-            { "Wrap", " Wrapping text lines on/off ",
+            { true, "Wrap", " Wrapping text lines on/off      \n"
+                            " - applied to selection if it is ",
             [](ui::pads& boss)
             {
                 boss.SUBMIT(tier::release, hids::events::mouse::button::click::left, gear)
@@ -159,8 +143,7 @@ namespace netxs::app::term
                     boss.color(wrapln == wrap::on ? 0xFF00ff00 : x3.fgc(), x3.bgc());
                 };
             }},
-            //todo unify
-            { "Selection", " Text selection mode ",
+            { true, "Selection", " Text selection mode ",
             [](ui::pads& boss)
             {
                 boss.SUBMIT(tier::release, hids::events::mouse::button::click::left, gear)
@@ -175,25 +158,27 @@ namespace netxs::app::term
                     {
                         default:
                         case ui::term::xsgr::disabled:
-                            //boss.attach(ui::item::ctor("Selection", faux, true));
+                            //"Selection"
                             if (boss.client) boss.client->SIGNAL(tier::release, e2::data::text, "Selection");
                             boss.color(x3.fgc(), x3.bgc());
                             break;
                         case ui::term::xsgr::textonly:
-                            //boss.attach(ui::item::ctor("Text only", faux, true));
+                            //"Text only"
                             if (boss.client) boss.client->SIGNAL(tier::release, e2::data::text, "Plaintext");
                             boss.color(0xFF00ff00, x3.bgc());
                             break;
                         case ui::term::xsgr::ansitext:
-                            //boss.attach(ui::item::ctor("Rich-Text", faux, true));
-                            //boss.attach(ui::item::ctor("+ANSI/SGR", faux, true));
+                            //"Rich-Text"
+                            //"+ANSI/SGR"
                             if (boss.client) boss.client->SIGNAL(tier::release, e2::data::text, "ANSI-text");
                             boss.color(0xFF00ffff, x3.bgc());
                             break;
                     }
                 };
             }},
-            { "<", " Previuos match ",
+            { true, "<", " Previuos match                    \n"
+                         " - using clipboard if no selection \n"
+                         " - page up if no clipboard data    ",
             [](ui::pads& boss)
             {
                 boss.SUBMIT(tier::release, hids::events::mouse::button::click::left, gear)
@@ -207,7 +192,9 @@ namespace netxs::app::term
                     boss.color(mode & 2 ? 0xFF00ff00 : x3.fgc(), x3.bgc());
                 };
             }},
-            { ">", " Next match ",
+            { true, ">", " Next match                        \n"
+                         " - using clipboard if no selection \n"
+                         " - page down if no clipboard data  ",
             [](ui::pads& boss)
             {
                 boss.SUBMIT(tier::release, hids::events::mouse::button::click::left, gear)
@@ -219,6 +206,30 @@ namespace netxs::app::term
                 {
                     //todo unify, get boss base colors, don't use x3
                     boss.color(mode & 1 ? 0xFF00ff00 : x3.fgc(), x3.bgc());
+                };
+            }},
+        #ifdef PROD
+            { faux, "  ", " ...empty menu block for safety ",
+            [](ui::pads& boss)
+            {
+            }},
+            { true, "Clear", " Clear viewport ",
+            [](ui::pads& boss)
+            {
+                boss.SUBMIT(tier::release, hids::events::mouse::button::click::left, gear)
+                {
+                    boss.SIGNAL(tier::anycast, app::term::events::cmd, ui::term::commands::ui::clear);
+                    gear.dismiss(true);
+                };
+            }},
+        #endif
+            { true, "Reset", " Clear scrollback and reset attributes ",
+            [](ui::pads& boss)
+            {
+                boss.SUBMIT(tier::release, hids::events::mouse::button::click::left, gear)
+                {
+                    boss.SIGNAL(tier::anycast, app::term::events::cmd, ui::term::commands::ui::reset);
+                    gear.dismiss(true);
                 };
             }},
         };

--- a/src/netxs/apps/term.hpp
+++ b/src/netxs/apps/term.hpp
@@ -223,7 +223,7 @@ namespace netxs::app::term
                 };
             }},
         #endif
-            { true, "Reset", " Clear scrollback and reset attributes ",
+            { true, "Reset", " Clear scrollback and SGR-attributes ",
             [](ui::pads& boss)
             {
                 boss.SUBMIT(tier::release, hids::events::mouse::button::click::left, gear)

--- a/src/netxs/apps/term.hpp
+++ b/src/netxs/apps/term.hpp
@@ -48,10 +48,10 @@ namespace netxs::app::term
         const static auto c3 = app::shared::c3;
         const static auto x3 = app::shared::x3;
 
-        auto items = std::list
+        auto items = app::shared::menu_list_type
         {
         #ifdef DEMO
-            std::pair<text, std::function<void(ui::pads&)>>{ "T1",
+            { "T1", " Exec `ls /bin` ",
             [](ui::pads& boss)
             {
                 boss.SUBMIT(tier::release, hids::events::mouse::button::click::left, gear)
@@ -61,7 +61,7 @@ namespace netxs::app::term
                     gear.dismiss(true);
                 };
             }},
-            std::pair<text, std::function<void(ui::pads&)>>{ "T2",
+            { "T2", " Exec `ping -c 3 127.0.0.1 | ccze -A` ",
             [](ui::pads& boss)
             {
                 boss.SUBMIT(tier::release, hids::events::mouse::button::click::left, gear)
@@ -71,7 +71,7 @@ namespace netxs::app::term
                     gear.dismiss(true);
                 };
             }},
-            std::pair<text, std::function<void(ui::pads&)>>{ "T3",
+            { "T3", " Exec `curl wttr.in` ",
             [](ui::pads& boss)
             {
                 boss.SUBMIT(tier::release, hids::events::mouse::button::click::left, gear)
@@ -83,7 +83,7 @@ namespace netxs::app::term
             }},
         #endif
         #ifdef PROD
-            std::pair<text, std::function<void(ui::pads&)>>{ "Clear",
+            { "Clear", " Clear viewport ",
             [](ui::pads& boss)
             {
                 boss.SUBMIT(tier::release, hids::events::mouse::button::click::left, gear)
@@ -93,7 +93,7 @@ namespace netxs::app::term
                 };
             }},
         #endif
-            std::pair<text, std::function<void(ui::pads&)>>{ "Reset",
+            { "Reset", " Clear scroolback and reset attributes ",
             [](ui::pads& boss)
             {
                 boss.SUBMIT(tier::release, hids::events::mouse::button::click::left, gear)
@@ -102,7 +102,7 @@ namespace netxs::app::term
                     gear.dismiss(true);
                 };
             }},
-            std::pair<text, std::function<void(ui::pads&)>>{ "=─",
+            { "=─", " Align text lines on left side ",
             [](ui::pads& boss)
             {
                 boss.SUBMIT(tier::release, hids::events::mouse::button::click::left, gear)
@@ -116,7 +116,7 @@ namespace netxs::app::term
                     boss.color(align == bias::left ? 0xFF00ff00 : x3.fgc(), x3.bgc());
                 };
             }},
-            std::pair<text, std::function<void(ui::pads&)>>{ "─=─",
+            { "─=─", " Center text lines ",
             [](ui::pads& boss)
             {
                 boss.SUBMIT(tier::release, hids::events::mouse::button::click::left, gear)
@@ -130,7 +130,7 @@ namespace netxs::app::term
                     boss.color(align == bias::center ? 0xFF00ff00 : x3.fgc(), x3.bgc());
                 };
             }},
-            std::pair<text, std::function<void(ui::pads&)>>{ "─=",
+            { "─=", " Align text lines on right side ",
             [](ui::pads& boss)
             {
                 boss.SUBMIT(tier::release, hids::events::mouse::button::click::left, gear)
@@ -144,7 +144,7 @@ namespace netxs::app::term
                     boss.color(align == bias::right ? 0xFF00ff00 : x3.fgc(), x3.bgc());
                 };
             }},
-            std::pair<text, std::function<void(ui::pads&)>>{ "Wrap",
+            { "Wrap", " Wrapping text lines on/off ",
             [](ui::pads& boss)
             {
                 boss.SUBMIT(tier::release, hids::events::mouse::button::click::left, gear)
@@ -159,7 +159,7 @@ namespace netxs::app::term
                 };
             }},
             //todo unify
-            std::pair<text, std::function<void(ui::pads&)>>{ "Selection",
+            { "Selection", " Text selection mode ",
             [](ui::pads& boss)
             {
                 boss.SUBMIT(tier::release, hids::events::mouse::button::click::left, gear)
@@ -192,7 +192,7 @@ namespace netxs::app::term
                     }
                 };
             }},
-            std::pair<text, std::function<void(ui::pads&)>>{ "<",
+            { "<", " Previuos match ",
             [](ui::pads& boss)
             {
                 boss.SUBMIT(tier::release, hids::events::mouse::button::click::left, gear)
@@ -206,7 +206,7 @@ namespace netxs::app::term
                     boss.color(mode ? 0xFF00ff00 : x3.fgc(), x3.bgc());
                 };
             }},
-            std::pair<text, std::function<void(ui::pads&)>>{ ">",
+            { ">", " Next match ",
             [](ui::pads& boss)
             {
                 boss.SUBMIT(tier::release, hids::events::mouse::button::click::left, gear)

--- a/src/netxs/apps/text.hpp
+++ b/src/netxs/apps/text.hpp
@@ -197,7 +197,7 @@ utility like ctags is used to locate the definitions.
                       {
                           static auto i = 0; i++;
                           auto title = ansi::jet(bias::center).add("Text Editor\n ~/Untitled ", i, ".txt");
-                          boss.base::template riseup<tier::preview>(e2::form::prop::header, title);
+                          boss.base::template riseup<tier::preview>(e2::form::prop::ui::header, title);
                       };
                   });
             auto object = window->attach(ui::fork::ctor(axis::Y))

--- a/src/netxs/apps/tile.hpp
+++ b/src/netxs/apps/tile.hpp
@@ -894,12 +894,13 @@ namespace netxs::app::tile
                 });
 
             object->attach(slot::_1, app::shared::custom_menu(true,
-                app::shared::menu_list_type{
+                    app::shared::menu_list_type
+                    {
                         //  Green                                  ?Even    Red
                         // ┌────┐  ┌────┐  ┌─┬──┐  ┌────┐  ┌─┬──┐  ┌─┬──┐  ┌────┐  // ┌─┐  ┌─┬─┐  ┌─┬─┐  ┌─┬─┐  
                         // │Exec│  ├─┐  │  │ H  │  ├ V ─┤  │Swap│  │Fair│  │Shut│  // ├─┤  └─┴─┘  └<┴>┘  └>┴<┘  
                         // └────┘  └─┴──┘  └─┴──┘  └────┘  └─┴──┘  └─┴──┘  └────┘  // └─┘                       
-                        {"  ┐└  ", " Maximize/restore active pane ",//  ─┐  ", //"  ▀█  ",
+                        { true,"  ┐└  ", " Maximize/restore active pane ", //  ─┐  ", //"  ▀█  ",
                         [](ui::pads& boss)
                         {
                             boss.SUBMIT(tier::release, hids::events::mouse::button::click::left, gear)
@@ -909,7 +910,7 @@ namespace netxs::app::tile
                                 gear.dismiss(true);
                             };
                         }},
-                        { "  +  ", " Create and run a new app in active panes ",
+                        { true, "  +  ", " Create and run a new app in active panes ",
                         [](ui::pads& boss)
                         {
                             boss.SUBMIT(tier::release, hids::events::mouse::button::click::left, gear)
@@ -918,7 +919,7 @@ namespace netxs::app::tile
                                 gear.dismiss(true);
                             };
                         }},
-                        { " ::: ", " Select all panes ",
+                        { true, " ::: ", " Select all panes ",
                         [](ui::pads& boss)
                         {
                             boss.SUBMIT(tier::release, hids::events::mouse::button::click::left, gear)
@@ -927,7 +928,7 @@ namespace netxs::app::tile
                                 gear.dismiss(true);
                             };
                         }},
-                        { "  │  ", " Split active panes horizontally ", // "  ║  ", - VGA Linux console doesn't support unicode glyphs
+                        { true, "  │  ", " Split active panes horizontally ", // "  ║  ", - VGA Linux console doesn't support unicode glyphs
                         [](ui::pads& boss)
                         {
                             boss.SUBMIT(tier::release, hids::events::mouse::button::click::left, gear)
@@ -936,7 +937,7 @@ namespace netxs::app::tile
                                 gear.dismiss(true);
                             };
                         }},
-                        {  " ── ", " Split active panes vertically ", // " ══ ", - VGA Linux console doesn't support unicode glyphs
+                        { true, " ── ", " Split active panes vertically ", // " ══ ", - VGA Linux console doesn't support unicode glyphs
                         [](ui::pads& boss)
                         {
                             boss.SUBMIT(tier::release, hids::events::mouse::button::click::left, gear)
@@ -945,7 +946,7 @@ namespace netxs::app::tile
                                 gear.dismiss(true);
                             };
                         }},
-                        { "  ┌┘  ", " Change split orientation ",
+                        { true, "  ┌┘  ", " Change split orientation ",
                         [](ui::pads& boss)
                         {
                             boss.SUBMIT(tier::release, hids::events::mouse::button::click::left, gear)
@@ -954,7 +955,7 @@ namespace netxs::app::tile
                                 gear.dismiss(true);
                             };
                         }},
-                        { " <-> ", " Swap two or more panes ",
+                        { true, " <-> ", " Swap two or more panes ",
                         [](ui::pads& boss)
                         {
                             boss.SUBMIT(tier::release, hids::events::mouse::button::click::left, gear)
@@ -963,7 +964,7 @@ namespace netxs::app::tile
                                 gear.dismiss(true);
                             };
                         }},
-                        { " >|< ", " Equalize split ratio ",
+                        { true, " >|< ", " Equalize split ratio ",
                         [](ui::pads& boss)
                         {
                             boss.SUBMIT(tier::release, hids::events::mouse::button::click::left, gear)
@@ -972,7 +973,7 @@ namespace netxs::app::tile
                                 gear.dismiss(true);
                             };
                         }},
-                        { "  ×  ", " Close active app or remove pane if there is no running app ",
+                        { true, "  ×  ", " Close active app or remove pane if there is no running app ",
                         [](ui::pads& boss)
                         {
                             boss.SUBMIT(tier::release, hids::events::mouse::button::click::left, gear)

--- a/src/netxs/apps/tile.hpp
+++ b/src/netxs/apps/tile.hpp
@@ -124,7 +124,7 @@ namespace netxs::app::tile
                             };
                         });
                 };
-                client->attach_element(e2::form::prop::header, object, label);
+                client->attach_element(e2::form::prop::ui::header, object, label);
             };
             boss.SUBMIT_T(tier::release, e2::render::any, memo, parent_canvas)
             {
@@ -277,8 +277,8 @@ namespace netxs::app::tile
                                 // Take current title.
                                 auto what = decltype(e2::form::proceed::createfrom)::type{};
                                 what.menuid = menu_item_id;
-                                master.SIGNAL(tier::request, e2::form::prop::header, what.header);
-                                master.SIGNAL(tier::request, e2::form::prop::footer, what.footer);
+                                master.SIGNAL(tier::request, e2::form::prop::ui::header, what.header);
+                                master.SIGNAL(tier::request, e2::form::prop::ui::footer, what.footer);
                                 if (what.header.empty()) what.header = menu_item_id;
                                  
                                 // Take coor and detach from the tiling wm.
@@ -327,15 +327,15 @@ namespace netxs::app::tile
                             auto shadow = ptr::shadow(boss.This());
                             boss.SUBMIT_BYVAL(tier::release, e2::form::upon::vtree::attached, parent)
                             {
-                                parent->SUBMIT_BYVAL(tier::preview, e2::form::prop::header, newtext)
+                                parent->SUBMIT_BYVAL(tier::preview, e2::form::prop::ui::header, newtext)
                                 {
                                     if (auto boss_ptr = shadow.lock())
                                     {
                                         boss_ptr->upload(newtext);
-                                        boss_ptr->parent()->SIGNAL(tier::release, e2::form::prop::header, newtext);
+                                        boss_ptr->parent()->SIGNAL(tier::release, e2::form::prop::ui::header, newtext);
                                     }
                                 };
-                                parent->SUBMIT_BYVAL(tier::request, e2::form::prop::header, curtext)
+                                parent->SUBMIT_BYVAL(tier::request, e2::form::prop::ui::header, curtext)
                                 {
                                     if (auto ptr = shadow.lock()) curtext = ptr->get_source();
                                 };
@@ -889,17 +889,17 @@ namespace netxs::app::tile
                     {
                         auto title = ansi::add(window_title);// + utf::debase(data));
                         log(" attached title=", window_title);
-                        parent->base::riseup<tier::preview>(e2::form::prop::header, title);
+                        parent->base::riseup<tier::preview>(e2::form::prop::ui::header, title);
                     };
                 });
 
             object->attach(slot::_1, app::shared::custom_menu(true,
-                std::list{
+                app::shared::menu_list_type{
                         //  Green                                  ?Even    Red
                         // ┌────┐  ┌────┐  ┌─┬──┐  ┌────┐  ┌─┬──┐  ┌─┬──┐  ┌────┐  // ┌─┐  ┌─┬─┐  ┌─┬─┐  ┌─┬─┐  
                         // │Exec│  ├─┐  │  │ H  │  ├ V ─┤  │Swap│  │Fair│  │Shut│  // ├─┤  └─┴─┘  └<┴>┘  └>┴<┘  
                         // └────┘  └─┴──┘  └─┴──┘  └────┘  └─┴──┘  └─┴──┘  └────┘  // └─┘                       
-                        std::pair<text, std::function<void(ui::pads&)>>{"  ┐└  ",//  ─┐  ", //"  ▀█  ",
+                        {"  ┐└  ", " Maximize/restore active pane ",//  ─┐  ", //"  ▀█  ",
                         [](ui::pads& boss)
                         {
                             boss.SUBMIT(tier::release, hids::events::mouse::button::click::left, gear)
@@ -909,7 +909,7 @@ namespace netxs::app::tile
                                 gear.dismiss(true);
                             };
                         }},
-                        std::pair<text, std::function<void(ui::pads&)>>{ "  +  ",
+                        { "  +  ", " Create and run a new app in active panes ",
                         [](ui::pads& boss)
                         {
                             boss.SUBMIT(tier::release, hids::events::mouse::button::click::left, gear)
@@ -918,7 +918,7 @@ namespace netxs::app::tile
                                 gear.dismiss(true);
                             };
                         }},
-                        std::pair<text, std::function<void(ui::pads&)>>{ " ::: ",
+                        { " ::: ", " Select all panes ",
                         [](ui::pads& boss)
                         {
                             boss.SUBMIT(tier::release, hids::events::mouse::button::click::left, gear)
@@ -927,7 +927,7 @@ namespace netxs::app::tile
                                 gear.dismiss(true);
                             };
                         }},
-                        std::pair<text, std::function<void(ui::pads&)>>{ "  │  ", // "  ║  ", - VGA Linux console doesn't support unicode glyphs
+                        { "  │  ", " Split active panes horizontally ", // "  ║  ", - VGA Linux console doesn't support unicode glyphs
                         [](ui::pads& boss)
                         {
                             boss.SUBMIT(tier::release, hids::events::mouse::button::click::left, gear)
@@ -936,7 +936,7 @@ namespace netxs::app::tile
                                 gear.dismiss(true);
                             };
                         }},
-                        std::pair<text, std::function<void(ui::pads&)>>{  " ── ", // " ══ ", - VGA Linux console doesn't support unicode glyphs
+                        {  " ── ", " Split active panes vertically ", // " ══ ", - VGA Linux console doesn't support unicode glyphs
                         [](ui::pads& boss)
                         {
                             boss.SUBMIT(tier::release, hids::events::mouse::button::click::left, gear)
@@ -945,7 +945,7 @@ namespace netxs::app::tile
                                 gear.dismiss(true);
                             };
                         }},
-                        std::pair<text, std::function<void(ui::pads&)>>{ "  ┌┘  ",
+                        { "  ┌┘  ", " Change split orientation ",
                         [](ui::pads& boss)
                         {
                             boss.SUBMIT(tier::release, hids::events::mouse::button::click::left, gear)
@@ -954,7 +954,7 @@ namespace netxs::app::tile
                                 gear.dismiss(true);
                             };
                         }},
-                        std::pair<text, std::function<void(ui::pads&)>>{ " <-> ",
+                        { " <-> ", " Swap two or more panes ",
                         [](ui::pads& boss)
                         {
                             boss.SUBMIT(tier::release, hids::events::mouse::button::click::left, gear)
@@ -963,7 +963,7 @@ namespace netxs::app::tile
                                 gear.dismiss(true);
                             };
                         }},
-                        std::pair<text, std::function<void(ui::pads&)>>{ " >|< ",
+                        { " >|< ", " Equalize split ratio ",
                         [](ui::pads& boss)
                         {
                             boss.SUBMIT(tier::release, hids::events::mouse::button::click::left, gear)
@@ -972,7 +972,7 @@ namespace netxs::app::tile
                                 gear.dismiss(true);
                             };
                         }},
-                        std::pair<text, std::function<void(ui::pads&)>>{ "  ×  ",
+                        { "  ×  ", " Close active app or remove pane if there is no running app ",
                         [](ui::pads& boss)
                         {
                             boss.SUBMIT(tier::release, hids::events::mouse::button::click::left, gear)

--- a/src/netxs/console/console.hpp
+++ b/src/netxs/console/console.hpp
@@ -5797,10 +5797,16 @@ again:
                             if (tooltip_boss != input.hover)
                             {
                                 tooltip_boss = input.hover;
-                                if (auto boss_ptr = std::dynamic_pointer_cast<base>(bell::getref(input.hover)))
+                                tooltip_text = {};
+                                if (auto boss_ptr = bell::getref(input.hover))
                                 {
-                                    tooltip_text = {};
-                                    boss_ptr->base::template riseup<tier::request>(e2::form::prop::ui::tooltip, tooltip_text);
+                                    if (!boss_ptr->SIGNAL(tier::request, e2::form::prop::ui::tooltip, tooltip_text))
+                                    {
+                                        if (auto base_ptr = std::dynamic_pointer_cast<base>(boss_ptr))
+                                        {
+                                            base_ptr->base::template riseup<tier::request>(e2::form::prop::ui::tooltip, tooltip_text);
+                                        }
+                                    }
                                     if (tooltip_text.size())
                                     {
                                         tooltip_page.style.rst().wrp(wrap::off);

--- a/src/netxs/console/console.hpp
+++ b/src/netxs/console/console.hpp
@@ -5766,7 +5766,7 @@ again:
                             auto deed = this->bell::template protos<tier::preview>();
                             if (deed == hids::events::mouse::move.id)
                             {
-                                if (tooltip_coor(gear.coord)) // Do nothing on shuffle.
+                                if (tooltip_coor(gear.coord) || (tooltip_show && tooltip_boss != input.hover)) // Do nothing on shuffle.
                                 {
                                     if (tooltip_show && tooltip_boss == input.hover) // Drop tooltip if moved.
                                     {
@@ -5858,7 +5858,11 @@ again:
             lock.unlock();
 
             conio.session(props.title);
-            mouse.reset(); // Reset active mouse clients to avoid hanging pointers.
+
+            lock.lock();
+                token.clear();
+                mouse.reset(); // Reset active mouse clients to avoid hanging pointers.
+            lock.unlock();
         }
 
     protected:
@@ -6086,9 +6090,13 @@ again:
                     if (!tooltip_stop && tooltip_show && tooltip_text.size() && !input.captured())
                     {
                         static constexpr auto def_tooltip = { rgba{ 0xFFffffff }, rgba{ 0xFF000000 } }; //todo unify
-                        auto coor = input.coord - twod{ 4,2 };
-                        parent_canvas.cup(coor);
+                        auto full = parent_canvas.full();
+                        auto area = full;
+                        area.coor = input.coord - twod{ 4, tooltip_page.size() + 1 };
+                        parent_canvas.full(area);
+                        parent_canvas.cup(dot_00);
                         parent_canvas.output(tooltip_page, cell::shaders::selection(def_tooltip));
+                        parent_canvas.full(full);
                     }
                 }
 

--- a/src/netxs/console/console.hpp
+++ b/src/netxs/console/console.hpp
@@ -5567,7 +5567,7 @@ again:
                 title         = _user;
             #endif
             tooltip_timeout   = 500ms;
-            tooltip_enabled   = faux;
+            tooltip_enabled   = true;
         }
 
         friend auto& operator << (std::ostream& s, conf const& c)

--- a/src/netxs/console/console.hpp
+++ b/src/netxs/console/console.hpp
@@ -5826,8 +5826,11 @@ again:
             };
             SUBMIT(tier::preview, hids::events::mouse::button::click::leftright, gear)
             {
-                this->SIGNAL(tier::release, e2::command::clipboard::set, "");
-                gear.dismiss();
+                if (!clip_rawtext.empty())
+                {
+                    this->SIGNAL(tier::release, e2::command::clipboard::set, "");
+                    gear.dismiss();
+                }
             };
             SUBMIT(tier::release, e2::render::prerender, parent_canvas)
             {

--- a/src/netxs/console/console.hpp
+++ b/src/netxs/console/console.hpp
@@ -5811,6 +5811,7 @@ again:
                                     {
                                         tooltip_page.style.rst().wrp(wrap::off);
                                         tooltip_page = tooltip_text;
+                                        base::strike();
                                     }
                                 }
                             }
@@ -6092,7 +6093,7 @@ again:
                         static constexpr auto def_tooltip = { rgba{ 0xFFffffff }, rgba{ 0xFF000000 } }; //todo unify
                         auto full = parent_canvas.full();
                         auto area = full;
-                        area.coor = input.coord - twod{ 4, tooltip_page.size() + 1 };
+                        area.coor = std::max(dot_00, input.coord - twod{ 4, tooltip_page.size() + 1 });
                         parent_canvas.full(area);
                         parent_canvas.cup(dot_00);
                         parent_canvas.output(tooltip_page, cell::shaders::selection(def_tooltip));

--- a/src/netxs/console/console.hpp
+++ b/src/netxs/console/console.hpp
@@ -403,8 +403,6 @@ namespace netxs::events::userland
                 };
                 SUBSET_XS( prop )
                 {
-                    EVENT_XS( header    , text        ), // set form caption header.
-                    EVENT_XS( footer    , text        ), // set form caption footer.
                     EVENT_XS( name      , text        ), // user name.
                     EVENT_XS( zorder    , si32        ), // set form z-order, si32: -1 backmost, 0 plain, 1 topmost.
                     EVENT_XS( brush     , const cell  ), // set form brush/color.
@@ -414,10 +412,17 @@ namespace netxs::events::userland
                     EVENT_XS( lucidity  , si32        ), // set or request window transparency, si32: 0-255, -1 to request.
                     EVENT_XS( fixedsize , bool        ), // set ui::fork ratio.
                     GROUP_XS( window    , twod        ), // set or request window properties.
+                    GROUP_XS( ui        , text        ), // set or request textual properties.
 
                     SUBSET_XS( window )
                     {
-                        EVENT_XS( size  , twod        ), // set window size.
+                        EVENT_XS( size  , twod ), // set window size.
+                    };
+                    SUBSET_XS( ui )
+                    {
+                        EVENT_XS( header , text ), // set/get form caption header.
+                        EVENT_XS( footer , text ), // set/get form caption footer.
+                        EVENT_XS( tooltip, text ), // set/get tooltip text.
                     };
                 };
                 SUBSET_XS( global )
@@ -1155,7 +1160,7 @@ namespace netxs::console
         }
         // base: Fire an event on yourself and pass it parent if not handled.
         // Usage example:
-        //          base::riseup<tier::preview, e2::form::prop::header>(txt);
+        //          base::riseup<tier::preview, e2::form::prop::ui::header>(txt);
         template<tier TIER, class EVENT, class T>
         void riseup(EVENT, T&& data, bool forced = faux)
         {
@@ -1748,9 +1753,9 @@ namespace netxs::console
                     body = area;
 
                     text newhead;
-                    gate.SIGNAL(tier::request, e2::form::prop::header, head);
-                    boss.SIGNAL(tier::request, e2::form::prop::header, newhead);
-                    gate.SIGNAL(tier::preview, e2::form::prop::header, newhead);
+                    gate.SIGNAL(tier::request, e2::form::prop::ui::header, head);
+                    boss.SIGNAL(tier::request, e2::form::prop::ui::header, newhead);
+                    gate.SIGNAL(tier::preview, e2::form::prop::ui::header, newhead);
                     gate.SIGNAL(tier::release, e2::form::prop::fullscreen, true);
 
                     gate.SUBMIT_T(tier::release, e2::size::set, memo, size)
@@ -1777,11 +1782,11 @@ namespace netxs::console
                     };
 
                     weak = master;
-                    boss.SUBMIT_T(tier::release, e2::form::prop::header, memo, newhead)
+                    boss.SUBMIT_T(tier::release, e2::form::prop::ui::header, memo, newhead)
                     {
                         if (auto gate_ptr = bell::getref(weak))
                         {
-                            gate_ptr->SIGNAL(tier::preview, e2::form::prop::header, newhead);
+                            gate_ptr->SIGNAL(tier::preview, e2::form::prop::ui::header, newhead);
                         }
                         else unbind();
                     };
@@ -1794,7 +1799,7 @@ namespace netxs::console
                     memo.clear();
                     if (auto gate_ptr = bell::getref(weak))
                     {
-                        gate_ptr->SIGNAL(tier::preview, e2::form::prop::header, head);
+                        gate_ptr->SIGNAL(tier::preview, e2::form::prop::ui::header, head);
                         gate_ptr->SIGNAL(tier::release, e2::form::prop::fullscreen, faux);
                     }
                 }
@@ -2823,10 +2828,10 @@ namespace netxs::console
                 head_page = newtext;
                 head_text = newtext;
                 recalc(head_page, head_size);
-                boss.SIGNAL(tier::release, e2::form::prop::header, head_text);
+                boss.SIGNAL(tier::release, e2::form::prop::ui::header, head_text);
                 /*
                 textline.link(boss.id);
-                boss.SIGNAL(tier::release, e2::form::prop::header, head_text);
+                boss.SIGNAL(tier::release, e2::form::prop::ui::header, head_text);
                 boss.SIGNAL(tier::release, e2::form::state::header, textline);
                 */
             }
@@ -2835,10 +2840,10 @@ namespace netxs::console
                 foot_page = newtext;
                 foot_text = newtext;
                 recalc(foot_page, foot_size);
-                boss.SIGNAL(tier::release, e2::form::prop::footer, foot_text);
+                boss.SIGNAL(tier::release, e2::form::prop::ui::footer, foot_text);
                 /*
                 textline.link(boss.id);
-                boss.SIGNAL(tier::release, e2::form::prop::footer, foot_text);
+                boss.SIGNAL(tier::release, e2::form::prop::ui::footer, foot_text);
                 boss.SIGNAL(tier::release, e2::form::state::footer, textline);
                 */
             }
@@ -2868,22 +2873,22 @@ namespace netxs::console
                 };
                 if (head_live)
                 {
-                    boss.SUBMIT_T(tier::preview, e2::form::prop::header, memo, newtext)
+                    boss.SUBMIT_T(tier::preview, e2::form::prop::ui::header, memo, newtext)
                     {
                         header(newtext);
                     };
-                    boss.SUBMIT_T(tier::request, e2::form::prop::header, memo, curtext)
+                    boss.SUBMIT_T(tier::request, e2::form::prop::ui::header, memo, curtext)
                     {
                         curtext = head_text;
                     };
                 }
                 if (foot_live)
                 {
-                    boss.SUBMIT_T(tier::preview, e2::form::prop::footer, memo, newtext)
+                    boss.SUBMIT_T(tier::preview, e2::form::prop::ui::footer, memo, newtext)
                     {
                         footer(newtext);
                     };
-                    boss.SUBMIT_T(tier::request, e2::form::prop::footer, memo, curtext)
+                    boss.SUBMIT_T(tier::request, e2::form::prop::ui::footer, memo, curtext)
                     {
                         curtext = foot_text;
                     };
@@ -3891,6 +3896,36 @@ namespace netxs::console
                 : skill{ boss }
             {
 
+            }
+        };
+
+        // pro: Tooltip.
+        class notes
+            : public skill
+        {
+            using skill::boss,
+                  skill::memo;
+
+            text note;
+
+        public:
+            notes(base&&) = delete;
+            notes(base& boss, view data)
+                : skill{ boss },
+                  note { data }
+            {
+                boss.SUBMIT_T(tier::preview, e2::form::prop::ui::tooltip, memo, new_note)
+                {
+                    note = new_note;
+                };
+                boss.SUBMIT_T(tier::request, e2::form::prop::ui::tooltip, memo, cur_note)
+                {
+                    cur_note = note;
+                };
+            }
+            void update(view new_note)
+            {
+                note = new_note;
             }
         };
     }
@@ -5480,6 +5515,69 @@ again:
         }
     };
 
+    // console: Client properties.
+    class conf
+    {
+    public:
+        text ip;
+        text port;
+        text fullname;
+        text region;
+        text name;
+        text os_user_id;
+        text title;
+        twod coor;
+        twod clip_preview_size;
+        si32 legacy_mode;
+        cell background_color;
+        si32 session_id;
+        period tooltip_timeout; // conf: Timeout for tooltip.
+
+        conf()            = default;
+        conf(conf const&) = default;
+        conf(conf&&)      = default;
+        conf& operator = (conf const&) = default;
+
+        conf(os::xipc peer, si32 session_id)
+            : session_id{ session_id }
+        {
+            auto _region = peer->line(';');
+            auto _ip     = peer->line(';');
+            auto _name   = peer->line(';');
+            auto _user   = peer->line(';');
+            auto _mode   = peer->line(';');
+
+            _user = "[" + _user + ":" + std::to_string(session_id) + "]";
+            auto c_info = utf::divide(_ip, " ");
+            ip   = c_info.size() > 0 ? c_info[0] : text{};
+            port = c_info.size() > 1 ? c_info[1] : text{};
+            legacy_mode       = utf::to_int(_mode, os::legacy::clean);
+            os_user_id        = _user;
+            clip_preview_size = twod{ 80,25 };
+            //background_color  = app::shared::background_color;
+            coor              = twod{ 0,0 }; //todo Move user's viewport to the last saved position
+            region            = _region;
+            fullname          = _name;
+            #ifndef PROD
+                name          = "[User." + utf::remain(ip) + ":" + port + "]";
+                title         = _region;
+            #else
+                name          = _user;
+                title         = _user;
+            #endif
+            tooltip_timeout   = 500ms;
+        }
+
+        friend auto& operator << (std::ostream& s, conf const& c)
+        {
+            return s << "\n\t    ip: " <<(c.ip.empty() ? text{} : (c.ip + ":" + c.port))
+                     << "\n\tregion: " << c.region
+                     << "\n\t  name: " << c.fullname
+                     << "\n\t  user: " << c.os_user_id
+                     << "\n\t  mode: " << os::legacy::str(c.legacy_mode);
+        }
+    };
+
     // console: Client's gate.
     class gate
         : public base
@@ -5506,6 +5604,15 @@ again:
         si32 legacy = os::legacy::clean;
         text clip_rawtext; // gate: Clipboard data.
         face clip_preview; // gate: Clipboard render.
+
+        conf props; // gate: Client properties.
+
+        testy<twod> tooltip_coor = {}; // gate: Show tooltip or not.
+        moment tooltip_time = {}; // gate: The moment to show tooltip.
+        bool   tooltip_show = faux; // gate: Show tooltip or not.
+        text   tooltip_text; // gate: Tooltip data.
+        page   tooltip_page; // gate: Tooltip render.
+        id_t   tooltip_boss; // gate: Tooltip hover object.
 
     public:
         sptr uibar; // gate: Local UI overlay, UI bar/taskbar/sidebar.
@@ -5534,21 +5641,21 @@ again:
             return item;
         }
         // Main loop.
-        template<class PROPS>
-        void run(sptr deskmenu, sptr bkground, os::xipc media /*session socket*/, PROPS const& conf)
+        void run(sptr deskmenu, sptr bkground, os::xipc media /*session socket*/, conf const& client_props)
         {
             auto lock = events::unique_lock();
 
+                props = client_props;
                 attach(deskmenu);
                 ground(bkground);
-                color(conf.background_color.fgc(), conf.background_color.bgc());
-                auto conf_usr_name = conf.name;
+                color(props.background_color.fgc(), props.background_color.bgc());
+                auto conf_usr_name = props.name;
                 SIGNAL(tier::release, e2::form::prop::name, conf_usr_name);
-                SIGNAL(tier::preview, e2::form::prop::header, conf_usr_name);
-                base::moveby(conf.coor);
+                SIGNAL(tier::preview, e2::form::prop::ui::header, conf_usr_name);
+                base::moveby(props.coor);
 
-                clip_preview.size(conf.clip_preview_size); //todo unify/make it configurable
-                legacy |= conf.legacy_mode;
+                clip_preview.size(props.clip_preview_size); //todo unify/make it configurable
+                legacy |= props.legacy_mode;
 
                 auto world = base::parent();
                 auto vga_mode = legacy & os::legacy::vga16  ? svga::vga16
@@ -5599,7 +5706,7 @@ again:
                 //    newheader.lyric->each([&](auto c) { title += c.txt(); });
                 //    conio.output(ansi::tag(title));
                 //};
-                SUBMIT_T(tier::release, e2::form::prop::header, token, newheader)
+                SUBMIT_T(tier::release, e2::form::prop::ui::header, token, newheader)
                 {
                     text temp;
                     temp.reserve(newheader.length());
@@ -5677,7 +5784,7 @@ again:
                 };
             lock.unlock();
 
-            conio.session(conf.title);
+            conio.session(props.title);
             mouse.reset(); // Reset active mouse clients to avoid hanging pointers.
         }
 
@@ -5832,6 +5939,41 @@ again:
                     gear.dismiss();
                 }
             };
+            SUBMIT(tier::preview, hids::events::mouse::move, gear)
+            {
+                if (tooltip_coor(gear.coord))
+                {
+                    tooltip_time = tempus::now() + props.tooltip_timeout;
+                    tooltip_show = faux;
+                }
+            };
+            SUBMIT(tier::general, e2::timer::any, something)
+            {
+                if (tooltip_show == faux
+                 && tooltip_time < tempus::now()
+                 && !input.captured())
+                {
+                    tooltip_show = true;
+                    if (tooltip_boss != input.hover)
+                    {
+                        tooltip_boss = input.hover;
+                        if (auto boss_ptr = std::dynamic_pointer_cast<base>(bell::getref(input.hover)))
+                        {
+                            tooltip_text = {};
+                            boss_ptr->base::template riseup<tier::request>(e2::form::prop::ui::tooltip, tooltip_text);
+                            if (tooltip_text.size())
+                            {
+                                tooltip_page.style.rst().wrp(wrap::off);
+                                tooltip_page = tooltip_text;
+                            }
+                        }
+                    }
+                }
+                else if (tooltip_show == true && input.captured())
+                {
+                    tooltip_show = faux;
+                }
+            };
             SUBMIT(tier::release, e2::render::prerender, parent_canvas)
             {
                 // Draw a shadow of user's terminal window for other users (spectators).
@@ -5894,11 +6036,21 @@ again:
                     parent_canvas.fill(area, cell::shaders::fuse(brush));
                 }
 
-                if (&parent_canvas == &cache.canvas && clip_rawtext.size())
+                if (&parent_canvas == &cache.canvas)
                 {
-                    auto coor = input.coord + dot_21 * 2;
-                    clip_preview.move(coor);
-                    parent_canvas.plot(clip_preview, cell::shaders::lite);
+                    if (clip_rawtext.size())
+                    {
+                        auto coor = input.coord + dot_21 * 2;
+                        clip_preview.move(coor);
+                        parent_canvas.plot(clip_preview, cell::shaders::lite);
+                    }
+                    if (tooltip_show && tooltip_text.size() && !input.captured())
+                    {
+                        static constexpr auto def_tooltip = { rgba{ 0xFFffffff }, rgba{ 0xFF000000 } }; //todo unify
+                        auto coor = input.coord - twod{ 4,2 };
+                        parent_canvas.cup(coor);
+                        parent_canvas.output(tooltip_page, cell::shaders::selection(def_tooltip));
+                    }
                 }
 
                 #ifdef REGIONS
@@ -5911,61 +6063,6 @@ again:
                 });
                 #endif
             };
-        }
-    };
-
-    class conf
-    {
-    public:
-        text ip;
-        text port;
-        text fullname;
-        text region;
-        text name;
-        text os_user_id;
-        text title;
-        twod coor;
-        twod clip_preview_size;
-        si32 legacy_mode;
-        cell background_color;
-        si32 session_id;
-
-        conf(os::xipc peer, si32 session_id)
-            : session_id{ session_id }
-        {
-            auto _region = peer->line(';');
-            auto _ip     = peer->line(';');
-            auto _name   = peer->line(';');
-            auto _user   = peer->line(';');
-            auto _mode   = peer->line(';');
-
-            _user = "[" + _user + ":" + std::to_string(session_id) + "]";
-            auto c_info = utf::divide(_ip, " ");
-            ip   = c_info.size() > 0 ? c_info[0] : text{};
-            port = c_info.size() > 1 ? c_info[1] : text{};
-            legacy_mode       = utf::to_int(_mode, os::legacy::clean);
-            os_user_id        = _user;
-            clip_preview_size = twod{ 80,25 };
-            //background_color  = app::shared::background_color;
-            coor              = twod{ 0,0 }; //todo Move user's viewport to the last saved position
-            region            = _region;
-            fullname          = _name;
-            #ifndef PROD
-            name              = "[User." + utf::remain(ip) + ":" + port + "]";
-            title             = _region;
-            #else
-            name              = _user;
-            title             = _user;
-            #endif
-        }
-
-        friend auto& operator << (std::ostream& s, conf const& c)
-        {
-            return s << "\n\t    ip: " <<(c.ip.empty() ? text{} : (c.ip + ":" + c.port))
-                     << "\n\tregion: " << c.region
-                     << "\n\t  name: " << c.fullname
-                     << "\n\t  user: " << c.os_user_id
-                     << "\n\t  mode: " << os::legacy::str(c.legacy_mode);
         }
     };
 }

--- a/src/netxs/console/console.hpp
+++ b/src/netxs/console/console.hpp
@@ -5532,6 +5532,7 @@ again:
         cell background_color;
         si32 session_id;
         period tooltip_timeout; // conf: Timeout for tooltip.
+        bool tooltip_enabled; // conf: Enable tooltips.
 
         conf()            = default;
         conf(conf const&) = default;
@@ -5566,6 +5567,7 @@ again:
                 title         = _user;
             #endif
             tooltip_timeout   = 500ms;
+            tooltip_enabled   = faux;
         }
 
         friend auto& operator << (std::ostream& s, conf const& c)
@@ -5750,6 +5752,70 @@ again:
                 {
                     clipbrd_size = clip_preview.size();
                 };
+                if (props.tooltip_enabled)
+                {
+                    SUBMIT_T(tier::preview, hids::events::mouse::any, token, gear)
+                    {
+                        if (tooltip_boss != input.hover) // Welcome new object.
+                        {
+                            tooltip_stop = faux;
+                        }
+
+                        if (!tooltip_stop)
+                        {
+                            auto deed = this->bell::template protos<tier::preview>();
+                            if (deed == hids::events::mouse::move.id)
+                            {
+                                if (tooltip_coor(gear.coord)) // Do nothing on shuffle.
+                                {
+                                    if (tooltip_show && tooltip_boss == input.hover) // Drop tooltip if moved.
+                                    {
+                                        tooltip_stop = true;
+                                    }
+                                    else
+                                    {
+                                        tooltip_time = tempus::now() + props.tooltip_timeout;
+                                        tooltip_show = faux;
+                                    }
+                                }
+                            }
+                            else // Drop tooltip on any other event.
+                            {
+                                tooltip_stop = true;
+                                tooltip_boss = input.hover;
+                            }
+                        }
+                    };
+                    SUBMIT_T(tier::general, e2::timer::any, token, something)
+                    {
+                        if (!tooltip_stop
+                         && !tooltip_show
+                         &&  tooltip_time < tempus::now()
+                         && !input.captured())
+                        {
+                            tooltip_show = true;
+                            if (tooltip_boss != input.hover)
+                            {
+                                tooltip_boss = input.hover;
+                                if (auto boss_ptr = std::dynamic_pointer_cast<base>(bell::getref(input.hover)))
+                                {
+                                    tooltip_text = {};
+                                    boss_ptr->base::template riseup<tier::request>(e2::form::prop::ui::tooltip, tooltip_text);
+                                    if (tooltip_text.size())
+                                    {
+                                        tooltip_page.style.rst().wrp(wrap::off);
+                                        tooltip_page = tooltip_text;
+                                    }
+                                }
+                            }
+                        }
+                        else if (tooltip_show == true && input.captured())
+                        {
+                            tooltip_show = faux;
+                            tooltip_stop = faux;
+                        }
+                    };
+                }
 
                 world->SUBMIT_T(tier::release, e2::form::proceed::render, token, render_scene)
                 {
@@ -5940,67 +6006,7 @@ again:
                     gear.dismiss();
                 }
             };
-            SUBMIT(tier::preview, hids::events::mouse::any, gear)
-            {
-                if (tooltip_boss != input.hover) // Welcome new object.
-                {
-                    tooltip_stop = faux;
-                }
 
-                if (!tooltip_stop)
-                {
-                    auto deed = this->bell::template protos<tier::preview>();
-                    if (deed == hids::events::mouse::move.id)
-                    {
-                        if (tooltip_coor(gear.coord)) // Do nothing on shuffle.
-                        {
-                            if (tooltip_show && tooltip_boss == input.hover) // Drop tooltip if moved.
-                            {
-                                tooltip_stop = true;
-                            }
-                            else
-                            {
-                                tooltip_time = tempus::now() + props.tooltip_timeout;
-                                tooltip_show = faux;
-                            }
-                        }
-                    }
-                    else // Drop tooltip on any other event.
-                    {
-                        tooltip_stop = true;
-                        tooltip_boss = input.hover;
-                    }
-                }
-            };
-            SUBMIT(tier::general, e2::timer::any, something)
-            {
-                if (!tooltip_stop
-                 && !tooltip_show
-                 &&  tooltip_time < tempus::now()
-                 && !input.captured())
-                {
-                    tooltip_show = true;
-                    if (tooltip_boss != input.hover)
-                    {
-                        tooltip_boss = input.hover;
-                        if (auto boss_ptr = std::dynamic_pointer_cast<base>(bell::getref(input.hover)))
-                        {
-                            tooltip_text = {};
-                            boss_ptr->base::template riseup<tier::request>(e2::form::prop::ui::tooltip, tooltip_text);
-                            if (tooltip_text.size())
-                            {
-                                tooltip_page.style.rst().wrp(wrap::off);
-                                tooltip_page = tooltip_text;
-                            }
-                        }
-                    }
-                }
-                else if (tooltip_show == true && input.captured())
-                {
-                    tooltip_show = faux;
-                    tooltip_stop = faux;
-                }
-            };
             SUBMIT(tier::release, e2::render::prerender, parent_canvas)
             {
                 // Draw a shadow of user's terminal window for other users (spectators).

--- a/src/netxs/console/console.hpp
+++ b/src/netxs/console/console.hpp
@@ -4498,9 +4498,9 @@ namespace netxs::console
 
             if (alive)
             {
-                log("link: signaling to close read channel ", canal);
+                log("link: signaling to close the read channel ", canal);
                 owner.SIGNAL(tier::release, e2::conio::quit, "link: read channel is closed");
-                log("link: signaling to close read channel complete ", canal);
+                log("link: read channel close signaling completed ", canal);
             }
             log("link: id: ", std::this_thread::get_id(), " reading thread ended");
         }

--- a/src/netxs/console/input.hpp
+++ b/src/netxs/console/input.hpp
@@ -632,6 +632,11 @@ namespace netxs::input
         {
             return swift == asker;
         }
+        // mouse: Is the mouse seized/captured?
+        bool captured() const
+        {
+            return locks != 0;
+        }
         // mouse: Seize specified mouse control.
         bool capture(id_t asker)
         {

--- a/src/netxs/console/richtext.hpp
+++ b/src/netxs/console/richtext.hpp
@@ -500,8 +500,7 @@ namespace netxs::console
             rtl ? txt.template output<true>(*this, pos, print)
                 : txt.template output<faux>(*this, pos, print);
         }
-        template<feed DIRECTION = feed::fwd>
-        auto find(core const& what, si32& from) const // core: Find the substring and place its offset in &from.
+        auto find(core const& what, si32& from, feed dir = feed::fwd) const // core: Find the substring and place its offset in &from.
         {
             auto full =      canvas.size();
             auto size = what.canvas.size();
@@ -539,7 +538,7 @@ namespace netxs::console
                 return faux;
             };
 
-            if constexpr (DIRECTION == feed::fwd)
+            if (dir == feed::fwd)
             {
                 if (look(canvas.begin(), canvas.end(), what.canvas.begin()))
                 {
@@ -1054,11 +1053,15 @@ namespace netxs::console
             : core{ std::forward<core>(s) }
         { }
 
-        auto length() const                                     { return size().x;                         }
         auto shadow() const                                     { return shot{ *this };                    }
         auto substr(si32 at, si32 width = netxs::maxsi32) const { return shadow().substr(at, width);       }
         void trimto(si32 max_size)                              { if (length() > max_size) crop(max_size); }
         void reserv(si32 oversize)                              { if (oversize > length()) crop(oversize); }
+        si32 length() const
+        {
+            assert(canvas.size() <= std::numeric_limits<si32>::max());
+            return static_cast<si32>(canvas.size());
+        }
         void shrink(cell const& blank, si32 max_size = 0, si32 min_size = 0)
         {
             assert(min_size <= length());
@@ -1483,6 +1486,7 @@ namespace netxs::console
         operator writ const& () const { return locus; }
 
         void decouple() { lyric = std::make_shared<rich>(*lyric); } // para: Make canvas isolated copy.
+        auto& content() const { return *lyric; } // para: Return paragraph content.
         shot   shadow() const { return *lyric; } // para: Return paragraph shadow.
         shot   substr(si32 start, si32 width) const // para: Return paragraph substring shadow.
         {

--- a/src/netxs/console/richtext.hpp
+++ b/src/netxs/console/richtext.hpp
@@ -500,10 +500,13 @@ namespace netxs::console
             rtl ? txt.template output<true>(*this, pos, print)
                 : txt.template output<faux>(*this, pos, print);
         }
-        auto find(core const& what, si32& from, feed dir = feed::fwd) const // core: Find the substring and place its offset in &from.
+        template<class SI32>
+        auto find(core const& what, SI32&& from, feed dir = feed::fwd) const // core: Find the substring and place its offset in &from.
         {
-            auto full =      canvas.size();
-            auto size = what.canvas.size();
+            assert(     canvas.size() <= std::numeric_limits<si32>::max());
+            assert(what.canvas.size() <= std::numeric_limits<si32>::max());
+            auto full = static_cast<si32>(     canvas.size());
+            auto size = static_cast<si32>(what.canvas.size());
             auto look = [&](auto canvas_begin, auto canvas_end, auto what_begin)
             {
                 auto rest = full - from;
@@ -1061,6 +1064,10 @@ namespace netxs::console
         {
             assert(canvas.size() <= std::numeric_limits<si32>::max());
             return static_cast<si32>(canvas.size());
+        }
+        auto empty()
+        {
+            return canvas.empty();
         }
         void shrink(cell const& blank, si32 max_size = 0, si32 min_size = 0)
         {

--- a/src/netxs/console/richtext.hpp
+++ b/src/netxs/console/richtext.hpp
@@ -500,17 +500,20 @@ namespace netxs::console
             rtl ? txt.template output<true>(*this, pos, print)
                 : txt.template output<faux>(*this, pos, print);
         }
+        template<feed DIRECTION = feed::fwd>
         auto find(core const& what, si32& from) const // core: Find the substring and place its offset in &from.
         {
+            static constexpr auto rev = DIRECTION == feed::fwd ? faux : true;
+
             auto size = what.canvas.size();
             auto rest =      canvas.size() - from;
             if (!size || size > rest) return faux;
 
             size--;
-            auto head = core::iter();
-            auto tail = core::iend() - size;
+            auto head = canvas.begin();
+            auto tail = canvas.end() - size;
             auto iter = head + from;
-            auto base = what.core::iter();
+            auto base = what.canvas.begin();
             auto dest = base;
             auto&test =*base;
             while (iter != tail)

--- a/src/netxs/console/richtext.hpp
+++ b/src/netxs/console/richtext.hpp
@@ -505,37 +505,76 @@ namespace netxs::console
         {
             static constexpr auto rev = DIRECTION == feed::fwd ? faux : true;
 
-            auto size = what.canvas.size();
-            auto rest =      canvas.size() - from;
-            if (!size || size > rest) return faux;
-
-            size--;
-            auto head = canvas.begin();
-            auto tail = canvas.end() - size;
-            auto iter = head + from;
-            auto base = what.canvas.begin();
-            auto dest = base;
-            auto&test =*base;
-            while (iter != tail)
+            if constexpr (rev)
             {
-                if (test.same_txt(*iter++))
-                {
-                    auto init = iter;
-                    auto stop = iter + size;
-                    while (init != stop && init->same_txt(*++dest))
-                    {
-                        ++init;
-                    }
+                //todo implement
+                //...
+                auto size = what.canvas.size();
+                auto rest =      canvas.size() - from;
+                if (!size || size > rest) return faux;
 
-                    if (init == stop)
+                size--;
+                auto head = canvas.begin();
+                auto tail = canvas.end() - size;
+                auto iter = head + from;
+                auto base = what.canvas.begin();
+                auto dest = base;
+                auto&test =*base;
+                while (iter != tail)
+                {
+                    if (test.same_txt(*iter++))
                     {
-                        from = static_cast<si32>(std::distance(head, iter)) - 1;
-                        return true;
+                        auto init = iter;
+                        auto stop = iter + size;
+                        while (init != stop && init->same_txt(*++dest))
+                        {
+                            ++init;
+                        }
+
+                        if (init == stop)
+                        {
+                            from = static_cast<si32>(std::distance(head, iter)) - 1;
+                            return true;
+                        }
+                        else dest = base;
                     }
-                    else dest = base;
                 }
+                return faux;
             }
-            return faux;
+            else
+            {
+                auto size = what.canvas.size();
+                auto rest =      canvas.size() - from;
+                if (!size || size > rest) return faux;
+
+                size--;
+                auto head = canvas.begin();
+                auto tail = canvas.end() - size;
+                auto iter = head + from;
+                auto base = what.canvas.begin();
+                auto dest = base;
+                auto&test =*base;
+                while (iter != tail)
+                {
+                    if (test.same_txt(*iter++))
+                    {
+                        auto init = iter;
+                        auto stop = iter + size;
+                        while (init != stop && init->same_txt(*++dest))
+                        {
+                            ++init;
+                        }
+
+                        if (init == stop)
+                        {
+                            from = static_cast<si32>(std::distance(head, iter)) - 1;
+                            return true;
+                        }
+                        else dest = base;
+                    }
+                }
+                return faux;
+            }
         }
         auto toxy(si32 offset) const // core: Convert offset to coor.
         {

--- a/src/netxs/console/richtext.hpp
+++ b/src/netxs/console/richtext.hpp
@@ -507,9 +507,9 @@ namespace netxs::console
             assert(what.canvas.size() <= std::numeric_limits<si32>::max());
             auto full = static_cast<si32>(     canvas.size());
             auto size = static_cast<si32>(what.canvas.size());
+            auto rest = full - from;
             auto look = [&](auto canvas_begin, auto canvas_end, auto what_begin)
             {
-                auto rest = full - from;
                 if (!size || size > rest) return faux;
 
                 size--;
@@ -550,10 +550,10 @@ namespace netxs::console
             }
             else
             {
-                from = full - from - 1;
+                std::swap(rest, from); // Reverse.
                 if (look(canvas.rbegin(), canvas.rend(), what.canvas.rbegin()))
                 {
-                    from = full - from - 1;
+                    from = full - from - 1; // Restore forward representation.
                     return true;
                 }
             }
@@ -1056,15 +1056,11 @@ namespace netxs::console
             : core{ std::forward<core>(s) }
         { }
 
+        auto length() const                                     { return size().x;                         }
         auto shadow() const                                     { return shot{ *this };                    }
         auto substr(si32 at, si32 width = netxs::maxsi32) const { return shadow().substr(at, width);       }
         void trimto(si32 max_size)                              { if (length() > max_size) crop(max_size); }
         void reserv(si32 oversize)                              { if (oversize > length()) crop(oversize); }
-        si32 length() const
-        {
-            assert(canvas.size() <= std::numeric_limits<si32>::max());
-            return static_cast<si32>(canvas.size());
-        }
         auto empty()
         {
             return canvas.empty();

--- a/src/netxs/console/richtext.hpp
+++ b/src/netxs/console/richtext.hpp
@@ -503,21 +503,18 @@ namespace netxs::console
         template<feed DIRECTION = feed::fwd>
         auto find(core const& what, si32& from) const // core: Find the substring and place its offset in &from.
         {
-            static constexpr auto rev = DIRECTION == feed::fwd ? faux : true;
-
-            if constexpr (rev)
+            auto full =      canvas.size();
+            auto size = what.canvas.size();
+            auto look = [&](auto canvas_begin, auto canvas_end, auto what_begin)
             {
-                //todo implement
-                //...
-                auto size = what.canvas.size();
-                auto rest =      canvas.size() - from;
+                auto rest = full - from;
                 if (!size || size > rest) return faux;
 
                 size--;
-                auto head = canvas.begin();
-                auto tail = canvas.end() - size;
+                auto head = canvas_begin;
+                auto tail = canvas_end - size;
                 auto iter = head + from;
-                auto base = what.canvas.begin();
+                auto base = what_begin;
                 auto dest = base;
                 auto&test =*base;
                 while (iter != tail)
@@ -540,41 +537,25 @@ namespace netxs::console
                     }
                 }
                 return faux;
+            };
+
+            if constexpr (DIRECTION == feed::fwd)
+            {
+                if (look(canvas.begin(), canvas.end(), what.canvas.begin()))
+                {
+                    return true;
+                }
             }
             else
             {
-                auto size = what.canvas.size();
-                auto rest =      canvas.size() - from;
-                if (!size || size > rest) return faux;
-
-                size--;
-                auto head = canvas.begin();
-                auto tail = canvas.end() - size;
-                auto iter = head + from;
-                auto base = what.canvas.begin();
-                auto dest = base;
-                auto&test =*base;
-                while (iter != tail)
+                from = full - from - 1;
+                if (look(canvas.rbegin(), canvas.rend(), what.canvas.rbegin()))
                 {
-                    if (test.same_txt(*iter++))
-                    {
-                        auto init = iter;
-                        auto stop = iter + size;
-                        while (init != stop && init->same_txt(*++dest))
-                        {
-                            ++init;
-                        }
-
-                        if (init == stop)
-                        {
-                            from = static_cast<si32>(std::distance(head, iter)) - 1;
-                            return true;
-                        }
-                        else dest = base;
-                    }
+                    from = full - from - 1;
+                    return true;
                 }
-                return faux;
             }
+            return faux;
         }
         auto toxy(si32 offset) const // core: Convert offset to coor.
         {

--- a/src/netxs/console/richtext.hpp
+++ b/src/netxs/console/richtext.hpp
@@ -590,7 +590,7 @@ namespace netxs::console
             if (from > upto) std::swap(from, upto);
             assert(canvas.size() <= std::numeric_limits<si32>::max());
             auto maxs = static_cast<si32>(canvas.size());
-            from = std::clamp(from, 0, maxs - 1);
+            from = std::clamp(from, 0, maxs ? maxs - 1 : 0);
             upto = std::clamp(upto, 0, maxs);
             auto size = upto - from;
             return core{ span{ canvas.data() + from, static_cast<size_t>(size) }, { size, 1 }};

--- a/src/netxs/console/terminal.hpp
+++ b/src/netxs/console/terminal.hpp
@@ -398,7 +398,7 @@ namespace netxs::ui
                                   props[ansi::OSC_LABEL] = txt;
                     auto& utf8 = (props[ansi::OSC_TITLE] = txt);
                     utf8 = jet_left + utf8;
-                    owner.base::riseup<tier::preview>(e2::form::prop::header, utf8);
+                    owner.base::riseup<tier::preview>(e2::form::prop::ui::header, utf8);
                 }
                 else
                 {
@@ -406,7 +406,7 @@ namespace netxs::ui
                     if (property == ansi::OSC_TITLE)
                     {
                         utf8 = jet_left + utf8;
-                        owner.base::riseup<tier::preview>(e2::form::prop::header, utf8);
+                        owner.base::riseup<tier::preview>(e2::form::prop::ui::header, utf8);
                     }
                 }
             }
@@ -5949,7 +5949,7 @@ namespace netxs::ui
             SIGNAL_GLOBAL(e2::debug::count::set, 0);
             SUBMIT(tier::release, e2::form::upon::vtree::attached, parent)
             {
-                this->base::riseup<tier::request>(e2::form::prop::header, wtrack.get(ansi::OSC_TITLE));
+                this->base::riseup<tier::request>(e2::form::prop::ui::header, wtrack.get(ansi::OSC_TITLE));
             };
             SUBMIT(tier::preview, e2::coor::set, new_coor)
             {
@@ -6058,7 +6058,7 @@ namespace netxs::ui
                 auto& console = *target;
                 if (status.update(console))
                 {
-                    this->base::riseup<tier::preview>(e2::form::prop::footer, status.data);
+                    this->base::riseup<tier::preview>(e2::form::prop::ui::footer, status.data);
                 }
 
                 auto view = parent_canvas.view();

--- a/src/netxs/console/terminal.hpp
+++ b/src/netxs/console/terminal.hpp
@@ -1862,7 +1862,7 @@ namespace netxs::ui
                     {
                         seltop = { offset % length,
                                    offset / length };
-                        offset += a - (b - 2);
+                        offset += a - b + 1;
                         selend = { offset % length,
                                    offset / length };
                         offset += a;
@@ -1876,8 +1876,8 @@ namespace netxs::ui
                         return faux;
                     }
                 };
-                return direction == feed::fwd ? find(match.length(),  3, uifwd, uirev)
-                                              : find(-1, match.length(), uirev, uifwd);
+                return direction == feed::fwd ? find(match.length(), 2, uifwd, uirev)
+                                              : find(0, match.length(), uirev, uifwd);
             }
             // bufferbase: Return match navigation state.
     virtual si32 selection_button(twod const& delta = {})
@@ -5480,8 +5480,8 @@ namespace netxs::ui
                     auto& curln = batch.item_by_id(startid);
                     auto from = selection_offset(curln, coord, 0);
                     auto mlen = match.length();
-                    auto step = ahead ? mlen : -1;
-                    auto back = ahead ? 3 : mlen;
+                    auto step = ahead ? mlen : 0;
+                    auto back = ahead ? 2 : mlen;
                     auto resx = [&](auto& curln)
                     {
                         if (curln.find(match, from, direction))
@@ -5489,7 +5489,7 @@ namespace netxs::ui
                             upmid.link = curln.index;
                             dnmid.link = curln.index;
                             upmid.coor = offset_to_screen(curln, from);
-                            from += step - (back - 2);
+                            from += step - back + 1;
                             dnmid.coor = offset_to_screen(curln, from);
                             delta += coord - upmid.coor;
                             uptop.role = dntop.role = grip::idle;

--- a/src/netxs/console/terminal.hpp
+++ b/src/netxs/console/terminal.hpp
@@ -4044,6 +4044,7 @@ namespace netxs::ui
                     //});
                     if (find)
                     {
+                        match.style = style;
                         auto offset = si32{ 0 };
                         while (curln.find(match, offset))
                         {
@@ -5489,8 +5490,9 @@ namespace netxs::ui
                         else
                         {
                             uifwd = faux;
+                            //todo use reverse iterators
                             auto head = batch.iter_by_id(upmid.link);
-                            auto tail = batch.begin();
+                            auto tail = batch.begin() - 1;
                             init.coor.y += curln.height(panel.x);
                             while (--head != tail)
                             {

--- a/src/netxs/console/terminal.hpp
+++ b/src/netxs/console/terminal.hpp
@@ -5717,6 +5717,7 @@ namespace netxs::ui
             invert = faux;
             decckm = faux;
             bpmode = faux;
+            normal.brush.reset();
         }
         // term: Set termnail parameters. (DECSET).
         void decset(fifo& queue)

--- a/src/netxs/console/terminal.hpp
+++ b/src/netxs/console/terminal.hpp
@@ -6431,6 +6431,15 @@ namespace netxs::ui
                     utf::change(data, "\033[1C", "\033OC");
                     utf::change(data, "\033[1D", "\033OD");
                 }
+                else // Issue with arrow keys in WSL under cmd.exe.
+                {
+                    #if defined(_WIN32)
+                    utf::change(data, "\033[1A", "\033[A");
+                    utf::change(data, "\033[1B", "\033[B");
+                    utf::change(data, "\033[1C", "\033[C");
+                    utf::change(data, "\033[1D", "\033[D");
+                    #endif
+                }
                 // Linux console specific.
                 utf::change(data, "\033[[A", "\033OP");      // F1
                 utf::change(data, "\033[[B", "\033OQ");      // F2

--- a/src/netxs/os/system.hpp
+++ b/src/netxs/os/system.hpp
@@ -397,7 +397,7 @@ namespace netxs::os
         auto conmode = -1;
         #if defined (__linux__)
             
-            if (ok(::ioctl(STDOUT_FD, KDGETMODE, &conmode), "KDGETMODE failed"))
+            if (ok(::ioctl(STDOUT_FD, KDGETMODE, &conmode), "ioctl(STDOUT_FD, KDGETMODE) failed"))
             {
                 switch (conmode)
                 {
@@ -481,7 +481,7 @@ namespace netxs::os
                                               .height    = 32,
                                               .charcount = 512,
                                               .data      = chars.data() };
-                if (!ok(::ioctl(STDOUT_FD, KDFONTOP, &fdata), "KDFONTOP + KD_FONT_OP_GET failed")) return;
+                if (!ok(::ioctl(STDOUT_FD, KDFONTOP, &fdata), "first KDFONTOP + KD_FONT_OP_GET failed")) return;
 
                 auto slice_bytes = (fdata.width + 7) / 8;
                 auto block_bytes = (slice_bytes * fdata.height + 31) / 32 * 32;
@@ -498,7 +498,7 @@ namespace netxs::os
                     lowhalf_ptr+= slice_bytes;
                 }
                 fdata.op = KD_FONT_OP_SET;
-                if (!ok(::ioctl(STDOUT_FD, KDFONTOP, &fdata), "KDFONTOP + KD_FONT_OP_SET failed")) return;
+                if (!ok(::ioctl(STDOUT_FD, KDFONTOP, &fdata), "second KDFONTOP + KD_FONT_OP_SET failed")) return;
 
                 auto max_sz = std::numeric_limits<unsigned short>::max();
                 auto spairs = std::vector<unipair>(max_sz);
@@ -507,7 +507,7 @@ namespace netxs::os
                 auto dstmap = unimapdesc{ max_sz, dpairs.data() };
                 auto dstptr = dstmap.entries;
                 auto srcptr = srcmap.entries;
-                if (!ok(::ioctl(STDOUT_FD, GIO_UNIMAP, &srcmap), "GIO_UNIMAP failed")) return;
+                if (!ok(::ioctl(STDOUT_FD, GIO_UNIMAP, &srcmap), "ioctl(STDOUT_FD, GIO_UNIMAP) failed")) return;
                 auto srcend = srcmap.entries + srcmap.entry_ct;
                 while (srcptr != srcend) // Drop 10, 211, 254 and 0x2580▀ + 0x2584▄.
                 {
@@ -530,7 +530,7 @@ namespace netxs::os
                 {
                     for (auto& p : new_recs) *dstptr++ = p;
                     dstmap.entry_ct += std::size(new_recs);
-                    if (!ok(::ioctl(STDOUT_FD, PIO_UNIMAP, &dstmap), "PIO_UNIMAP failed")) return;
+                    if (!ok(::ioctl(STDOUT_FD, PIO_UNIMAP, &dstmap), "ioctl(STDOUT_FD, PIO_UNIMAP) failed")) return;
                 }
                 else log("  os: vgafont_update failed - UNIMAP is full");
             }
@@ -1484,7 +1484,7 @@ namespace netxs::os
 
         public:
             operator auto () { return h[0]; }
-            fire()           { ok(::pipe(h), "pipe(2) creation error"); }
+            fire()           { ok(::pipe(h), "pipe[2] creation failed"); }
            ~fire()           { for (auto f : h) if (f != INVALID_FD) ::close(f); }
             void reset()     { os::send(h[1], &x, sizeof(x)); }
             void flush()     { os::recv(h[0], &x, sizeof(x)); }
@@ -1702,8 +1702,10 @@ namespace netxs::os
                     unsigned size = sizeof(cred);
                 #endif
 
-                if (!ok(::getsockopt(handle.get_r(), SOL_SOCKET, SO_PEERCRED, &cred, &size), "getsockopt error"))
+                if (!ok(::getsockopt(handle.get_r(), SOL_SOCKET, SO_PEERCRED, &cred, &size), "getsockopt(SOL_SOCKET) failed"))
+                {
                     return faux;
+                }
 
                 if (cred.uid && id != cred.uid)
                 {
@@ -1721,8 +1723,10 @@ namespace netxs::os
                 uid_t euid;
                 gid_t egid;
 
-                if (!ok(::getpeereid(handle.get_r(), &euid, &egid), "getpeereid error"))
+                if (!ok(::getpeereid(handle.get_r(), &euid, &egid), "getpeereid failed"))
+                {
                     return faux;
+                }
 
                 if (euid && id != euid)
                 {
@@ -2126,10 +2130,12 @@ namespace netxs::os
             static testy<twod> winsz;
             static void resize_handler()
             {
+                static constexpr auto winsz_fallback = twod{ 132, 60 };
+
                 #if defined(_WIN32)
 
                     auto cinfo = CONSOLE_SCREEN_BUFFER_INFO{};
-                    if (ok(::GetConsoleScreenBufferInfo(STDOUT_FD, &cinfo)))
+                    if (ok(::GetConsoleScreenBufferInfo(STDOUT_FD, &cinfo), "GetConsoleScreenBufferInfo failed"))
                     {
                         winsz({ cinfo.srWindow.Right  - cinfo.srWindow.Left + 1,
                                 cinfo.srWindow.Bottom - cinfo.srWindow.Top  + 1 });
@@ -2138,12 +2144,18 @@ namespace netxs::os
                 #else
 
                     auto size = winsize{};
-                    if (ok(::ioctl(STDOUT_FD, TIOCGWINSZ, &size)))
+                    if (ok(::ioctl(STDOUT_FD, TIOCGWINSZ, &size), "ioctl(STDOUT_FD, TIOCGWINSZ) failed"))
                     {
                         winsz({ size.ws_col, size.ws_row });
                     }
 
                 #endif
+
+                    else
+                    {
+                        log("xtty: fallback tty window size ", winsz_fallback, " (consider using 'ssh -tt ...')");
+                        winsz(winsz_fallback);
+                    }
 
                 if (winsz.test)
                 {
@@ -2155,8 +2167,8 @@ namespace netxs::os
 
                 static void default_mode()
                 {
-                    ok(::SetConsoleMode(STDOUT_FD, state[0]), "SetConsoleMode error (revert_o)");
-                    ok(::SetConsoleMode(STDIN_FD , state[1]), "SetConsoleMode error (revert_i)");
+                    ok(::SetConsoleMode(STDOUT_FD, state[0]), "SetConsoleMode failed (revert_o)");
+                    ok(::SetConsoleMode(STDIN_FD , state[1]), "SetConsoleMode failed (revert_i)");
                 }
                 static BOOL signal_handler(DWORD signal)
                 {
@@ -2398,7 +2410,7 @@ namespace netxs::os
                     si32 state = 0;
                     #if defined(__linux__)
                         si32 shift_state = 6;
-                        ok(::ioctl(STDIN_FD, TIOCLINUX, &shift_state));
+                        ok(::ioctl(STDIN_FD, TIOCLINUX, &shift_state), "ioctl(STDIN_FD, TIOCLINUX) failed");
                         state = 0
                             | (shift_state & (1 << KG_ALTGR)) >> 1 // 0x1
                             | (shift_state & (1 << KG_ALT  )) >> 2 // 0x2
@@ -2409,7 +2421,7 @@ namespace netxs::os
                     #endif
                     return state;
                 };
-                ok(::ttyname_r(STDOUT_FD, buffer.data(), buffer.size()), "ttyname_r error");
+                ok(::ttyname_r(STDOUT_FD, buffer.data(), buffer.size()), "ttyname_r(STDOUT_FD) failed");
                 auto tty_name = view(buffer.data());
                 log(" tty: pseudoterminal ", tty_name);
                 if (legacy_mouse)
@@ -2480,7 +2492,7 @@ namespace netxs::os
                     {
                     #if defined(__linux__)
                         vt_stat vt_state;
-                        ok(::ioctl(STDOUT_FD, VT_GETSTATE, &vt_state));
+                        ok(::ioctl(STDOUT_FD, VT_GETSTATE, &vt_state), "ioctl(VT_GETSTATE) failed");
                         if (vt_state.v_active == ttynum) // Proceed current active tty only.
                         {
                             auto scale = twod{ 6,12 }; //todo magic numbers
@@ -2551,7 +2563,7 @@ namespace netxs::os
         {
             return os::send<true>(STDOUT_FD, utf8.data(), utf8.size());
         }
-        void ignite()
+        bool ignite()
         {
             auto& sig_hndl = _globals<void>::signal_handler;
 
@@ -2560,8 +2572,8 @@ namespace netxs::os
                 auto& omode = _globals<void>::state[0];
                 auto& imode = _globals<void>::state[1];
 
-                ok(::GetConsoleMode(STDOUT_FD, &omode), "GetConsoleMode error (stdout)");
-                ok(::GetConsoleMode(STDIN_FD , &imode), "GetConsoleMode error (stdin)");
+                ok(::GetConsoleMode(STDOUT_FD, &omode), "GetConsoleMode(STDOUT_FD) failed");
+                ok(::GetConsoleMode(STDIN_FD , &imode), "GetConsoleMode(STDIN_FD) failed");
 
                 DWORD inpmode = 0
                               | ENABLE_EXTENDED_FLAGS
@@ -2572,34 +2584,45 @@ namespace netxs::os
                               | ENABLE_VIRTUAL_TERMINAL_INPUT
                             #endif
                               ;
-                ok(::SetConsoleMode(STDIN_FD, inpmode), "SetConsoleMode error (stdin)");
+                ok(::SetConsoleMode(STDIN_FD, inpmode), "SetConsoleMode(STDIN_FD) failed");
 
                 DWORD outmode = 0
                               | ENABLE_PROCESSED_OUTPUT
                               | ENABLE_VIRTUAL_TERMINAL_PROCESSING
                               | DISABLE_NEWLINE_AUTO_RETURN
                               ;
-                ok(::SetConsoleMode(STDOUT_FD, outmode), "SetConsoleMode error (stdout)");
-                ok(::SetConsoleCtrlHandler(sig_hndl, TRUE), "SetConsoleCtrlHandler error");
+                ok(::SetConsoleMode(STDOUT_FD, outmode), "SetConsoleMode(STDOUT_FD) failed");
+                ok(::SetConsoleCtrlHandler(sig_hndl, TRUE), "SetConsoleCtrlHandler failed");
 
             #else
 
                 auto& state = _globals<void>::state;
-                if (ok(::tcgetattr(STDIN_FD, &state))) // Set stdin raw mode.
+                if (ok(::tcgetattr(STDIN_FD, &state), "tcgetattr(STDIN_FD) failed")) // Set stdin raw mode.
                 {
                     auto raw_mode = state;
                     ::cfmakeraw(&raw_mode);
-                    ok(::tcsetattr(STDIN_FD, TCSANOW, &raw_mode));
+                    ok(::tcsetattr(STDIN_FD, TCSANOW, &raw_mode), "tcsetattr(STDIN_FD, TCSANOW) failed");
                 }
-                ok(::signal(SIGPIPE , SIG_IGN ));
-                ok(::signal(SIGWINCH, sig_hndl));
-                ok(::signal(SIGTERM , sig_hndl));
-                ok(::signal(SIGHUP  , sig_hndl));
+                else
+                {
+                    if (_globals<void>::ipcio)
+                    {
+                        _globals<void>::ipcio->shut();
+                    }
+                    return os::fail("abort: check you are using the proper tty device, try `ssh -tt ...` option");
+                }
+
+                ok(::signal(SIGPIPE , SIG_IGN ), "set signal(SIGPIPE ) failed");
+                ok(::signal(SIGWINCH, sig_hndl), "set signal(SIGWINCH) failed");
+                ok(::signal(SIGTERM , sig_hndl), "set signal(SIGTERM ) failed");
+                ok(::signal(SIGHUP  , sig_hndl), "set signal(SIGHUP  ) failed");
 
             #endif
 
             ::atexit(_globals<void>::default_mode);
             _globals<void>::resize_handler();
+
+            return true;
         }
         void splice(si32 mode)
         {
@@ -2834,7 +2857,7 @@ namespace netxs::os
                     argv.push_back(nullptr);
 
                     ::setenv("TERM", "xterm-256color", 1); //todo too hacky
-                    ok(::execvp(argv.front(), argv.data()), "execvp error");
+                    ok(::execvp(argv.front(), argv.data()), "execvp failed");
                     os::exit(1, "xpty: exec error ", errno);
                 }
 
@@ -2873,8 +2896,8 @@ namespace netxs::os
             if (pid != 0)
             {
                 int status;
-                ok(::kill(pid, SIGKILL));
-                ok(::waitpid(pid, &status, 0)); // Wait for the child to avoid zombies.
+                ok(::kill(pid, SIGKILL), "kill(pid, SIGKILL) failed");
+                ok(::waitpid(pid, &status, 0), "waitpid(pid) failed"); // Wait for the child to avoid zombies.
                 if (WIFEXITED(status))
                 {
                     exit_code = WEXITSTATUS(status);
@@ -2948,7 +2971,7 @@ namespace netxs::os
                     winsize winsz;
                     winsz.ws_col = newsize.x;
                     winsz.ws_row = newsize.y;
-                    ok(::ioctl(termlink.get(), TIOCSWINSZ, &winsz));
+                    ok(::ioctl(termlink.get(), TIOCSWINSZ, &winsz), "ioctl(termlink.get(), TIOCSWINSZ) failed");
 
                 #endif
             }

--- a/src/netxs/os/system.hpp
+++ b/src/netxs/os/system.hpp
@@ -1691,7 +1691,8 @@ namespace netxs::os
         {
             #if defined(_WIN32)
 
-                //todo implement for win32
+                //Note: Named Pipes - default ACL used for a named pipe grant full control to the LocalSystem, admins, and the creator owner
+                //https://docs.microsoft.com/en-us/windows/win32/ipc/named-pipe-security-and-access-rights
 
             #elif defined(__linux__)
 

--- a/src/netxs/text/logger.hpp
+++ b/src/netxs/text/logger.hpp
@@ -165,8 +165,10 @@ namespace netxs
             }
         };
 
-        logger(logger const&) = default;
-        logger(logger&&)      = default;
+        logger(logger&& l)
+            : writers{ std::    move(l.writers)   },
+              token  { std::exchange(l.token, {}) }
+        { }
         template<class ...Args>
         logger(Args&&... writers)
         {
@@ -176,7 +178,7 @@ namespace netxs
         ~logger()
         {
             auto sync = guard();
-            g::checkout(token);
+            if (token) g::checkout(token);
             writers.clear();
         }
 

--- a/src/netxs/text/utf.hpp
+++ b/src/netxs/text/utf.hpp
@@ -1430,6 +1430,13 @@ namespace netxs::utf
         if (!skip.empty()) trim_front(utf8, skip);
         return str;
     };
+
+    template<class TEXT_or_VIEW>
+    auto is_plain(TEXT_or_VIEW&& utf8)
+    {
+        auto test = utf8.find('\033');
+        return test == text::npos;
+    }
 }
 
 #endif // NETXS_UTF_HPP

--- a/src/vtm.cpp
+++ b/src/vtm.cpp
@@ -182,7 +182,7 @@ int main(int argc, char* argv[])
             return 1;
         }
 
-        syslog.tee<events::try_sync>([](auto utf8) { SIGNAL_GLOBAL(e2::debug::logs, utf8); });
+        auto srvlog = syslog.tee<events::try_sync>([](auto utf8) { SIGNAL_GLOBAL(e2::debug::logs, utf8); });
 
         log("main: listening socket ", link,
                          "\n\tuser: ", user,

--- a/src/vtm.cpp
+++ b/src/vtm.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) NetXS Group.
 // Licensed under the MIT license.
 
-#define MONOTTY_VER "Monotty Desktopio v0.7.4"
+#define MONOTTY_VER "Monotty Desktopio v0.7.5"
 
 // Enable demo apps and assign Esc key to log off.
 //#define DEMO

--- a/src/vtm.cpp
+++ b/src/vtm.cpp
@@ -154,20 +154,22 @@ int main(int argc, char* argv[])
                                user, ";",
                                mode, ";"));
         auto gate = os::tty::proxy(link);
-        gate.ignite();
-        gate.output(ansi::esc{}.save_title()
-                               .altbuf(true)
-                               .vmouse(true)
-                               .cursor(faux)
-                               .bpmode(true)
-                               .setutf(true));
-        gate.splice(mode);
-        gate.output(ansi::esc{}.scrn_reset()
-                               .vmouse(faux)
-                               .cursor(true)
-                               .altbuf(faux)
-                               .bpmode(faux)
-                               .load_title());
+        if (gate.ignite())
+        {
+            gate.output(ansi::esc{}.save_title()
+                                   .altbuf(true)
+                                   .vmouse(true)
+                                   .cursor(faux)
+                                   .bpmode(true)
+                                   .setutf(true));
+            gate.splice(mode);
+            gate.output(ansi::esc{}.scrn_reset()
+                                   .vmouse(faux)
+                                   .cursor(true)
+                                   .altbuf(faux)
+                                   .bpmode(faux)
+                                   .load_title());
+        }
 
         std::this_thread::sleep_for(200ms); // Pause to complete consuming/receiving buffered input (e.g. mouse tracking) that has just been canceled.
     }


### PR DESCRIPTION
- Tooltips #212
- Named region (`View` app) titles are now editable using clipboard data #180
- Terminal
  - Navigation between previous/next highlighted fragments #211
  - Scroll buffer search using clipboard data as search string (buttons `<``>`)
  - Page by page scrolling if no selection (buttons `<``>`)
  - Issue with arrow keys in WSL under cmd.exe
- Fix vtm-server logs
- Detect non-tty environment on client start
- Passing arguments via -DCMAKE_CXX_FLAGS when building #214

Closes #212
Closes #211
Closes #180