### PR TITLE
Fix build by including <utility> for std::exchange

### DIFF
--- a/src/netxs/text/logger.hpp
+++ b/src/netxs/text/logger.hpp
@@ -37,6 +37,7 @@
 #include <mutex>
 #include <functional>
 #include <unordered_map>
+#include <utility>
 
 #define AUTO_PROMPT const netxs::logger::prompt __func__##_auto_prompt(__func__)
 


### PR DESCRIPTION
Had troubles compiling (gcc 12.1.1 on Fedora 36), had to include <utility> for std::exchange