### PR TITLE
Configurable menu for built-in terminal

### DIFF
--- a/.resources/status/freebsd.svg
+++ b/.resources/status/freebsd.svg
@@ -18,8 +18,8 @@
     <text x="1000" y="140" transform="scale(.1)" text-anchor="end"
     >FreeBSD amd64</text>
     <text x="1230" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" text-anchor="start"
-    >v0.9.8i</text>
+    >v0.9.8j</text>
     <text x="1230" y="140" transform="scale(.1)" text-anchor="start"
-    >v0.9.8i</text>
+    >v0.9.8j</text>
   </g>
 </svg>

--- a/.resources/status/linux.svg
+++ b/.resources/status/linux.svg
@@ -18,8 +18,8 @@
     <text x="1000" y="140" transform="scale(.1)" text-anchor="end"
     >Linux amd64</text>
     <text x="1230" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" text-anchor="start"
-    >v0.9.8i</text>
+    >v0.9.8j</text>
     <text x="1230" y="140" transform="scale(.1)" text-anchor="start"
-    >v0.9.8i</text>
+    >v0.9.8j</text>
   </g>
 </svg>

--- a/.resources/status/macos.svg
+++ b/.resources/status/macos.svg
@@ -18,8 +18,8 @@
     <text x="1000" y="140" transform="scale(.1)" text-anchor="end"
     >macOS any</text>
     <text x="1230" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" text-anchor="start"
-    >v0.9.8i</text>
+    >v0.9.8j</text>
     <text x="1230" y="140" transform="scale(.1)" text-anchor="start"
-    >v0.9.8i</text>
+    >v0.9.8j</text>
   </g>
 </svg>

--- a/.resources/status/netbsd.svg
+++ b/.resources/status/netbsd.svg
@@ -18,8 +18,8 @@
     <text x="1000" y="140" transform="scale(.1)" text-anchor="end"
     >NetBSD amd64</text>
     <text x="1230" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" text-anchor="start"
-    >v0.9.8i</text>
+    >v0.9.8j</text>
     <text x="1230" y="140" transform="scale(.1)" text-anchor="start"
-    >v0.9.8i</text>
+    >v0.9.8j</text>
   </g>
 </svg>

--- a/.resources/status/openbsd.svg
+++ b/.resources/status/openbsd.svg
@@ -18,8 +18,8 @@
     <text x="1000" y="140" transform="scale(.1)" text-anchor="end"
     >OpenBSD amd64</text>
     <text x="1230" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" text-anchor="start"
-    >v0.9.8i</text>
+    >v0.9.8j</text>
     <text x="1230" y="140" transform="scale(.1)" text-anchor="start"
-    >v0.9.8i</text>
+    >v0.9.8j</text>
   </g>
 </svg>

--- a/.resources/status/windows.svg
+++ b/.resources/status/windows.svg
@@ -18,8 +18,8 @@
     <text x="1000" y="140" transform="scale(.1)" text-anchor="end"
     >Windows amd64</text>
     <text x="1230" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" text-anchor="start"
-    >v0.9.8i</text>
+    >v0.9.8j</text>
     <text x="1230" y="140" transform="scale(.1)" text-anchor="start"
-    >v0.9.8i</text>
+    >v0.9.8j</text>
   </g>
 </svg>

--- a/readme.md
+++ b/readme.md
@@ -814,6 +814,33 @@ Note: `$0` will be expanded to the fully qualified current module filename when 
             <item label="  "    notes=" ...empty menu block/splitter for safety "/>
             <item label="Clear" notes=" Clear TTY viewport "                  action=TerminalOutput data="\e[2J"/>
             <item label="Reset" notes=" Clear scrollback and SGR-attributes " action=TerminalOutput data="\e[!p"/>
+            <item label="Restart" type=Command action=TerminalRestart/>
+            <item label="Top" action=TerminalViewportTop/>
+            <item label="End" action=TerminalViewportEnd/>
+
+            <item label="PgLeft"    type=Repeat action=TerminalViewportPageLeft/>
+            <item label="PgRight"   type=Repeat action=TerminalViewportPageRight/>
+            <item label="CharLeft"  type=Repeat action=TerminalViewportCharLeft/>
+            <item label="CharRight" type=Repeat action=TerminalViewportCharRight/>
+
+            <item label="PgUp"   type=Repeat action=TerminalViewportPageUp/>
+            <item label="PgDn"   type=Repeat action=TerminalViewportPageDown/>
+            <item label="LineUp" type=Repeat action=TerminalViewportLineUp/>
+            <item label="LineDn" type=Repeat action=TerminalViewportLineDown/>
+
+            <item label="PrnScr" action=TerminalViewportCopy/>
+            <item label="Deselect" action=TerminalSelectionClear/>
+            
+            <item label="Line" type=Option action=TerminalSelectionRect data="false">
+                <label="Rect" data="true"/>
+            </item>
+            <item label="Copy" type=Repeat action=TerminalSelectionCopy/>
+            <item label="Paste" type=Repeat action=TerminalPaste/>
+            <item label="Undo" type=Command action=TerminalUndo/>
+            <item label="Redo" type=Command action=TerminalRedo/>
+            <item label="Quit" type=Command action=TerminalQuit/>
+            <item label="Maximize" type=Command action=TerminalMaximize/>
+
             <item label="Hello, World!" notes=" Simulating keypresses "       action=TerminalSendKey data="Hello World!"/>
             <item label="Push Me" notes=" test " type=Repeat action=TerminalOutput data="pressed ">
                 <label="\e[37mPush Me\e[m"/>

--- a/readme.md
+++ b/readme.md
@@ -680,6 +680,10 @@ Note: The following configuration sections are not implemented yet
             <item label="  "    notes=" ...empty menu block/splitter for safety "/>
             <item label="Clear" notes=" Clear TTY viewport "                  action=TerminalOutput data="\e[2J"/>
             <item label="Reset" notes=" Clear scrollback and SGR-attributes " action=TerminalOutput data="\e[!p"/>
+            <item label="Top" action=TerminalViewportTop/> <!-- See Term app description below for details (readme.md). -->
+            <item label="End" action=TerminalViewportEnd/>
+            <item label="PgUp" type=Repeat action=TerminalViewportPageUp/>
+            <item label="PgDn" type=Repeat action=TerminalViewportPageDown/>
             <item label="Hello, World!" notes=" Simulating keypresses "       action=TerminalSendKey data="Hello World!"/>
         </menu>
         <selection>

--- a/readme.md
+++ b/readme.md
@@ -46,8 +46,8 @@ Build-time dependencies
  - `cmake` (https://github.com/netxs-group/vtm/issues/172#issuecomment-1340519942)
  - C++20 compiler
  - Minimal requirements to compile
-   - Using [`GCC`](https://gcc.gnu.org/projects/cxx-status.html) — `3GB` of RAM
-   - Using [`Clang`](https://clang.llvm.org/cxx_status.html) — `8GB` of RAM
+   - Using [`GCC`](https://gcc.gnu.org/projects/cxx-status.html) — `4GB` of RAM
+   - Using [`Clang`](https://clang.llvm.org/cxx_status.html) — `9GB` of RAM
 
 ```bash
 git clone https://github.com/netxs-group/vtm.git && cd ./vtm

--- a/readme.md
+++ b/readme.md
@@ -870,6 +870,11 @@ Note: `$0` will be expanded to the fully qualified current module filename when 
        TerminalMaximize             | Maximize/Restore built-in terminal window.
        TerminalUndo                 | (Win32 Cooked/ENABLE_LINE_INPUT mode only) Discard the last input.
        TerminalRedo                 | (Win32 Cooked/ENABLE_LINE_INPUT mode only) Discard the last Undo command.
+       TerminalPaste                | Paste from clipboard.
+       TerminalSelectionCopy        | Сopy selection to clipboard.
+       TerminalSelectionRect        | Set linear(false) or rectangular(true) selection form using boolean value.
+       TerminalSelectionClear       | Deselect a selection.
+       TerminalViewportCopy         | Сopy viewport to clipboard.
        *TerminalViewportPageUp      | Scroll one page up.
        *TerminalViewportPageDown    | Scroll one page down.
        *TerminalViewportLineUp      | Scroll N lines up.
@@ -880,8 +885,6 @@ Note: `$0` will be expanded to the fully qualified current module filename when 
        *TerminalViewportColumnRight | Scroll N cells to the right.
        *TerminalViewportTop         | Scroll to the scrollback top.
        *TerminalViewportEnd         | Scroll to the scrollback bottom (reset viewport position).
-       *TerminalViewportCopy        | Сopy viewport to clipboard.
-       *TerminalSelectionCopy       | Сopy selection to clipboard.
        *TerminalLogStart            | Start logging to file.
        *TerminalLogPause            | Pause logging.
        *TerminalLogStop             | Stop logging.

--- a/readme.md
+++ b/readme.md
@@ -875,7 +875,6 @@ Note: `$0` will be expanded to the fully qualified current module filename when 
        *TerminalViewportTop         | Scroll to the scrollback top.
        *TerminalViewportEnd         | Scroll to the scrollback bottom (reset viewport position).
        *TerminalViewportCopy        | Сopy viewport to clipboard.
-       *ClipboardWipe               | Clear clipboard.
        *TerminalSelectionCopy       | Сopy selection to clipboard.
        *TerminalLogStart            | Start logging to file.
        *TerminalLogPause            | Pause logging.

--- a/readme.md
+++ b/readme.md
@@ -865,9 +865,11 @@ Note: `$0` will be expanded to the fully qualified current module filename when 
        TerminalFindPrev             | Highlight previous match of selected text fragment. Clipboard content is used if no active selection.
        TerminalOutput               | Direct output the `data=` value to the terminal scrollback.
        TerminalSendKey              | Simulating keypresses using the `data=` string.
-       *TerminalQuit                | Kill all runnning console apps and quit the built-in terminal.
-       *TerminalRestart             | Kill all runnning console apps and restart current session.
-       *TerminalMaximize            | Maximize/Restore built-in terminal window.
+       TerminalQuit                 | Kill all runnning console apps and quit the built-in terminal.
+       TerminalRestart              | Kill all runnning console apps and restart current session.
+       TerminalMaximize             | Maximize/Restore built-in terminal window.
+       TerminalUndo                 | (Win32 Cooked/ENABLE_LINE_INPUT mode only) Discard the last input.
+       TerminalRedo                 | (Win32 Cooked/ENABLE_LINE_INPUT mode only) Discard the last Undo command.
        *TerminalViewportPageUp      | Scroll one page up.
        *TerminalViewportPageDown    | Scroll one page down.
        *TerminalViewportLineUp      | Scroll N lines up.

--- a/readme.md
+++ b/readme.md
@@ -875,16 +875,16 @@ Note: `$0` will be expanded to the fully qualified current module filename when 
        TerminalSelectionRect        | Set linear(false) or rectangular(true) selection form using boolean value.
        TerminalSelectionClear       | Deselect a selection.
        TerminalViewportCopy         | Сopy viewport to clipboard.
-       *TerminalViewportPageUp      | Scroll one page up.
-       *TerminalViewportPageDown    | Scroll one page down.
-       *TerminalViewportLineUp      | Scroll N lines up.
-       *TerminalViewportLineDown    | Scroll N lines down.
-       *TerminalViewportPageLeft    | Scroll one page to the left.
-       *TerminalViewportPageRight   | Scroll one page to the right.
-       *TerminalViewportColumnLeft  | Scroll N cells to the left.
-       *TerminalViewportColumnRight | Scroll N cells to the right.
-       *TerminalViewportTop         | Scroll to the scrollback top.
-       *TerminalViewportEnd         | Scroll to the scrollback bottom (reset viewport position).
+       TerminalViewportPageUp       | Scroll one page up.
+       TerminalViewportPageDown     | Scroll one page down.
+       TerminalViewportLineUp       | Scroll N lines up.
+       TerminalViewportLineDown     | Scroll N lines down.
+       TerminalViewportPageLeft     | Scroll one page to the left.
+       TerminalViewportPageRight    | Scroll one page to the right.
+       TerminalViewportColumnLeft   | Scroll N cells to the left.
+       TerminalViewportColumnRight  | Scroll N cells to the right.
+       TerminalViewportTop          | Scroll to the scrollback top.
+       TerminalViewportEnd          | Scroll to the scrollback bottom (reset viewport position).
        *TerminalLogStart            | Start logging to file.
        *TerminalLogPause            | Pause logging.
        *TerminalLogStop             | Stop logging.

--- a/readme.md
+++ b/readme.md
@@ -815,6 +815,9 @@ Note: `$0` will be expanded to the fully qualified current module filename when 
             <item label="Clear" notes=" Clear TTY viewport "                  action=TerminalOutput data="\e[2J"/>
             <item label="Reset" notes=" Clear scrollback and SGR-attributes " action=TerminalOutput data="\e[!p"/>
             <item label="Hello, World!" notes=" Simulating keypresses "       action=TerminalSendKey data="Hello World!"/>
+            <item label="Push Me" notes=" test " type=Repeat action=TerminalOutput data="pressed ">
+                <label="\e[37mPush Me\e[m"/>
+            </item>
         </menu>
        </term>
       </config>
@@ -847,6 +850,7 @@ Note: `$0` will be expanded to the fully qualified current module filename when 
       ----------|------------
        Option   | Cyclically selects the next label in the list and exec the function specified by the `action=` with `data=` as its parameter.
        Command  | Exec the function specified by the `action=` with `data=` as its parameter.
+       Repeat   | Selects the next label and exec the function specified by the `action=` with `data=` as its parameter repeatedly from the time it is pressed until it is released.
 
       ### Attribute `action=`
 

--- a/src/netxs/apps.hpp
+++ b/src/netxs/apps.hpp
@@ -266,6 +266,7 @@ R"==(
         </menu>
         <selection>
             <mode="text"/> <!-- text | ansi | rich | html | protected | none -->
+            <rect=faux/>  <!-- Preferred selection form: Rectangular: true, Linear false. -->
         </selection>
         <atexit = auto/>  <!-- auto:    Stay open and ask if exit code != 0. (default)
                                ask:     Stay open and ask.
@@ -1382,9 +1383,13 @@ namespace netxs::app::shared
                                                      if (deed == e2::form::prop::colors::bg.id) boss.SIGNAL(tier::anycast, app::term::events::preview::colors::bg, clr);
                                                 else if (deed == e2::form::prop::colors::fg.id) boss.SIGNAL(tier::anycast, app::term::events::preview::colors::fg, clr);
                                             };
-                                            boss.SUBMIT(tier::anycast, app::term::events::preview::selmod, selmod)
+                                            boss.SUBMIT(tier::anycast, app::term::events::preview::selection::mode, selmod)
                                             {
                                                 boss.set_selmod(selmod);
+                                            };
+                                            boss.SUBMIT(tier::anycast, app::term::events::preview::selection::box, selalt)
+                                            {
+                                                boss.set_selalt(selalt);
                                             };
                                             boss.SUBMIT(tier::anycast, app::term::events::preview::wrapln, wrapln)
                                             {
@@ -1405,6 +1410,10 @@ namespace netxs::app::shared
                                             boss.SUBMIT(tier::anycast, app::term::events::search::reverse, gear)
                                             {
                                                 boss.search(gear, feed::rev);
+                                            };
+                                            boss.SUBMIT(tier::anycast, app::term::events::data::prnscrn, gear)
+                                            {
+                                                boss.prnscrn(gear);
                                             };
                                       });
                 layers->attach(app::shared::scroll_bars(scroll));

--- a/src/netxs/apps.hpp
+++ b/src/netxs/apps.hpp
@@ -328,6 +328,7 @@ R"==(
             static const auto Command  = "Command"s;
             static const auto Splitter = "Splitter"s;
             static const auto Option   = "Option"s;
+            static const auto Repeat   = "Repeat"s;
         }
 
         struct item
@@ -337,6 +338,7 @@ R"==(
                 Splitter,
                 Command,
                 Option,
+                Repeat,
             };
             struct look
             {

--- a/src/netxs/apps/calc.cpp
+++ b/src/netxs/apps/calc.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) NetXS Group.
 // Licensed under the MIT license.
 
-#define DESKTOPIO_VER "v0.9.8i"
+#define DESKTOPIO_VER "v0.9.8j"
 #define DESKTOPIO_MYNAME "Desktopio Calc " DESKTOPIO_VER
 #define DESKTOPIO_MYPATH "vtm/calc"
 #define DESKTOPIO_DEFAPP "Calc"

--- a/src/netxs/apps/term.cpp
+++ b/src/netxs/apps/term.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) NetXS Group.
 // Licensed under the MIT license.
 
-#define DESKTOPIO_VER "v0.9.8i"
+#define DESKTOPIO_VER "v0.9.8j"
 #define DESKTOPIO_MYNAME "Desktopio Terminal " DESKTOPIO_VER
 #define DESKTOPIO_MYPATH "vtm/term"
 #define DESKTOPIO_DEFAPP "Term"

--- a/src/netxs/apps/term.hpp
+++ b/src/netxs/apps/term.hpp
@@ -402,43 +402,95 @@ namespace netxs::app::term
             }
             static void TerminalViewportPageUp(ui::pads& boss, menu::item& item)
             {
-
+                _submit<true>(boss, item, [](auto& boss, auto& item, auto& gear)
+                {
+                    auto info = e2::form::upon::scroll::bypage::y.param();
+                    info.vector = 1;
+                    boss.SIGNAL(tier::anycast, e2::form::upon::scroll::bypage::y, info);
+                });
             }
             static void TerminalViewportPageDown(ui::pads& boss, menu::item& item)
             {
-
+                _submit<true>(boss, item, [](auto& boss, auto& item, auto& gear)
+                {
+                    auto info = e2::form::upon::scroll::bypage::y.param();
+                    info.vector = -1;
+                    boss.SIGNAL(tier::anycast, e2::form::upon::scroll::bypage::y, info);
+                });
             }
             static void TerminalViewportLineUp(ui::pads& boss, menu::item& item)
             {
-
+                item.reindex([](auto& utf8){ auto v = xml::take<si32>(utf8); return v ? v.value() : 1; });
+                _submit<true>(boss, item, [](auto& boss, auto& item, auto& gear)
+                {
+                    auto info = e2::form::upon::scroll::bystep::y.param();
+                    info.vector = std::abs(item.views[item.taken].value);
+                    boss.SIGNAL(tier::anycast, e2::form::upon::scroll::bystep::y, info);
+                });
             }
             static void TerminalViewportLineDown(ui::pads& boss, menu::item& item)
             {
-
-            }
-            static void TerminalViewportPageLeft(ui::pads& boss, menu::item& item)
-            {
-
-            }
-            static void TerminalViewportPageRight(ui::pads& boss, menu::item& item)
-            {
-
-            }
-            static void TerminalViewportCharLeft(ui::pads& boss, menu::item& item)
-            {
-
-            }
-            static void TerminalViewportCharRight(ui::pads& boss, menu::item& item)
-            {
-
+                item.reindex([](auto& utf8){ auto v = xml::take<si32>(utf8); return v ? v.value() : 1; });
+                _submit<true>(boss, item, [](auto& boss, auto& item, auto& gear)
+                {
+                    auto info = e2::form::upon::scroll::bystep::y.param();
+                    info.vector = -std::abs(item.views[item.taken].value);
+                    boss.SIGNAL(tier::anycast, e2::form::upon::scroll::bystep::y, info);
+                });
             }
             static void TerminalViewportTop(ui::pads& boss, menu::item& item)
             {
-
+                _submit<true>(boss, item, [](auto& boss, auto& item, auto& gear)
+                {
+                    auto info = e2::form::upon::scroll::to_top::y.param();
+                    boss.SIGNAL(tier::anycast, e2::form::upon::scroll::to_top::y, info);
+                });
             }
             static void TerminalViewportEnd(ui::pads& boss, menu::item& item)
             {
-
+                _submit<true>(boss, item, [](auto& boss, auto& item, auto& gear)
+                {
+                    auto info = e2::form::upon::scroll::to_end::y.param();
+                    boss.SIGNAL(tier::anycast, e2::form::upon::scroll::to_end::y, info);
+                });
+            }
+            static void TerminalViewportPageLeft(ui::pads& boss, menu::item& item)
+            {
+                _submit<true>(boss, item, [](auto& boss, auto& item, auto& gear)
+                {
+                    auto info = e2::form::upon::scroll::bypage::x.param();
+                    info.vector = 1;
+                    boss.SIGNAL(tier::anycast, e2::form::upon::scroll::bypage::x, info);
+                });
+            }
+            static void TerminalViewportPageRight(ui::pads& boss, menu::item& item)
+            {
+                _submit<true>(boss, item, [](auto& boss, auto& item, auto& gear)
+                {
+                    auto info = e2::form::upon::scroll::bypage::x.param();
+                    info.vector = -1;
+                    boss.SIGNAL(tier::anycast, e2::form::upon::scroll::bypage::x, info);
+                });
+            }
+            static void TerminalViewportCharLeft(ui::pads& boss, menu::item& item)
+            {
+                item.reindex([](auto& utf8){ auto v = xml::take<si32>(utf8); return v ? v.value() : 1; });
+                _submit<true>(boss, item, [](auto& boss, auto& item, auto& gear)
+                {
+                    auto info = e2::form::upon::scroll::bystep::x.param();
+                    info.vector = std::abs(item.views[item.taken].value);
+                    boss.SIGNAL(tier::anycast, e2::form::upon::scroll::bystep::x, info);
+                });
+            }
+            static void TerminalViewportCharRight(ui::pads& boss, menu::item& item)
+            {
+                item.reindex([](auto& utf8){ auto v = xml::take<si32>(utf8); return v ? v.value() : 1; });
+                _submit<true>(boss, item, [](auto& boss, auto& item, auto& gear)
+                {
+                    auto info = e2::form::upon::scroll::bystep::x.param();
+                    info.vector = -std::abs(item.views[item.taken].value);
+                    boss.SIGNAL(tier::anycast, e2::form::upon::scroll::bystep::x, info);
+                });
             }
             static void TerminalLogStart(ui::pads& boss, menu::item& item)
             {
@@ -725,6 +777,14 @@ namespace netxs::app::term
                     boss.SUBMIT(tier::anycast, app::term::events::data::prnscrn, gear)
                     {
                         boss.prnscrn(gear);
+                    };
+                    boss.SUBMIT(tier::anycast, e2::form::upon::scroll::any, i)
+                    {
+                        auto info = e2::form::upon::scroll::bypage::y.param();
+                        auto deed = boss.bell::protos<tier::anycast>();
+                        boss.base::template raw_riseup<tier::request>(e2::form::upon::scroll::any.id, info);
+                        info.vector = i.vector;
+                        boss.base::template raw_riseup<tier::preview>(deed, info);
                     };
                 });
             return window;

--- a/src/netxs/apps/term.hpp
+++ b/src/netxs/apps/term.hpp
@@ -781,7 +781,7 @@ namespace netxs::app::term
                     boss.SUBMIT(tier::anycast, e2::form::upon::scroll::any, i)
                     {
                         auto info = e2::form::upon::scroll::bypage::y.param();
-                        auto deed = boss.bell::protos<tier::anycast>();
+                        auto deed = boss.bell::template protos<tier::anycast>();
                         boss.base::template raw_riseup<tier::request>(e2::form::upon::scroll::any.id, info);
                         info.vector = i.vector;
                         boss.base::template raw_riseup<tier::preview>(deed, info);

--- a/src/netxs/apps/term.hpp
+++ b/src/netxs/apps/term.hpp
@@ -48,8 +48,9 @@ namespace netxs::events::userland
             };
             SUBSET_XS( data )
             {
-                EVENT_XS( in , view ),
-                EVENT_XS( out, view ),
+                EVENT_XS( in   , view        ),
+                EVENT_XS( out  , view        ),
+                EVENT_XS( paste, input::hids ),
             };
             SUBSET_XS( search )
             {
@@ -333,17 +334,26 @@ namespace netxs::app::term
                     boss.SIGNAL(tier::anycast, app::term::events::cmd, ui::term::commands::ui::commands::restart);
                 });
             }
-            static void TerminalPaste(ui::pads& boss, menu::item& item)
-            {
-
-            }
             static void TerminalUndo(ui::pads& boss, menu::item& item)
             {
-
+                _submit<true>(boss, item, [](auto& boss, auto& item, auto& gear)
+                {
+                    boss.SIGNAL(tier::anycast, app::term::events::cmd, ui::term::commands::ui::commands::undo);
+                });
             }
             static void TerminalRedo(ui::pads& boss, menu::item& item)
             {
-
+                _submit<true>(boss, item, [](auto& boss, auto& item, auto& gear)
+                {
+                    boss.SIGNAL(tier::anycast, app::term::events::cmd, ui::term::commands::ui::commands::redo);
+                });
+            }
+            static void TerminalPaste(ui::pads& boss, menu::item& item)
+            {
+                _submit<true>(boss, item, [](auto& boss, auto& item, auto& gear)
+                {
+                    boss.SIGNAL(tier::anycast, app::term::events::data::paste, gear);
+                });
             }
             static void TerminalSelectionType(ui::pads& boss, menu::item& item)
             {
@@ -669,6 +679,10 @@ namespace netxs::app::term
                     boss.SUBMIT(tier::anycast, app::term::events::search::reverse, gear)
                     {
                         boss.search(gear, feed::rev);
+                    };
+                    boss.SUBMIT(tier::anycast, app::term::events::data::paste, gear)
+                    {
+                        boss.paste(gear);
                     };
                 });
             return window;

--- a/src/netxs/apps/term.hpp
+++ b/src/netxs/apps/term.hpp
@@ -190,14 +190,14 @@ namespace netxs::app::term
                 };
                 boss.SUBMIT(tier::release, hids::events::mouse::button::up::left, gear)
                 {
+                    tick.pacify();
+                    gear.setfree();
+                    gear.dismiss(true);
                     if (item.views.size() && item.taken)
                     {
                         item.taken = 0;
                         _update(boss, item);
                     }
-                    gear.setfree();
-                    gear.dismiss(true);
-                    tick.pacify();
                 };
                 boss.SUBMIT(tier::release, e2::form::state::mouse, active)
                 {
@@ -306,15 +306,27 @@ namespace netxs::app::term
             }
             static void TerminalQuit(ui::pads& boss, menu::item& item)
             {
-
+                _submit(boss, item, [](auto& boss, auto& item, auto& gear)
+                {
+                    boss.base::template riseup<tier::release>(e2::form::quit, boss.This());
+                    if (item.brand == menu::item::Option) _update(boss, item);
+                });
             }
             static void TerminalMaximize(ui::pads& boss, menu::item& item)
             {
-
+                _submit(boss, item, [](auto& boss, auto& item, auto& gear)
+                {
+                    boss.base::template riseup<tier::release>(e2::form::maximize, gear);
+                    if (item.brand == menu::item::Option) _update(boss, item);
+                });
             }
             static void TerminalRestart(ui::pads& boss, menu::item& item)
             {
-
+                _submit(boss, item, [](auto& boss, auto& item, auto& gear)
+                {
+                    boss.SIGNAL(tier::anycast, app::term::events::cmd, ui::term::commands::ui::commands::restart);
+                    if (item.brand == menu::item::Option) _update(boss, item);
+                });
             }
             static void TerminalPaste(ui::pads& boss, menu::item& item)
             {

--- a/src/netxs/apps/term.hpp
+++ b/src/netxs/apps/term.hpp
@@ -85,12 +85,13 @@ namespace netxs::app::term
 
         #define PROC_LIST \
             X(Noop                      ) /* */ \
-            X(ClipboardWipe             ) /* */ \
             X(TerminalQuit              ) /* */ \
             X(TerminalMaximize          ) /* */ \
             X(TerminalRestart           ) /* */ \
             X(TerminalSendKey           ) /* */ \
             X(TerminalPaste             ) /* */ \
+            X(TerminalUndo              ) /* Undo/Redo for cooked read under win32 */ \
+            X(TerminalRedo              ) /* */ \
             X(TerminalSelectionMode     ) /* */ \
             X(TerminalSelectionType     ) /* Linear/Boxed*/ \
             X(TerminalSelectionClear    ) /* */ \
@@ -250,10 +251,6 @@ namespace netxs::app::term
                     if (item.brand == menu::item::Option) _update_ui(boss, item);
                 });
             }
-            static void ClipboardWipe(ui::pads& boss, menu::item& item)
-            {
-
-            }
             static void TerminalQuit(ui::pads& boss, menu::item& item)
             {
 
@@ -267,6 +264,14 @@ namespace netxs::app::term
 
             }
             static void TerminalPaste(ui::pads& boss, menu::item& item)
+            {
+
+            }
+            static void TerminalUndo(ui::pads& boss, menu::item& item)
+            {
+
+            }
+            static void TerminalRedo(ui::pads& boss, menu::item& item)
             {
 
             }

--- a/src/netxs/console/ansi.hpp
+++ b/src/netxs/console/ansi.hpp
@@ -647,7 +647,7 @@ namespace netxs::ansi
                 netxs::onrect(canvas, region, allfx, eolfx);
                 if constexpr (FINALISE)
                 {
-                    block.pop_back(); // Pop last eol (lf).
+                    if (block.size()) block.pop_back(); // Pop last eol (lf).
                     if constexpr (USESGR) basevt::nil();
                 }
             }

--- a/src/netxs/console/terminal.hpp
+++ b/src/netxs/console/terminal.hpp
@@ -13,6 +13,7 @@ namespace netxs::events::userland
         EVENTPACK( uiterm, netxs::events::userland::root::custom )
         {
             EVENT_XS( selmod, si32 ),
+            EVENT_XS( selalt, si32 ),
             GROUP_XS( colors, rgba ),
             GROUP_XS( layout, si32 ),
             GROUP_XS( search, input::hids ),
@@ -82,6 +83,7 @@ namespace netxs::ui
                     restart,
                     undo,
                     redo,
+                    deselect,
                     look_fwd,
                     look_rev,
                 };
@@ -137,9 +139,10 @@ namespace netxs::ui
             si32 def_lucent;
             si32 def_margin;
             si32 def_atexit;
-            mime def_selmod;
             rgba def_fcolor;
             rgba def_bcolor;
+            mime def_selmod;
+            bool def_selalt;
             bool def_cursor;
             bool def_cur_on;
             bool resetonkey;
@@ -188,6 +191,7 @@ namespace netxs::ui
                 def_lucent = std::max(0, config.take("fields/lucent",        si32{ 0xC0 } ));
                 def_margin = std::max(0, config.take("fields/size",          si32{ 0 }    ));
                 def_selmod =             config.take("selection/mode",       clip::textonly, xml::options::selmod);
+                def_selalt =             config.take("selection/rect",       faux);
                 def_cur_on =             config.take("cursor/show",          true);
                 def_cursor =             config.take("cursor/style",         true, xml::options::cursor);
                 def_period =             config.take("cursor/blink",         time{ BLINK_PERIOD });
@@ -6111,6 +6115,7 @@ namespace netxs::ui
         bool       onlogs; // term: Avoid logs if no subscriptions.
         bool       unsync; // term: Viewport is out of sync.
         bool       invert; // term: Inverted rendering (DECSCNM).
+        bool       selalt; // term: Selection form (rectangular/linear).
         si32       selmod; // term: Selection mode (ansi::clip::mime).
         vtty       ptycon; // term: PTY device. Should be destroyed first.
 
@@ -6535,13 +6540,25 @@ namespace netxs::ui
                 ondata("");             // Recalc trigger.
             }
         }
+        // term: Set selection form.
+        void selection_selalt(bool boxed)
+        {
+            selalt = boxed;
+            SIGNAL(tier::release, e2::form::draggable::left, selection_passed());
+            SIGNAL(tier::release, ui::term::events::selalt, selalt);
+            if (mtrack && selmod == clip::disabled)
+            {
+                follow[axis::Y] = true; // Reset viewport.
+                ondata("");             // Recalc trigger.
+            }
+        }
         // term: Set the next selection mode.
         void selection_selmod()
         {
             auto newmod = (selmod + 1) % clip::count;
             selection_selmod(newmod);
         }
-        auto selection_cancel(hids& gear)
+        auto selection_cancel()
         {
             auto active = target->selection_cancel();
             if (active)
@@ -6600,34 +6617,57 @@ namespace netxs::ui
             }
             return faux;
         }
+        auto _copy(hids& gear, text const& data)
+        {
+            auto mimetype = selmod == clip::mime::disabled ? clip::mime::textonly
+                                                           : static_cast<clip::mime>(selmod);
+            //todo unify (hids)
+            auto state = gear.state();
+            gear.combine_focus = true; // Preserve all selected panes.
+            gear.offer_kb_focus(this->This());
+            gear.set_clip_data(clip{ target->panel, data, mimetype });
+            gear.state(state);
+        }
+        auto copy(hids& gear)
+        {
+            auto data = target->selection_pickup(selmod);
+            if (data.size())
+            {
+                _copy(gear, data);
+            }
+            if (gear.meta(hids::anyCtrl) || selection_cancel()) // Keep selection if Ctrl is pressed.
+            {
+                base::expire<tier::release>();
+                return true;
+            }
+            return faux;
+        }
+        auto prnscrn(hids& gear)
+        {
+            auto selbox = true;
+            auto square = target->panel;
+            auto seltop = dot_00;
+            auto selend = square - dot_11;
+            auto buffer = ansi::esc{};
+            auto canvas = e2::render::any.param();
+            canvas.size(square);
+            canvas.full({ origin, square });
+            SIGNAL(tier::release, e2::render::any, canvas);
+            target->bufferbase::selection_pickup(buffer, canvas, seltop, selend, selmod, selbox);
+            if (buffer.size()) buffer.eol();
+            _copy(gear, buffer);
+        }
+        auto selection_active()
+        {
+            return target->selection_active();
+        }
         void selection_pickup(hids& gear)
         {
             auto gear_test = e2::form::state::keybd::find.param(gear.id, 0);
             SIGNAL(tier::anycast, e2::form::state::keybd::find, gear_test);
             if (!gear_test.second) return; // Right clicks are only allowed on the focused terminal.
-
-            auto& console = *target;
-            if (console.selection_active())
-            {
-                auto data = console.selection_pickup(selmod);
-                if (data.size())
-                {
-                    auto mimetype = selmod == clip::mime::disabled ? clip::mime::textonly
-                                                                   : static_cast<clip::mime>(selmod);
-                    //todo unify (hids)
-                    auto state = gear.state();
-                    gear.combine_focus = true; // Preserve all selected panes.
-                    gear.offer_kb_focus(this->This());
-                    gear.set_clip_data(clip{ target->panel, data, mimetype });
-                    gear.state(state);
-                }
-                if (gear.meta(hids::anyCtrl) || selection_cancel(gear)) // Keep selection if Ctrl is pressed.
-                {
-                    base::expire<tier::release>();
-                    gear.dismiss();
-                }
-            }
-            else if (selection_passed() && paste(gear)) // Paste from clipboard.
+            if ((selection_active() && copy(gear))
+             || (selection_passed() && paste(gear)))
             {
                 gear.dismiss();
             }
@@ -6663,7 +6703,7 @@ namespace netxs::ui
                 gear.dismiss();
                 base::expire<tier::release>();
             }
-            else selection_cancel(gear);
+            else selection_cancel();
         }
         void selection_dblclk(hids& gear)
         {
@@ -6682,7 +6722,7 @@ namespace netxs::ui
         void selection_create(hids& gear)
         {
             auto& console = *target;
-            auto boxed = gear.meta(hids::anyAlt);
+            auto boxed = selalt ^ !!gear.meta(hids::anyAlt);
             auto go_on = gear.meta(hids::anyCtrl);
             console.selection_follow(gear.coord, go_on);
             if (go_on) console.selection_extend(gear.coord, boxed);
@@ -6710,7 +6750,7 @@ namespace netxs::ui
         {
             // Check bounds and scroll if needed.
             auto& console = *target;
-            auto boxed = gear.meta(hids::anyAlt);
+            auto boxed = selalt ^ !!gear.meta(hids::anyAlt);
             auto coord = gear.coord;
             auto vport = rect{ -origin, console.panel };
             auto delta = dot_00;
@@ -6765,7 +6805,7 @@ namespace netxs::ui
             SUBMIT(tier::release, e2::form::drag::start                ::left,  gear) { if (selection_passed()) selection_create(gear); };
             SUBMIT(tier::release, e2::form::drag::pull                 ::left,  gear) { if (selection_passed()) selection_extend(gear); };
             SUBMIT(tier::release, e2::form::drag::stop                 ::left,  gear) {                         selection_finish(gear); };
-            SUBMIT(tier::release, e2::form::drag::cancel               ::left,  gear) {                         selection_cancel(gear); };
+            SUBMIT(tier::release, e2::form::drag::cancel               ::left,  gear) {                         selection_cancel();     };
             SUBMIT(tier::release, hids::events::mouse::button::click   ::right, gear) {                         selection_pickup(gear); };
             SUBMIT(tier::release, hids::events::mouse::button::click   ::left,  gear) {                         selection_lclick(gear); };
             SUBMIT(tier::release, hids::events::mouse::button::click   ::middle,gear) {                         selection_mclick(gear); };
@@ -6869,6 +6909,12 @@ namespace netxs::ui
             if (faux == target->selection_active()) follow[axis::Y] = true; // Reset viewport.
             ondata(""); // Recalc trigger.
         }
+        void set_selalt(bool boxed)
+        {
+            selection_selalt(boxed);
+            if (faux == target->selection_active()) follow[axis::Y] = true; // Reset viewport.
+            ondata(""); // Recalc trigger.
+        }
         void exec_cmd(commands::ui::commands cmd)
         {
             log("term: tier::preview, ui::commands, ", cmd);
@@ -6883,6 +6929,7 @@ namespace netxs::ui
                     case commands::ui::restart:   restart(); break;
                     case commands::ui::undo:      ptycon.undo(true); break;
                     case commands::ui::redo:      ptycon.undo(faux); break;
+                    case commands::ui::deselect:  selection_cancel(); break;
                     case commands::ui::look_fwd:  console.selection_search(feed::fwd); break;
                     case commands::ui::look_rev:  console.selection_search(feed::rev); break;
                     default: break;
@@ -6897,6 +6944,7 @@ namespace netxs::ui
                     case commands::ui::restart:   restart(); break;
                     case commands::ui::undo:      ptycon.undo(true); break;
                     case commands::ui::redo:      ptycon.undo(faux); break;
+                    case commands::ui::deselect:  selection_cancel(); break;
                     case commands::ui::look_fwd:  console.selection_search(feed::fwd); break;
                     case commands::ui::look_rev:  console.selection_search(feed::rev); break;
                     default: break;
@@ -6974,12 +7022,14 @@ namespace netxs::ui
               invert{  faux },
               curdir{ cwd   },
               cmdarg{ cmd   },
-              selmod{ config.def_selmod }
+              selmod{ config.def_selmod },
+              selalt{ config.def_selalt }
         {
             linux_console = os::local_mode();
             form::keybd.accept(true); // Subscribe on keybd offers.
             selection_submit();
             publish_property(ui::term::events::selmod,         [&](auto& v){ v = selmod; });
+            publish_property(ui::term::events::selalt,         [&](auto& v){ v = selalt; });
             publish_property(ui::term::events::colors::bg,     [&](auto& v){ v = target->brush.bgc(); });
             publish_property(ui::term::events::colors::fg,     [&](auto& v){ v = target->brush.fgc(); });
             publish_property(ui::term::events::layout::wrapln, [&](auto& v){ v = (si32)target->style.wrp(); });

--- a/src/netxs/console/terminal.hpp
+++ b/src/netxs/console/terminal.hpp
@@ -6845,7 +6845,6 @@ namespace netxs::ui
                 selection_moveto(delta);
             }
         }
-
         void search(hids& gear, feed dir)
         {
             selection_search(gear, dir);

--- a/src/netxs/console/terminal.hpp
+++ b/src/netxs/console/terminal.hpp
@@ -79,8 +79,7 @@ namespace netxs::ui
                     center,
                     togglewrp,
                     togglesel,
-                    reset,
-                    clear,
+                    restart,
                     look_fwd,
                     look_rev,
                 };
@@ -6871,12 +6870,11 @@ namespace netxs::ui
             {
                 switch (cmd)
                 {
-                    case commands::ui::togglewrp: console.selection_setwrp();                     break;
-                    case commands::ui::togglesel: selection_selmod();                             break;
-                    case commands::ui::reset:     decstr();                                       break;
-                    case commands::ui::clear:     console.ed(commands::erase::display::viewport); break;
-                    case commands::ui::look_fwd:  console.selection_search(feed::fwd);            break;
-                    case commands::ui::look_rev:  console.selection_search(feed::rev);            break;
+                    case commands::ui::togglewrp: console.selection_setwrp(); break;
+                    case commands::ui::togglesel: selection_selmod(); break;
+                    case commands::ui::restart:   restart(); break;
+                    case commands::ui::look_fwd:  console.selection_search(feed::fwd); break;
+                    case commands::ui::look_rev:  console.selection_search(feed::rev); break;
                     default: break;
                 }
             }
@@ -6885,11 +6883,10 @@ namespace netxs::ui
                 switch (cmd)
                 {
                     case commands::ui::togglewrp: console.style.wrp(console.style.wrp() == wrap::on ? wrap::off : wrap::on); break;
-                    case commands::ui::togglesel: selection_selmod();                   return; // Return without resetting the viewport.
-                    case commands::ui::reset:     decstr();                             break;
-                    case commands::ui::clear:     console.ed(commands::erase::display::viewport); break;
-                    case commands::ui::look_fwd:  console.selection_search(feed::fwd);  break;
-                    case commands::ui::look_rev:  console.selection_search(feed::rev);  break;
+                    case commands::ui::togglesel: selection_selmod(); return; // Return without resetting the viewport.
+                    case commands::ui::restart:   restart(); break;
+                    case commands::ui::look_fwd:  console.selection_search(feed::fwd); break;
+                    case commands::ui::look_rev:  console.selection_search(feed::rev); break;
                     default: break;
                 }
                 follow[axis::Y] = true; // Reset viewport.
@@ -6926,6 +6923,12 @@ namespace netxs::ui
                     }
                 };
             }
+        }
+        void restart()
+        {
+            ptycon.stop();
+            ondata("\n");
+            start();
         }
         // term: Resize terminal window.
         void window_resize(twod winsz)

--- a/src/netxs/os/consrv.hpp
+++ b/src/netxs/os/consrv.hpp
@@ -8,6 +8,13 @@
     #define log(...)
 #endif
 
+#ifndef VK_AGAIN
+    #define VK_AGAIN 65481
+#endif
+#ifndef VK_UNDO
+    #define VK_UNDO 65483
+#endif
+
 struct consrv
 {
     struct cook
@@ -834,6 +841,8 @@ struct consrv
                             case VK_RIGHT:  burn(); hist.save(line); while (n-- && line.step_fwd(contrl, hist.fallback())) { }     break;
                             case VK_F3:     burn(); hist.save(line); while (       line.step_fwd(faux,   hist.fallback())) { }     break;
                             case VK_F8:     burn();                  while (n-- && hist.find(line)) { };                           break;
+                            case VK_UNDO:   while (n--) hist.swap(line, faux); break;
+                            case VK_AGAIN:  while (n--) hist.swap(line, true); break;
                             case VK_PRIOR:  burn(); hist.pgup(line);                                                               break;
                             case VK_NEXT:   burn(); hist.pgdn(line);                                                               break;
                             case VK_F5:
@@ -867,8 +876,6 @@ struct consrv
                                     };
                                          if (stops & 1 << c)                { cook(c, 0); hist.save(line);                                }
                                     else if (c == '\r' || c == '\n')        { cook(c, 1); hist.done(line);                                }
-                                    else if (c == 'Z' - '@')                {             hist.swap(line, faux);                          }
-                                    else if (c == 'Y' - '@')                {             hist.swap(line, true);                          }
                                     else if (c == 'I' - '@' && v == VK_TAB) { burn();     hist.save(line); line.insert("        ", mode); }
                                     else if (c == 'C' - '@')
                                     {

--- a/src/netxs/os/consrv.hpp
+++ b/src/netxs/os/consrv.hpp
@@ -763,6 +763,13 @@ struct consrv
                 signal.notify_one();
             }
         }
+        void undo(bool undoredo)
+        {
+            auto lock = std::lock_guard{ locker };
+            generate({}, {}, undoredo ? VK_UNDO : VK_AGAIN);
+            ondata.reset();
+            signal.notify_one();
+        }
         template<class L>
         auto readline(L& lock, bool& cancel, bool utf16, bool EOFon, ui32 stops, memo& hist)
         {

--- a/src/netxs/os/system.hpp
+++ b/src/netxs/os/system.hpp
@@ -4249,11 +4249,7 @@ namespace netxs::os
        ~pty()
         {
             log("xpty: dtor started");
-            if (connected())
-            {
-                wait_child();
-            }
-            cleanup();
+            stop();
             log("xpty: dtor complete");
         }
 
@@ -4434,6 +4430,14 @@ namespace netxs::os
             writesyn.notify_one(); // Flush temp buffer.
 
             log("xpty: new pty created with size ", winsz);
+        }
+        void stop()
+        {
+            if (connected())
+            {
+                wait_child();
+            }
+            cleanup();
         }
         si32 wait_child()
         {

--- a/src/netxs/os/system.hpp
+++ b/src/netxs/os/system.hpp
@@ -4581,6 +4581,12 @@ namespace netxs::os
             writebuf += data;
             if (connected()) writesyn.notify_one();
         }
+        void undo(bool undoredo)
+        {
+            #if defined(_WIN32)
+                con_serv.events.undo(undoredo);
+            #endif
+        }
     };
 
     namespace direct

--- a/src/netxs/ui/controls.hpp
+++ b/src/netxs/ui/controls.hpp
@@ -1380,6 +1380,10 @@ namespace netxs::ui
                     {
                         case upon::scroll::bycoor::x.id: move<X>(scinfo.window.coor.x - info.window.coor.x); break;
                         case upon::scroll::bycoor::y.id: move<Y>(scinfo.window.coor.y - info.window.coor.y); break;
+                        case upon::scroll::to_top::x.id: move<X>(dot_mx.x); break;
+                        case upon::scroll::to_top::y.id: move<Y>(dot_mx.y); break;
+                        case upon::scroll::to_end::x.id: move<X>(-dot_mx.x); break;
+                        case upon::scroll::to_end::y.id: move<Y>(-dot_mx.y); break;
                         case upon::scroll::bystep::x.id: move<X>(info.vector); break;
                         case upon::scroll::bystep::y.id: move<Y>(info.vector); break;
                         case upon::scroll::bypage::x.id: move<X>(info.vector * scinfo.window.size.x); break;

--- a/src/vtm.cpp
+++ b/src/vtm.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) NetXS Group.
 // Licensed under the MIT license.
 
-#define DESKTOPIO_VER "v0.9.8i"
+#define DESKTOPIO_VER "v0.9.8j"
 #define DESKTOPIO_MYNAME "vtm " DESKTOPIO_VER
 #define DESKTOPIO_PREFIX "desktopio_"
 #define DESKTOPIO_MYPATH "vtm"


### PR DESCRIPTION
- Configurable menu for built-in terminal (except TerminalLog* and TerminalVideo*)
- Unmap key assignment Ctrl+Z/Y as Undo/Redo for cooked read on Windows (Ctrl+Z/Y is not a Undo/Redo anymore for Win32 Console line input), #312.

Closes #312