### PR TITLE
Code pages support on Windows

### DIFF
--- a/.resources/status/freebsd.svg
+++ b/.resources/status/freebsd.svg
@@ -18,8 +18,8 @@
     <text x="1000" y="140" transform="scale(.1)" text-anchor="end"
     >FreeBSD amd64</text>
     <text x="1230" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" text-anchor="start"
-    >v0.9.9h</text>
+    >v0.9.9i</text>
     <text x="1230" y="140" transform="scale(.1)" text-anchor="start"
-    >v0.9.9h</text>
+    >v0.9.9i</text>
   </g>
 </svg>

--- a/.resources/status/linux.svg
+++ b/.resources/status/linux.svg
@@ -18,8 +18,8 @@
     <text x="1000" y="140" transform="scale(.1)" text-anchor="end"
     >Linux amd64</text>
     <text x="1230" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" text-anchor="start"
-    >v0.9.9h</text>
+    >v0.9.9i</text>
     <text x="1230" y="140" transform="scale(.1)" text-anchor="start"
-    >v0.9.9h</text>
+    >v0.9.9i</text>
   </g>
 </svg>

--- a/.resources/status/macos.svg
+++ b/.resources/status/macos.svg
@@ -18,8 +18,8 @@
     <text x="1000" y="140" transform="scale(.1)" text-anchor="end"
     >macOS any</text>
     <text x="1230" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" text-anchor="start"
-    >v0.9.9h</text>
+    >v0.9.9i</text>
     <text x="1230" y="140" transform="scale(.1)" text-anchor="start"
-    >v0.9.9h</text>
+    >v0.9.9i</text>
   </g>
 </svg>

--- a/.resources/status/netbsd.svg
+++ b/.resources/status/netbsd.svg
@@ -18,8 +18,8 @@
     <text x="1000" y="140" transform="scale(.1)" text-anchor="end"
     >NetBSD amd64</text>
     <text x="1230" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" text-anchor="start"
-    >v0.9.9h</text>
+    >v0.9.9i</text>
     <text x="1230" y="140" transform="scale(.1)" text-anchor="start"
-    >v0.9.9h</text>
+    >v0.9.9i</text>
   </g>
 </svg>

--- a/.resources/status/openbsd.svg
+++ b/.resources/status/openbsd.svg
@@ -18,8 +18,8 @@
     <text x="1000" y="140" transform="scale(.1)" text-anchor="end"
     >OpenBSD amd64</text>
     <text x="1230" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" text-anchor="start"
-    >v0.9.9h</text>
+    >v0.9.9i</text>
     <text x="1230" y="140" transform="scale(.1)" text-anchor="start"
-    >v0.9.9h</text>
+    >v0.9.9i</text>
   </g>
 </svg>

--- a/.resources/status/windows.svg
+++ b/.resources/status/windows.svg
@@ -18,8 +18,8 @@
     <text x="1000" y="140" transform="scale(.1)" text-anchor="end"
     >Windows amd64</text>
     <text x="1230" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" text-anchor="start"
-    >v0.9.9h</text>
+    >v0.9.9i</text>
     <text x="1230" y="140" transform="scale(.1)" text-anchor="start"
-    >v0.9.9h</text>
+    >v0.9.9i</text>
   </g>
 </svg>

--- a/readme.md
+++ b/readme.md
@@ -159,7 +159,7 @@ vtm
     <td>Set default app</td>
     <td>Center app window</td>
     <td colspan="1"></td>
-    <td colspan="2">Toggle menu height</td>
+    <td colspan="2">Minimize/restore</td>
     <td colspan="1"></td>
     <td colspan="2">Center app window</td>
     <td></td>

--- a/readme.md
+++ b/readme.md
@@ -550,6 +550,7 @@ Note: The following configuration sections are not implemented yet
             <fps      = 60   />
             <bordersz = 1,1  />
             <lucidity = 0xff /> <!-- not implemented -->
+            <tracking = off  /> <!-- Mouse cursor highlighting. -->
             <brighter   fgc=purewhite bgc=purewhite alpha=60 /> <!-- Highlighter. -->
             <kb_focus   fgc=bluelt    bgc=bluelt    alpha=60 /> <!-- Keyboard focus indicator. -->
             <shadower   bgc=0xB4202020 />                       <!-- Darklighter. -->
@@ -629,10 +630,10 @@ Note: The following configuration sections are not implemented yet
         </clipboard>
         <viewport coor=0,0 />
         <mouse dblclick=500ms />
-        <tooltip timeout=500ms enabled=true fgc=pureblack bgc=purewhite />
+        <tooltips timeout=2000ms enabled=true fgc=pureblack bgc=purewhite />
         <glowfx=true />                      <!-- Show glow effect around selected item. -->
-        <debug overlay=faux toggle="🐞" />  <!-- Display console debug info. -->
-        <regions enabled=faux />             <!-- Highlight UI objects boundaries. -->
+        <debug overlay=off toggle="🐞" />  <!-- Display console debug info. -->
+        <regions enabled=0 />             <!-- Highlight UI objects boundaries. -->
     </client>
     <term>      <!-- Base configuration for the Term app. It can be partially overridden by the menu item's config subarg. -->
         <scrollback>
@@ -735,7 +736,7 @@ Note: The following configuration sections are not implemented yet
         </menu>
         <selection>
             <mode="text"/> <!-- text | ansi | rich | html | protected | none -->
-            <rect=faux/>  <!-- Preferred selection form: Rectangular: true, Linear false. -->
+            <rect=false/>  <!-- Preferred selection form: Rectangular: true, Linear false. -->
         </selection>
         <atexit = auto /> <!-- auto:    Stay open and ask if exit code != 0. (default)
                                ask:     Stay open and ask.
@@ -749,7 +750,7 @@ Note: The following configuration sections are not implemented yet
     </term>
     <defapp>
         <menu>
-            <autohide=faux />  <!--  If true, show menu only on hover. -->
+            <autohide=off />  <!--  If true, show menu only on hover. -->
             <enabled="on"/>
             <slim=true />
         </menu>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -15,13 +15,8 @@ if (CMAKE_SYSTEM_NAME STREQUAL "Windows")    # WIN32 and similar checks are soft
     set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /DWIN32 /D_WINDOWS /W3 /GR /EHsc /bigobj /utf-8")
 elseif (NOT CMAKE_SYSTEM_NAME MATCHES "Android")
     set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread")
-    if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
-        #gcc static linkage
-        #set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -static -static-libstdc++ -static-libgcc -pthread -s")
-    else ()
-        #clang static linkage
-        #set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -static -pthread -s")
-    endif ()
+    #gcc static linkage
+    set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -static -pthread -s")
 endif ()
 
 add_executable (vtm "vtm.cpp")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -16,7 +16,7 @@ if (CMAKE_SYSTEM_NAME STREQUAL "Windows")    # WIN32 and similar checks are soft
 elseif (NOT CMAKE_SYSTEM_NAME MATCHES "Android")
     set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread")
     #gcc static linkage
-    set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -static -pthread -s")
+    #set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -static -pthread -s")
 endif ()
 
 add_executable (vtm "vtm.cpp")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -17,7 +17,7 @@ elseif (NOT CMAKE_SYSTEM_NAME MATCHES "Android")
     set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread")
     if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
         #gcc static linkage
-        #set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -static-libstdc++ -static-libgcc -pthread -s")
+        #set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -static -static-libstdc++ -static-libgcc -pthread -s")
     else ()
         #clang static linkage
         #set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -static -pthread -s")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -15,7 +15,7 @@ if (CMAKE_SYSTEM_NAME STREQUAL "Windows")    # WIN32 and similar checks are soft
     set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /DWIN32 /D_WINDOWS /W3 /GR /EHsc /bigobj /utf-8")
 elseif (NOT CMAKE_SYSTEM_NAME MATCHES "Android")
     set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -pthread")
-    #gcc static linkage
+    # Static linkage
     #set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -static -pthread -s")
 endif ()
 

--- a/src/CMakeSettings.json
+++ b/src/CMakeSettings.json
@@ -79,7 +79,7 @@
         },
         {
           "name": "CMAKE_EXE_LINKER_FLAGS_RELEASE",
-          "value": "-static-libstdc++",
+          "value": "-static-libstdc++ -static-libgcc -static",
           "type": "STRING"
         },
         {

--- a/src/CMakeSettings.json
+++ b/src/CMakeSettings.json
@@ -79,7 +79,7 @@
         },
         {
           "name": "CMAKE_EXE_LINKER_FLAGS_RELEASE",
-          "value": "-static-libstdc++ -static-libgcc -static",
+          "value": "-static",
           "type": "STRING"
         },
         {

--- a/src/netxs/apps.hpp
+++ b/src/netxs/apps.hpp
@@ -439,14 +439,14 @@ namespace netxs::app::shared
                     {
                         boss.RISEUP(tier::release, e2::config::plugins::sizer::alive, state);
                     };
-                    boss.LISTEN(tier::anycast, e2::form::quit, boss_ptr)
+                    boss.LISTEN(tier::anycast, e2::form::proceed::quit::any, boss_ptr)
                     {
-                        boss.SIGNAL(tier::preview, e2::form::quit, boss_ptr);
+                        boss.SIGNAL(tier::preview, e2::form::proceed::quit::one, boss_ptr);
                     };
-                    boss.LISTEN(tier::preview, e2::form::quit, boss_ptr)
+                    boss.LISTEN(tier::preview, e2::form::proceed::quit::one, boss_ptr)
                     {
                         boss.shut();
-                        boss.RISEUP(tier::release, e2::form::quit, boss_ptr); // Detach base window.
+                        boss.RISEUP(tier::release, e2::form::proceed::quit::one, boss_ptr); // Detach base window.
                     };
                 });
         };

--- a/src/netxs/apps/calc.hpp
+++ b/src/netxs/apps/calc.hpp
@@ -337,9 +337,9 @@ namespace netxs::app::calc
                   ->invoke([&](auto& boss)
                   {
                       //boss.keybd.accept(true);
-                      boss.LISTEN(tier::anycast, e2::form::quit, item)
+                      boss.LISTEN(tier::anycast, e2::form::proceed::quit::any, item)
                       {
-                          boss.RISEUP(tier::release, e2::form::quit, item);
+                          boss.RISEUP(tier::release, e2::form::proceed::quit::one, item);
                       };
                       boss.LISTEN(tier::release, e2::form::upon::vtree::attached, parent)
                       {

--- a/src/netxs/apps/calc.xml
+++ b/src/netxs/apps/calc.xml
@@ -9,6 +9,7 @@ R"==(
             <shadower = 180  />
             <shadow   = 180  />
             <lucidity = 0xff /> <!-- not implemented -->
+            <tracking = off  /> <!-- Mouse cursor highlighting. -->
             <selector = 48   />
             <highlight  fgc=purewhite bgc=bluelt      />
             <warning    fgc=whitelt   bgc=yellowdk    />
@@ -75,14 +76,14 @@ R"==(
         </clipboard>
         <viewport coor=0,0/>
         <mouse dblclick=500ms/>
-        <tooltip timeout=500ms enabled=true fgc=pureblack bgc=purewhite/>
+        <tooltips timeout=2000ms enabled=true fgc=pureblack bgc=purewhite/>
         <glowfx=true/>                      <!-- Show glow effect around selected item. -->
-        <debug overlay=faux toggle="🐞"/>  <!-- Display console debug info. -->
-        <regions enabled=faux/>             <!-- Highlight UI objects boundaries. -->
+        <debug overlay=0 toggle="🐞"/>  <!-- Display console debug info. -->
+        <regions enabled=0/>             <!-- Highlight UI objects boundaries. -->
     </client>
     <defapp>
         <menu>
-            <autohide=faux/>
+            <autohide=off/>
             <enabled="on"/>
             <slim=true/>
         </menu>

--- a/src/netxs/apps/desk.hpp
+++ b/src/netxs/apps/desk.hpp
@@ -78,9 +78,7 @@ namespace netxs::app::desk
                         {
                             auto& inst = *data_src;
                             inst.SIGNAL(tier::preview, e2::form::layout::expose, inst);
-                            auto& area = inst.base::area();
-                            auto center = area.coor + (area.size / 2);
-                            gear.owner.SIGNAL(tier::release, e2::form::layout::shift, center);  // Goto to the window.
+                            gear.owner.SIGNAL(tier::release, e2::form::layout::shift, center, (inst.base::center()));  // Goto to the window.
                             pro::focus::set(data_src, gear.id, pro::focus::solo::on, pro::focus::flip::off);
                             gear.dismiss();
                         }
@@ -92,7 +90,7 @@ namespace netxs::app::desk
                             auto& inst = *data_src;
                             inst.SIGNAL(tier::preview, e2::form::layout::expose, inst);
                             boss.SIGNAL(tier::anycast, e2::form::prop::viewport, viewport, ());
-                            inst.SIGNAL(tier::preview, e2::form::layout::appear, center, (gear.area().coor + viewport.coor + (viewport.size / 2))); // Pull window.
+                            inst.SIGNAL(tier::preview, e2::form::layout::appear, center, (gear.area().coor + viewport.center())); // Pull window.
                             pro::focus::set(data_src, gear.id, pro::focus::solo::on, pro::focus::flip::off);
                             gear.dismiss();
                         }
@@ -186,7 +184,7 @@ namespace netxs::app::desk
 
                             boss.SIGNAL(tier::anycast, events::ui::selected, inst_id);
                             boss.SIGNAL(tier::anycast, e2::form::prop::viewport, viewport, ());
-                            viewport.coor += gear.area().coor;;
+                            viewport.coor += gear.area().coor;
                             offset = (offset + dot_21 * 2) % (viewport.size * 7 / 32);
                             gear.slot.coor = viewport.coor + offset + viewport.size * 1 / 32;
                             gear.slot.size = viewport.size * 3 / 4;
@@ -219,8 +217,7 @@ namespace netxs::app::desk
                         //           // Expose window.
                         //           auto& inst = *app_list.back();
                         //           inst.SIGNAL(tier::preview, e2::form::layout::expose, inst);
-                        //           auto& area = inst.base::area();
-                        //           auto center = area.coor + (area.size / 2);
+                        //           auto center = inst.base::center();
                         //           gear.owner.SIGNAL(tier::release, e2::form::layout::shift, center);  // Goto to the window.
                         //           gear.kb_offer_3(app_list.back());//pass_kb_focus(inst);
                         //           pro::focus::set(app_list.back(), gear.id, pro::focus::solo::on, pro::focus::flip::off);

--- a/src/netxs/apps/desk.hpp
+++ b/src/netxs/apps/desk.hpp
@@ -254,9 +254,10 @@ namespace netxs::app::desk
             auto highlight_color = skin::color(tone::highlight);
             auto c8 = cell{}.bgc(0x00).fgc(highlight_color.bgc());
             auto x8 = cell{ c8 }.alpha(0x00);
+            auto ver_label = ui::item::ctor(utf::concat(app::shared::version))
+                ->plugin<pro::fader>(x8, c8, 0ms);
             return ui::park::ctor()
-                ->branch(ui::snap::tail, ui::snap::tail, ui::item::ctor(utf::concat(app::shared::version))
-                ->plugin<pro::fader>(x8, c8, 0ms))
+                ->branch(ver_label, ui::snap::tail, ui::snap::tail)
                 ->plugin<pro::notes>(" About ")
                 ->invoke([&](auto& boss)
                 {
@@ -585,7 +586,7 @@ namespace netxs::app::desk
                             gear.dismiss();
                         };
                     });
-                auto disconnect_area = disconnect_park->attach(snap::head, snap::center, ui::pads::ctor(dent{ 2,3,1,1 }));
+                auto disconnect_area = disconnect_park->attach(ui::pads::ctor(dent{ 2,3,1,1 }), snap::head, snap::center);
                 auto disconnect = disconnect_area->attach(ui::item::ctor("× Disconnect"));
                 auto shutdown_park = bttns->attach(slot::_2, ui::park::ctor())
                     ->plugin<pro::fader>(x1, c1, skin::globals().fader_time)
@@ -597,7 +598,7 @@ namespace netxs::app::desk
                             boss.SIGNAL(tier::general, e2::shutdown, "desk: server shutdown");
                         };
                     });
-                auto shutdown_area = shutdown_park->attach(snap::tail, snap::center, ui::pads::ctor(dent{ 2,3,1,1 }));
+                auto shutdown_area = shutdown_park->attach(ui::pads::ctor(dent{ 2,3,1,1 }), snap::tail, snap::center);
                 auto shutdown = shutdown_area->attach(ui::item::ctor("× Shutdown"));
             }
             return window;

--- a/src/netxs/apps/desk.hpp
+++ b/src/netxs/apps/desk.hpp
@@ -118,7 +118,7 @@ namespace netxs::app::desk
                     {
                         if (auto data_src = data_src_shadow.lock())
                         {
-                            data_src->SIGNAL(tier::anycast, e2::form::quit, data_src);
+                            data_src->SIGNAL(tier::anycast, e2::form::proceed::quit::one, data_src);
                             gear.dismiss();
                         }
                     };

--- a/src/netxs/apps/shop.hpp
+++ b/src/netxs/apps/shop.hpp
@@ -79,9 +79,8 @@ namespace netxs::app::shop
 
                 appstore_head =
                 ansi::nil().eol().mgl(2).mgr(2)
-                .bld(faux).fgc(whitelt).jet(bias::left).wrp(wrap::on).add(
-                "Desktopio Application Distribution Platform that allows "
-                "users to browse and download software.\n\n");
+                .bld(true).fgc(whitelt).jet(bias::left).wrp(wrap::on)
+                .add("Desktopio Application Distribution Hub").bld(faux).add("\n\n");
 
                 auto textancy_text = ansi::nil().add(
                 "Hello World!😎\n"
@@ -217,13 +216,13 @@ namespace netxs::app::shop
                     auto [menu_block, cover, menu_data] = app::shared::menu::create(config, {});
                     menu_object->attach(slot::_1, menu_block);
                     menu_object->attach(slot::_2, ui::post::ctor())
-                               ->plugin<pro::limit>(twod{ 37,-1 }, twod{ -1,-1 })
+                               ->plugin<pro::limit>(twod{ 42,-1 }, twod{ -1,-1 })
                                ->upload(appstore_head)
                                ->active();
                 auto layers = object->attach(slot::_2, ui::cake::ctor());
                     auto scroll = layers->attach(ui::rail::ctor())
                                         ->colors(whitedk, 0xFF0f0f0f)
-                                        ->plugin<pro::limit>(twod{ -1,2 }, twod{ -1,-1 });
+                                        ->plugin<pro::limit>(twod{ -1,-1 }, twod{ -1,-1 });
                         auto items = scroll->attach(ui::list::ctor());
                         for (auto& body : appstore_body) items->attach(ui::post::ctor())
                                                               ->upload(body)

--- a/src/netxs/apps/shop.hpp
+++ b/src/netxs/apps/shop.hpp
@@ -205,9 +205,9 @@ namespace netxs::app::shop
                   ->invoke([](auto& boss)
                   {
                         //boss.keybd.accept(true);
-                        boss.LISTEN(tier::anycast, e2::form::quit, item)
+                        boss.LISTEN(tier::anycast, e2::form::proceed::quit::any, item)
                         {
-                            boss.RISEUP(tier::release, e2::form::quit, item);
+                            boss.RISEUP(tier::release, e2::form::proceed::quit::one, item);
                         };
                   });
             auto object = window->attach(ui::fork::ctor(axis::Y))

--- a/src/netxs/apps/term.hpp
+++ b/src/netxs/apps/term.hpp
@@ -319,7 +319,7 @@ namespace netxs::app::term
             {
                 _submit<true>(boss, item, [](auto& boss, auto& item, auto& gear)
                 {
-                    boss.RISEUP(tier::release, e2::form::quit, boss.This());
+                    boss.RISEUP(tier::release, e2::form::proceed::quit::one, boss.This());
                 });
             }
             static void TerminalFullscreen(ui::pads& boss, menu::item& item)
@@ -756,14 +756,14 @@ namespace netxs::app::term
                 ->attach_property(ui::term::events::search::status,  app::term::events::search::status)
                 ->invoke([](auto& boss)
                 {
-                    boss.LISTEN(tier::anycast, e2::form::quit, boss_ptr)
+                    boss.LISTEN(tier::anycast, e2::form::proceed::quit::any, boss_ptr)
                     {
-                        boss.SIGNAL(tier::preview, e2::form::quit, boss_ptr);
+                        boss.SIGNAL(tier::preview, e2::form::proceed::quit::one, boss_ptr);
                     };
-                    boss.LISTEN(tier::preview, e2::form::quit, item_ptr)
+                    boss.LISTEN(tier::preview, e2::form::proceed::quit::one, item_ptr)
                     {
                         boss.stop();
-                        boss.RISEUP(tier::release, e2::form::quit, item_ptr);
+                        boss.RISEUP(tier::release, e2::form::proceed::quit::one, item_ptr);
                     };
                     boss.LISTEN(tier::anycast, app::term::events::cmd, cmd)
                     {

--- a/src/netxs/apps/term.hpp
+++ b/src/netxs/apps/term.hpp
@@ -710,8 +710,8 @@ namespace netxs::app::term
                 auto bar = cell{ "▀"sv }.link(slot1->id);
                 auto brush = ptr::shared(cell{ cB }.inv(true).txt("▀"sv).link(slot1->id));
                 auto winsz = ptr::shared(dot_00);
-                auto visible = ptr::shared(true);
-                auto check_state = ptr::function([state = testy<bool>{}, winsz, visible](base& boss) mutable
+                auto visible = ptr::shared(slot1->back() != boss.This());
+                auto check_state = ptr::function([state = testy<bool>{ true }, winsz, visible](base& boss) mutable
                 {
                     if (state(*visible || winsz->y != 1))
                     {

--- a/src/netxs/apps/term.xml
+++ b/src/netxs/apps/term.xml
@@ -9,6 +9,7 @@ R"==(
             <shadower = 180  />
             <shadow   = 180  />
             <lucidity = 0xff /> <!-- not implemented -->
+            <tracking = off  /> <!-- Mouse cursor highlighting. -->
             <selector = 48   />
             <highlight  fgc=purewhite bgc=bluelt      />
             <warning    fgc=whitelt   bgc=yellowdk    />
@@ -75,10 +76,10 @@ R"==(
         </clipboard>
         <viewport coor=0,0/>
         <mouse dblclick=500ms/>
-        <tooltip timeout=500ms enabled=true fgc=pureblack bgc=purewhite/>
+        <tooltips timeout=2000ms enabled=true fgc=pureblack bgc=purewhite/>
         <glowfx=true/>                      <!-- Show glow effect around selected item. -->
-        <debug overlay=faux toggle="🐞"/>  <!-- Display console debug info. -->
-        <regions enabled=faux/>             <!-- Highlight UI objects boundaries. -->
+        <debug overlay=0 toggle="🐞"/>  <!-- Display console debug info. -->
+        <regions enabled=0/>            <!-- Highlight UI objects boundaries. -->
     </client>
     <term>      <!-- Base configuration for the Term app. It can be partially overridden by the menu item's config subarg. -->
         <scrollback>
@@ -177,7 +178,7 @@ R"==(
         </menu>
         <selection>
             <mode="text"/> <!-- text | ansi | rich | html | protected | none -->
-            <rect=faux/>  <!-- Preferred selection form: Rectangular: true, Linear false. -->
+            <rect=false/>  <!-- Preferred selection form: Rectangular: true, Linear false. -->
         </selection>
         <atexit = auto/>  <!-- auto:    Stay open and ask if exit code != 0. (default)
                                ask:     Stay open and ask.

--- a/src/netxs/apps/test.hpp
+++ b/src/netxs/apps/test.hpp
@@ -427,9 +427,9 @@ namespace netxs::app::test
                 ->invoke([](auto& boss)
                 {
                     //boss.keybd.accept(true);
-                    boss.LISTEN(tier::anycast, e2::form::quit, item)
+                    boss.LISTEN(tier::anycast, e2::form::proceed::quit::any, item)
                     {
-                        boss.RISEUP(tier::release, e2::form::quit, item);
+                        boss.RISEUP(tier::release, e2::form::proceed::quit::one, item);
                     };
                 });
             auto object0 = window->attach(ui::fork::ctor(axis::Y))

--- a/src/netxs/apps/text.hpp
+++ b/src/netxs/apps/text.hpp
@@ -197,9 +197,9 @@ utility like ctags is used to locate the definitions.
                   ->invoke([&](auto& boss)
                   {
                       //boss.keybd.accept(true);
-                      boss.LISTEN(tier::anycast, e2::form::quit, item)
+                      boss.LISTEN(tier::anycast, e2::form::proceed::quit::any, item)
                       {
-                          boss.RISEUP(tier::release, e2::form::quit, item);
+                          boss.RISEUP(tier::release, e2::form::proceed::quit::one, item);
                       };
                       boss.LISTEN(tier::release, e2::form::upon::vtree::attached, parent)
                       {

--- a/src/netxs/apps/tile.hpp
+++ b/src/netxs/apps/tile.hpp
@@ -321,6 +321,12 @@ namespace netxs::app::tile
                         ->upload(what.header)
                         ->invoke([&](auto& boss)
                         {
+                            boss.color(0, 0);
+                            boss.LISTEN(tier::release, hids::events::mouse::button::click::right, gear)
+                            {
+                                boss.RISEUP(tier::release, e2::form::layout::minimize, gear);
+                                gear.dismiss();
+                            };
                             boss.LISTEN(tier::release, e2::form::upon::vtree::attached, parent)
                             {
                                 auto shadow = ptr::shadow(boss.This());
@@ -387,7 +393,7 @@ namespace netxs::app::tile
             auto cC = menu_black;
 
             using namespace app::shared;
-            auto [menu_block, cover, menu_data] = menu::mini(true, true, faux, true,
+            auto [menu_block, cover, menu_data] = menu::mini(true, true, faux, true, faux,
             menu::list
             {
                 { ptr::shared(menu::item{ menu::item::type::Command, true, 0, std::vector<menu::item::look>{ { .label = " +", .notes = " New app " } }}),
@@ -493,6 +499,7 @@ namespace netxs::app::tile
                                 saved_ratio = ratio;
                                 node->set_ratio(min_state);
                                 min_ratio = node->get_ratio();
+                                pro::focus::off(boss.This(), gear.id);
                             }
                             node->base::reflow();
                         }

--- a/src/netxs/apps/tile.hpp
+++ b/src/netxs/apps/tile.hpp
@@ -191,7 +191,7 @@ namespace netxs::app::tile
                                     boss.RISEUP(tier::request, e2::form::proceed::createby, gear);
                                     break;
                                 case app::tile::events::ui::close.id:
-                                    boss.RISEUP(tier::preview, e2::form::quit, boss.This());
+                                    boss.RISEUP(tier::preview, e2::form::proceed::quit::one, boss.This());
                                     break;
                                 case app::tile::events::ui::toggle.id:
                                     if (boss.base::kind() == 0) // Only apps can be maximized.
@@ -238,12 +238,12 @@ namespace netxs::app::tile
             };
             //boss.LISTEN(tier::release, hids::events::mouse::button::click::leftright, gear)
             //{
-            //    boss.RISEUP(tier::release, e2::form::quit, boss.This());
+            //    boss.RISEUP(tier::release, e2::form::proceed::quit::one, boss.This());
             //    gear.dismiss();
             //};
             //boss.LISTEN(tier::release, hids::events::mouse::button::click::middle, gear)
             //{
-            //    boss.RISEUP(tier::release, e2::form::quit, boss.This());
+            //    boss.RISEUP(tier::release, e2::form::proceed::quit::one, boss.This());
             //    gear.dismiss();
             //};
         };
@@ -305,7 +305,7 @@ namespace netxs::app::tile
                                     auto gear_id_list = pro::focus::get(parent_ptr); // Expropriate all foci.
                                     world_ptr->SIGNAL(tier::request, vtm::events::handoff, what); // Attach to the world.
                                     pro::focus::set(what.applet, gear_id_list, pro::focus::solo::off, pro::focus::flip::off, true); // Refocus.
-                                    master.RISEUP(tier::release, e2::form::quit, master_ptr); // Destroy placeholder.
+                                    master.RISEUP(tier::release, e2::form::proceed::quit::one, master_ptr); // Destroy placeholder.
                                 }
 
                                 // Redirect this mouse event to the new world's window.
@@ -428,7 +428,7 @@ namespace netxs::app::tile
                 {
                     boss.LISTEN(tier::release, hids::events::mouse::button::click::left, gear)
                     {
-                        boss.RISEUP(tier::release, e2::form::quit, boss.This());
+                        boss.RISEUP(tier::release, e2::form::proceed::quit::one, boss.This());
                         gear.dismiss(true);
                     };
                 }},
@@ -661,19 +661,19 @@ namespace netxs::app::tile
                             pro::focus::set(slot_2->back(), gear_id, pro::focus::solo::off, pro::focus::flip::off);
                         }
                     };
-                    boss.LISTEN(tier::anycast, e2::form::quit, nested_item_ptr)
+                    boss.LISTEN(tier::anycast, e2::form::proceed::quit::any, nested_item_ptr)
                     {
-                        boss.SIGNAL(tier::preview, e2::form::quit, nested_item_ptr);
+                        boss.SIGNAL(tier::preview, e2::form::proceed::quit::one, nested_item_ptr);
                     };
-                    boss.LISTEN(tier::preview, e2::form::quit, nested_item_ptr)
+                    boss.LISTEN(tier::preview, e2::form::proceed::quit::one, nested_item_ptr)
                     {
                         if (boss.count() > 1 && boss.back()->base::kind() == 0)
                         {
-                            boss.back()->SIGNAL(tier::anycast, e2::form::quit, nested_item_ptr);
+                            boss.back()->SIGNAL(tier::anycast, e2::form::proceed::quit::one, nested_item_ptr);
                         }
-                        else boss.SIGNAL(tier::release, e2::form::quit, nested_item_ptr);
+                        else boss.SIGNAL(tier::release, e2::form::proceed::quit::one, nested_item_ptr);
                     };
-                    boss.LISTEN(tier::release, e2::form::quit, nested_item_ptr)
+                    boss.LISTEN(tier::release, e2::form::proceed::quit::any, nested_item_ptr)
                     {
                         if (auto parent = boss.base::parent())
                         if (nested_item_ptr)
@@ -924,9 +924,9 @@ namespace netxs::app::tile
             object->attach(slot::_1, menu_block)
                   ->invoke([](auto& boss)
                   {
-                      boss.LISTEN(tier::anycast, e2::form::quit, item)
+                      boss.LISTEN(tier::anycast, e2::form::proceed::quit::any, item)
                       {
-                          boss.RISEUP(tier::release, e2::form::quit, item);
+                          boss.RISEUP(tier::release, e2::form::proceed::quit::one, item);
                       };
                   });
             menu_data->colors(cB.fgc(), cB.bgc())

--- a/src/netxs/apps/tile.hpp
+++ b/src/netxs/apps/tile.hpp
@@ -372,10 +372,9 @@ namespace netxs::app::tile
                                 {
                                     anycasting(boss);
                                     //todo implement keydb support
-                                    boss.LISTEN(tier::release, hids::events::mouse::button::click::right, gear, -, (minimize_state = faux))
+                                    boss.LISTEN(tier::release, hids::events::mouse::button::click::right, gear)
                                     {
-                                        minimize_state = !minimize_state;
-                                        boss.RISEUP(tier::release, e2::form::layout::minimize, minimize_state);
+                                        boss.RISEUP(tier::release, e2::form::layout::minimize, gear);
                                         gear.dismiss();
                                     };
                                 })
@@ -478,15 +477,16 @@ namespace netxs::app::tile
                         boss.front()->color(c.fgc(), c.bgc());
                         boss.deface();
                     };
-                    boss.LISTEN(tier::release, e2::form::layout::minimize, state, -, (saved_ratio = 1, min_ratio = 1, min_state))
+                    boss.LISTEN(tier::release, e2::form::layout::minimize, gear, -, (saved_ratio = 1, min_ratio = 1, min_state))
                     {
                         if (auto node = std::dynamic_pointer_cast<ui::fork>(boss.base::parent()))
                         {
                             auto ratio = node->get_ratio();
-                            if (state == (ratio == min_ratio)) state = !state;
                             if (ratio == min_ratio)
                             {
                                 node->set_ratio(saved_ratio);
+                                pro::focus::set(boss.This(), gear.id, gear.meta(hids::anyCtrl) ? pro::focus::solo::off
+                                                                                               : pro::focus::solo::on, pro::focus::flip::off, true);
                             }
                             else
                             {

--- a/src/netxs/apps/tile.hpp
+++ b/src/netxs/apps/tile.hpp
@@ -450,13 +450,13 @@ namespace netxs::app::tile
                 })
                 ->branch
                 (
-                    snap::center, snap::center,
-                    ui::post::ctor()->upload("Empty Slot", 10)
+                    ui::post::ctor()->upload("Empty Slot", 10),
+                    snap::center, snap::center
                 )
                 ->branch
                 (
-                    snap::stretch, snap::head,
-                    menu_block
+                    menu_block,
+                    snap::stretch, snap::head
                 );
         };
         auto empty_slot = [](auto&& empty_slot) -> sptr<ui::veer>

--- a/src/netxs/desktopio/ansivt.hpp
+++ b/src/netxs/desktopio/ansivt.hpp
@@ -560,6 +560,10 @@ namespace netxs::ansi
                                                                                                  c.chan.b, 'm');
             else return block;
         }
+        template<class ...Args>
+        auto& hi(Args&&... data) { return inv(true).add(std::forward<Args>(data)...).nil(); } // esc: Add highlighted message.
+        template<class ...Args>
+        auto& err(Args&&... data) { return fgc(redlt).add(std::forward<Args>(data)...).nil(); } // esc: Add error message.
         // basevt: Ansify/textify content of specified region.
         template<bool UseSGR = true, bool Initial = true, bool Finalize = true>
         auto& s11n(core const& canvas, rect region, cell& state)
@@ -942,7 +946,9 @@ namespace netxs::ansi
     template<class ...Args>
     static auto add(Args&&... data)   { return esc{}.add(std::forward<Args>(data)...); } // ansi: Add text.
     template<class ...Args>
-    static auto err(Args&&... data)   { return esc{}.fgc(redlt).add(std::forward<Args>(data)...).nil(); } // ansi: Add error message.
+    static auto err(Args&&... data)   { return esc{}.err(std::forward<Args>(data)...); } // ansi: Add error message.
+    template<class ...Args>
+    static auto hi(Args&&... data)    { return esc{}.hi(std::forward<Args>(data)...); } // ansi: Add highlighted message.
     static auto cup(twod const& n)    { return esc{}.cup(n);        } // ansi: 0-Based caret position.
     static auto cuu(si32 n)           { return esc{}.cuu(n);        } // ansi: Caret up.
     static auto cud(si32 n)           { return esc{}.cud(n);        } // ansi: Caret down.

--- a/src/netxs/desktopio/ansivt.hpp
+++ b/src/netxs/desktopio/ansivt.hpp
@@ -634,7 +634,7 @@ namespace netxs::ansi
                     if constexpr (UseSGR) basevt::nil();
                 }
             }
-            return *this;
+            return block;
         }
         template<bool UseSGR = true, bool Initial = true, bool Finalize = true>
         auto& s11n(core const& canvas, rect region) // basevt: Ansify/textify content of specified region.
@@ -941,6 +941,11 @@ namespace netxs::ansi
         auto& link(si32 i)       { return add("\033[31:", i  , csi_ccc); } // esc: Set object id link.
     };
 
+    template<bool UseSGR = true, bool Initial = true, bool Finalize = true>
+    static auto s11n(core const& canvas, rect region) // ansi: Ansify/textify content of specified region.
+    {
+        return esc{}.s11n<UseSGR, Initial, Finalize>(canvas, region);
+    }
     template<class ...Args>
     static auto clipbuf(Args&&... data) { return esc{}.clipbuf(std::forward<Args>(data)...); } // ansi: Set clipboard.
     template<class ...Args>

--- a/src/netxs/desktopio/ansivt.hpp
+++ b/src/netxs/desktopio/ansivt.hpp
@@ -1538,7 +1538,7 @@ namespace netxs::ansi
                         {
                             auto c = ascii.front();
                             if (trap(c)) continue;
-                            push(0); // Default zero parameter expressed by standalone delimiter/semicolon.
+                            push(fifo::skip); // Default parameter expressed by standalone delimiter/semicolon.
                             a = c; // Delimiter or cmd after number.
                         }
                         ascii.pop_front();

--- a/src/netxs/desktopio/application.hpp
+++ b/src/netxs/desktopio/application.hpp
@@ -115,9 +115,7 @@ namespace netxs::app::shared
             auto x1 = cell{ c1 }.alpha(0x00);
 
             auto slot1 = ui::veer::ctor();
-
-            auto menuarea = ui::fork::ctor()
-                            ->active();
+            auto menuarea = ui::fork::ctor()->active();
                 auto inner_pads = dent{ 1,2,1,1 };
                 auto menulist = menuarea->attach(slot::_1, ui::fork::ctor());
                 auto fader = skin::globals().fader_time;
@@ -169,11 +167,7 @@ namespace netxs::app::shared
                             ->plugin<pro::notes>(" Close ")
                             ->invoke([&](auto& boss)
                             {
-                                #if defined(_DEBUG)
-                                boss.LISTEN(tier::release, hids::events::mouse::button::click::any, gear)
-                                #else
                                 boss.LISTEN(tier::release, hids::events::mouse::button::click::left, gear)
-                                #endif
                                 {
                                     boss.SIGNAL(tier::anycast, e2::form::quit, boss.This());
                                     gear.dismiss();
@@ -186,7 +180,7 @@ namespace netxs::app::shared
                 auto scrllist = scrlrail->attach(ui::list::ctor(axis::X));
 
                 auto scroll_hint = ui::park::ctor();
-                auto hints = scroll_hint->attach(snap::stretch, menusize ? snap::center : snap::tail, ui::gripfx<axis::X, drawfx>::ctor(scrlrail));
+                auto hints = scroll_hint->attach(ui::gripfx<axis::X, drawfx>::ctor(scrlrail), snap::stretch, menusize ? snap::center : snap::tail);
 
                 auto scrl_grip = scrlarea->attach(scroll_hint);
 
@@ -201,67 +195,60 @@ namespace netxs::app::shared
                 ->invoke([&](ui::park& boss)
                 {
                     scroll_hint->visible(hints, faux);
-                    auto park_shadow = ptr::shadow(scroll_hint);
-                    auto grip_shadow = ptr::shadow(hints);
-                    boss.LISTEN(tier::release, hids::events::mouse::button::click::right, gear, -, (park_shadow, grip_shadow))
+                    auto slim_status = ptr::shared(menusize);
+                    boss.LISTEN(tier::release, hids::events::mouse::button::click::right, gear, -, (minimize_state = faux))
                     {
-                        if (auto park_ptr = park_shadow.lock())
-                        if (auto grip_ptr = grip_shadow.lock())
+                        minimize_state = !minimize_state;
+                        boss.RISEUP(tier::release, e2::form::layout::minimize, minimize_state);
+                        gear.dismiss();
+                    };
+                    boss.LISTEN(tier::anycast, e2::form::upon::resize, new_size, -, (slim_status))
+                    {
+                        if (!*slim_status)
                         {
                             auto& limit = boss.plugins<pro::limit>();
                             auto limits = limit.get();
-                            if (limits.min.y == 1)
+                            if (new_size.y < 3)
                             {
-                                park_ptr->config(grip_ptr, snap::stretch, snap::tail);
+                                if (limits.min.y != new_size.y)
+                                {
+                                    limits.min.y = limits.max.y = new_size.y;
+                                    limit.set(limits);
+                                }
+                            }
+                            else if (limits.min.y != 3)
+                            {
                                 limits.min.y = limits.max.y = 3;
+                                limit.set(limits);
                             }
-                            else
-                            {
-                                park_ptr->config(grip_ptr, snap::stretch, snap::center);
-                                limits.min.y = limits.max.y = 1;
-                            }
-                            limit.set(limits);
-                            boss.reflow();
-                            gear.dismiss();
                         }
                     };
-                    boss.LISTEN(tier::anycast, e2::form::prop::ui::slimmenu, slim, -, (park_shadow, grip_shadow))
+                    boss.LISTEN(tier::anycast, e2::form::prop::ui::slimmenu, slim, -, (slim_status))
                     {
-                        auto size = slim ? 1 : 3;
-                        if (auto park_ptr = park_shadow.lock())
-                        if (auto grip_ptr = grip_shadow.lock())
-                        {
-                            auto& limit = boss.plugins<pro::limit>();
-                            auto limits = limit.get();
-                            limits.min.y = limits.max.y = std::max(0, size);
-                            //todo too hacky
-                            if (limits.min.y == 3)
-                            {
-                                park_ptr->config(grip_ptr, snap::stretch, snap::tail);
-                            }
-                            else
-                            {
-                                park_ptr->config(grip_ptr, snap::stretch, snap::center);
-                            }
-                            limit.set(limits);
-                            boss.reflow();
-                        }
+                        auto& limit = boss.plugins<pro::limit>();
+                        auto limits = limit.get();
+                        *slim_status = slim;
+                        limits.min.y = limits.max.y = slim ? 1 : 3;
+                        limit.set(limits);
+                        boss.reflow();
                     };
                     //todo revise
                     if (menu_items.size()) // Show scrolling hint only if elements exist.
                     {
-                        boss.LISTEN(tier::release, e2::form::state::mouse, active, -, (park_shadow, grip_shadow))
+                        auto scrl_shadow = ptr::shadow(scroll_hint);
+                        auto grip_shadow = ptr::shadow(hints);
+                        boss.LISTEN(tier::release, e2::form::state::mouse, active, -, (scrl_shadow, grip_shadow))
                         {
-                            if (auto park_ptr = park_shadow.lock())
+                            if (auto scrl_ptr = scrl_shadow.lock())
                             if (auto grip_ptr = grip_shadow.lock())
                             {
-                                park_ptr->visible(grip_ptr, active);
+                                scrl_ptr->visible(grip_ptr, active);
                                 boss.base::deface();
                             }
                         };
                     }
                 });
-            menu_block->attach(snap::stretch, snap::center, menuarea);
+            menu_block->attach(menuarea, snap::stretch, snap::center);
 
             auto menu = slot1->attach(menu_block);
                     auto border = slot1->attach(ui::mock::ctor())
@@ -362,7 +349,7 @@ namespace netxs::app::shared
     {
         auto area = ui::park::ctor();
         auto grip = ui::gripfx<axis::X, menu::drawfx>::ctor(master);
-        area->branch(snap::stretch, snap::tail, grip)
+        area->branch(grip, snap::stretch, snap::tail)
             ->invoke([&](auto& boss)
             {
                 area->visible(grip, faux);
@@ -439,7 +426,7 @@ namespace netxs::app::shared
                 );
             auto placeholder = ui::park::ctor()
                 ->colors(whitelt, rgba{ 0x7F404040 })
-                ->attach(snap::stretch, snap::stretch, msg);
+                ->attach(msg, snap::stretch, snap::stretch);
             window->attach(ui::rail::ctor())
                   ->attach(placeholder);
             return window;

--- a/src/netxs/desktopio/application.hpp
+++ b/src/netxs/desktopio/application.hpp
@@ -169,7 +169,7 @@ namespace netxs::app::shared
                             {
                                 boss.LISTEN(tier::release, hids::events::mouse::button::click::left, gear)
                                 {
-                                    boss.SIGNAL(tier::anycast, e2::form::quit, boss.This());
+                                    boss.SIGNAL(tier::anycast, e2::form::proceed::quit::one, boss.This());
                                     gear.dismiss();
                                 };
                             })
@@ -325,9 +325,9 @@ namespace netxs::app::shared
     };
     const auto closing_on_quit = [](auto& boss)
     {
-        boss.LISTEN(tier::anycast, e2::form::quit, item)
+        boss.LISTEN(tier::anycast, e2::form::proceed::quit::any, item)
         {
-            boss.RISEUP(tier::release, e2::form::quit, item);
+            boss.RISEUP(tier::release, e2::form::proceed::quit::one, item);
         };
     };
     const auto closing_by_gesture = [](auto& boss)
@@ -335,13 +335,13 @@ namespace netxs::app::shared
         boss.LISTEN(tier::release, hids::events::mouse::button::click::leftright, gear)
         {
             auto backup = boss.This();
-            boss.RISEUP(tier::release, e2::form::quit, backup);
+            boss.RISEUP(tier::release, e2::form::proceed::quit::one, backup);
             gear.dismiss();
         };
         boss.LISTEN(tier::release, hids::events::mouse::button::click::middle, gear)
         {
             auto backup = boss.This();
-            boss.RISEUP(tier::release, e2::form::quit, backup);
+            boss.RISEUP(tier::release, e2::form::proceed::quit::one, backup);
             gear.dismiss();
         };
     };

--- a/src/netxs/desktopio/application.hpp
+++ b/src/netxs/desktopio/application.hpp
@@ -198,8 +198,7 @@ namespace netxs::app::shared
                     auto slim_status = ptr::shared(menusize);
                     boss.LISTEN(tier::release, hids::events::mouse::button::click::right, gear, -, (minimize_state = faux))
                     {
-                        minimize_state = !minimize_state;
-                        boss.RISEUP(tier::release, e2::form::layout::minimize, minimize_state);
+                        boss.RISEUP(tier::release, e2::form::layout::minimize, gear);
                         gear.dismiss();
                     };
                     boss.LISTEN(tier::anycast, e2::form::upon::resize, new_size, -, (slim_status))

--- a/src/netxs/desktopio/application.hpp
+++ b/src/netxs/desktopio/application.hpp
@@ -21,7 +21,7 @@ namespace netxs::app
 
 namespace netxs::app::shared
 {
-    static const auto version = "v0.9.9h";
+    static const auto version = "v0.9.9i";
     static const auto desktopio = "desktopio";
     static const auto logsuffix = "_log";
     static const auto usr_config = "~/.config/vtm/settings.xml";

--- a/src/netxs/desktopio/baseui.hpp
+++ b/src/netxs/desktopio/baseui.hpp
@@ -175,15 +175,16 @@ namespace netxs::events::userland
                 {
                     EVENT_XS( fullscreen, input::hids    ), // request to fullscreen.
                     EVENT_XS( minimize  , input::hids    ), // request to minimize.
+                    EVENT_XS( unselect  , input::hids    ), // inform if unselected.
+                    EVENT_XS( selected  , input::hids    ), // inform if selected.
                     EVENT_XS( restore   , sptr<ui::base> ), // request to restore.
                     EVENT_XS( shift     , const twod     ), // request a global shifting  with delta.
                     EVENT_XS( convey    , cube           ), // request a global conveying with delta (Inform all children to be conveyed).
                     EVENT_XS( bubble    , ui::base       ), // order to popup the requested item through the visual tree.
                     EVENT_XS( expose    , ui::base       ), // order to bring the requested item on top of the visual tree (release: ask parent to expose specified child; preview: ask child to expose itself).
                     EVENT_XS( appear    , twod           ), // fly to the specified coords.
-                    EVENT_XS( gonext    , sptr<ui::base> ), // request: proceed request for available objects (next)
-                    EVENT_XS( goprev    , sptr<ui::base> ), // request: proceed request for available objects (prev)
                     EVENT_XS( swarp     , const dent     ), // preview: form swarping
+                    GROUP_XS( go        , sptr<ui::base> ), // preview: form swarping
                     //EVENT_XS( order     , si32       ), // return
                     //EVENT_XS( strike    , rect       ), // inform about the child canvas has changed, only preview.
                     //EVENT_XS( coor      , twod       ), // return client rect coor, only preview.
@@ -191,6 +192,13 @@ namespace netxs::events::userland
                     //EVENT_XS( rect      , rect       ), // return client rect.
                     //EVENT_XS( show      , bool       ), // order to make it visible.
                     //EVENT_XS( hide      , bool       ), // order to make it hidden.
+                    
+                    SUBSET_XS( go )
+                    {
+                        EVENT_XS( next , sptr<ui::base> ), // request: proceed request for available objects (next)
+                        EVENT_XS( prev , sptr<ui::base> ), // request: proceed request for available objects (prev)
+                        EVENT_XS( item , sptr<ui::base> ), // request: proceed request for available objects (current)
+                    };
                 };
                 SUBSET_XS( upon )
                 {

--- a/src/netxs/desktopio/baseui.hpp
+++ b/src/netxs/desktopio/baseui.hpp
@@ -850,17 +850,18 @@ namespace netxs::ui
         twod anchor; // base: Object balance point. Center point for any transform (on preview).
 
         template<class T = base>
-        auto  This()       { return std::static_pointer_cast<std::remove_reference_t<T>>(shared_from_this()); }
-        auto& coor() const { return square.coor; }
-        auto& size() const { return square.size; }
-        auto& area() const { return square; }
-        void  root(bool b) { visual_root = b; }
-        bool  root()       { return visual_root; }
-        si32  kind()       { return object_kind; }
-        void  kind(si32 k) { object_kind = k; }
-        auto parent()      { return parent_shadow.lock(); }
-        void ruined(bool state) { invalid = state; }
-        auto ruined() const { return invalid; }
+        auto   This()       { return std::static_pointer_cast<std::remove_reference_t<T>>(shared_from_this()); }
+        auto&  coor() const { return square.coor;          }
+        auto&  size() const { return square.size;          }
+        auto&  area() const { return square;               }
+        void   root(bool b) { visual_root = b;             }
+        bool   root()       { return visual_root;          }
+        si32   kind()       { return object_kind;          }
+        void   kind(si32 k) { object_kind = k;             }
+        auto center() const { return square.center();      }
+        auto parent()       { return parent_shadow.lock(); }
+        void ruined(bool s) { invalid = s;                 }
+        auto ruined() const { return invalid;              }
         template<bool Absolute = true>
         auto actual_area() const
         {

--- a/src/netxs/desktopio/baseui.hpp
+++ b/src/netxs/desktopio/baseui.hpp
@@ -174,7 +174,7 @@ namespace netxs::events::userland
                 SUBSET_XS( layout )
                 {
                     EVENT_XS( fullscreen, input::hids    ), // request to fullscreen.
-                    EVENT_XS( minimize  , bool           ), // request to minimize.
+                    EVENT_XS( minimize  , input::hids    ), // request to minimize.
                     EVENT_XS( restore   , sptr<ui::base> ), // request to restore.
                     EVENT_XS( shift     , const twod     ), // request a global shifting  with delta.
                     EVENT_XS( convey    , cube           ), // request a global conveying with delta (Inform all children to be conveyed).

--- a/src/netxs/desktopio/baseui.hpp
+++ b/src/netxs/desktopio/baseui.hpp
@@ -370,6 +370,8 @@ namespace netxs::events::userland
                         EVENT_XS( footer  , text ), // set/get form caption footer.
                         EVENT_XS( tooltip , text ), // set/get tooltip text.
                         EVENT_XS( slimmenu, bool ), // set/get window menu size.
+                        EVENT_XS( acryl   , bool ), // set/get window acrylic effect.
+                        EVENT_XS( cache   , bool ), // set/get render cache usage.
                     };
                     SUBSET_XS( colors )
                     {
@@ -402,6 +404,7 @@ namespace netxs::events::userland
                     //EVENT_XS( params   , ui::para ), // notify the client has changed title params.
                     EVENT_XS( color    , ui::tone ), // notify the client has changed tone, preview to set.
                     EVENT_XS( highlight, bool     ),
+                    EVENT_XS( visible  , bool     ),
                     GROUP_XS( keybd    , bool     ),
 
                     SUBSET_XS( keybd )

--- a/src/netxs/desktopio/baseui.hpp
+++ b/src/netxs/desktopio/baseui.hpp
@@ -460,6 +460,7 @@ namespace netxs::ui
 
         twod bordersz = dot_11;
         si32 lucidity = 0xFF;
+        bool tracking = true;
 
         si32 spd;
         si32 pls;

--- a/src/netxs/desktopio/baseui.hpp
+++ b/src/netxs/desktopio/baseui.hpp
@@ -174,6 +174,7 @@ namespace netxs::events::userland
                 SUBSET_XS( layout )
                 {
                     EVENT_XS( fullscreen, input::hids    ), // request to fullscreen.
+                    EVENT_XS( minimize  , bool           ), // request to minimize.
                     EVENT_XS( restore   , sptr<ui::base> ), // request to restore.
                     EVENT_XS( shift     , const twod     ), // request a global shifting  with delta.
                     EVENT_XS( convey    , cube           ), // request a global conveying with delta (Inform all children to be conveyed).
@@ -200,6 +201,7 @@ namespace netxs::events::userland
                     EVENT_XS( dragged, input::hids    ), // event after drag.
                     EVENT_XS( created, input::hids    ), // release: notify the instance of who created it.
                     EVENT_XS( started, sptr<ui::base> ), // release: notify the instance is commissioned. arg: visual root.
+                    EVENT_XS( resize , const twod     ), // anycast: notify about the actual window size.
                     GROUP_XS( vtree  , sptr<ui::base> ), // visual tree events, arg: parent base_sptr.
                     GROUP_XS( scroll , rack           ), // event after scroll.
                     //EVENT_XS( created    , sptr<ui::base> ), // event after itself creation, arg: itself bell_sptr.

--- a/src/netxs/desktopio/baseui.hpp
+++ b/src/netxs/desktopio/baseui.hpp
@@ -148,7 +148,6 @@ namespace netxs::events::userland
             SUBSET_XS( form )
             {
                 EVENT_XS( canvas   , sptr<core>     ), // request global canvas.
-                EVENT_XS( quit     , sptr<ui::base> ), // request parent for destroy.
                 GROUP_XS( layout   , const twod     ),
                 GROUP_XS( draggable, bool           ), // signal to the form to enable draggablity for specified mouse button.
                 GROUP_XS( upon     , bool           ),
@@ -286,11 +285,17 @@ namespace netxs::events::userland
                     EVENT_XS( swap      , sptr<ui::base> ), // order to replace existing client. See tiling manager empty slot.
                     EVENT_XS( functor   , ui::functor    ), // exec functor (see pro::focus).
                     EVENT_XS( onbehalf  , ui::proc       ), // exec functor on behalf (see gate).
+                    GROUP_XS( quit      , sptr<ui::base> ), // request parent for destroy.
                     //EVENT_XS( focus      , sptr<ui::base>     ), // order to set focus to the specified object, arg is a object sptr.
                     //EVENT_XS( commit     , si32               ), // order to output the targets, arg is a frame number.
                     //EVENT_XS( multirender, vector<sptr<face>> ), // ask children to render itself to the set of canvases, arg is an array of the face sptrs.
                     //EVENT_XS( draw       , face               ), // ????  order to render itself to the canvas.
                     //EVENT_XS( checkin    , face_sptr          ), // order to register an output client canvas.
+
+                    SUBSET_XS( quit )
+                    {
+                        EVENT_XS( one, sptr<ui::base> ), // Signal to close.
+                    };
                 };
                 SUBSET_XS( cursor )
                 {

--- a/src/netxs/desktopio/baseui.hpp
+++ b/src/netxs/desktopio/baseui.hpp
@@ -465,7 +465,7 @@ namespace netxs::ui
 
         twod bordersz = dot_11;
         si32 lucidity = 0xFF;
-        bool tracking = true;
+        bool tracking = faux;
 
         si32 spd;
         si32 pls;

--- a/src/netxs/desktopio/canvas.hpp
+++ b/src/netxs/desktopio/canvas.hpp
@@ -1225,6 +1225,7 @@ namespace netxs
         auto& link(id_t oid)      { id = oid;           return *this; } // cell: Set link object ID.
         auto& link(cell const& c) { id = c.id;          return *this; } // cell: Set link object ID.
         auto& txt (view c)        { c.size() ? gc.set(c) : gc.wipe(); return *this; } // cell: Set Grapheme cluster.
+        auto& txt (view c, si32 w){ gc.set(c, w);       return *this; } // cell: Set Grapheme cluster.
         auto& txt (char c)        { gc.set(c);          return *this; } // cell: Set Grapheme cluster from char.
         auto& txt (cell const& c) { gc = c.gc;          return *this; } // cell: Set Grapheme cluster from cell.
         auto& clr (cell const& c) { uv = c.uv;          return *this; } // cell: Set the foreground and background colors only.

--- a/src/netxs/desktopio/canvas.hpp
+++ b/src/netxs/desktopio/canvas.hpp
@@ -1395,6 +1395,11 @@ namespace netxs
                 template<class C> constexpr inline auto operator () (C brush) const { return func<C>(brush); }
                 template<class D, class S>  inline void operator () (D& dst, S& src) const { dst = src; }
             };
+            struct nonzero_t : public brush_t<nonzero_t>
+            {
+                template<class C> constexpr inline auto operator () (C brush) const { return func<C>(brush); }
+                template<class D, class S>  inline void operator () (D& dst, S& src) const { if (!src.isnul()) dst = src; }
+            };
             struct fuse_t : public brush_t<fuse_t>
             {
                 template<class C> constexpr inline auto operator () (C brush) const { return func<C>(brush); }
@@ -1508,6 +1513,7 @@ namespace netxs
             static constexpr auto     fuse =     fuse_t{};
             static constexpr auto     flat =     flat_t{};
             static constexpr auto     full =     full_t{};
+            static constexpr auto  nonzero =  nonzero_t{};
             static constexpr auto     text =     text_t{};
             static constexpr auto     meta =     meta_t{};
             static constexpr auto   xlight =   xlight_t{};

--- a/src/netxs/desktopio/canvas.hpp
+++ b/src/netxs/desktopio/canvas.hpp
@@ -992,7 +992,7 @@ namespace netxs
         }
         auto& data() const { return *this;} // cell: Return the const reference of the base cell.
 
-        // cell: Merge the two cells according to visibility and other attributes.
+        // cell: Merge two cells according to visibility and other attributes.
         inline void fuse(cell const& c)
         {
             //if (c.uv.fg.chan.a) uv.fg = c.uv.fg;
@@ -1007,7 +1007,7 @@ namespace netxs
             st = c.st;
             if (c.wdt()) gc = c.gc;
         }
-        // cell: Merge the two cells if text part != '\0'.
+        // cell: Merge two cells if text part != '\0'.
         inline void lite(cell const& c)
         {
             if (c.gc.glyph[1] != 0) fuse(c);
@@ -1044,13 +1044,13 @@ namespace netxs
             uv.fg.mix(c.uv.fg, alpha);
             uv.bg.mix(c.uv.bg, alpha);
         }
-        // cell: Merge the two cells and update ID with COOR.
+        // cell: Merge two cells and update ID with COOR.
         void fuse(cell const& c, id_t oid)//, twod const& pos)
         {
             fuse(c);
             id = oid;
         }
-        // cell: Merge the two cells and update ID with COOR.
+        // cell: Merge two cells and update ID with COOR.
         void fusefull(cell const& c)
         {
             fuse(c);

--- a/src/netxs/desktopio/canvas.hpp
+++ b/src/netxs/desktopio/canvas.hpp
@@ -95,11 +95,14 @@ namespace netxs
                 switch (fifo::desub(mode))
                 {
                     case mode_RGB:
-                        chan.r = queue.subarg(0);
+                    {
+                        auto r = queue.subarg(-1); // Skip the case with color space: \x1b[38:2::255:255:255:::m.
+                        chan.r = r == -1 ? queue.subarg(0) : r;
                         chan.g = queue.subarg(0);
                         chan.b = queue.subarg(0);
                         chan.a = queue.subarg(0xFF);
                         break;
+                    }
                     case mode_256:
                         token = netxs::letoh(color256[queue.subarg(0)]);
                         break;

--- a/src/netxs/desktopio/console.hpp
+++ b/src/netxs/desktopio/console.hpp
@@ -2682,19 +2682,19 @@ namespace netxs::ui
             void read(xmls& config)
             {
                 config.cd("/config/client/");
-                clip_preview_clrs = config.take("clipboard/preview", cell{}.bgc(bluedk).fgc(whitelt));
+                clip_preview_clrs = config.take("clipboard/preview"        , cell{}.bgc(bluedk).fgc(whitelt));
                 clip_preview_time = config.take("clipboard/preview/timeout", span{ 3s });
-                clip_preview_alfa = config.take("clipboard/preview/alpha", 0xFF);
-                clip_preview_glow = config.take("clipboard/preview/shadow", 7);
+                clip_preview_alfa = config.take("clipboard/preview/alpha"  , 0xFF);
+                clip_preview_glow = config.take("clipboard/preview/shadow" , 7);
                 clip_preview_show = config.take("clipboard/preview/enabled", true);
-                clip_preview_size = config.take("clipboard/preview/size", twod{ 80,25 });
-                dblclick_timeout  = config.take("mouse/dblclick",  span{ 500ms });
-                tooltip_colors    = config.take("tooltip", cell{}.bgc(0xFFffffff).fgc(0xFF000000));
-                tooltip_timeout   = config.take("tooltip/timeout", span{ 500ms });
-                tooltip_enabled   = config.take("tooltip/enabled", true);
-                debug_overlay     = config.take("debug/overlay", faux);
-                debug_toggle      = config.take("debug/toggle", "🐞"s);
-                show_regions      = config.take("regions/enabled", faux);
+                clip_preview_size = config.take("clipboard/preview/size"   , twod{ 80,25 });
+                dblclick_timeout  = config.take("mouse/dblclick"           , span{ 500ms });
+                tooltip_colors    = config.take("tooltips"                 , cell{}.bgc(0xFFffffff).fgc(0xFF000000));
+                tooltip_timeout   = config.take("tooltips/timeout"         , span{ 2000ms });
+                tooltip_enabled   = config.take("tooltips/enabled"         , true);
+                debug_overlay     = config.take("debug/overlay"            , faux);
+                debug_toggle      = config.take("debug/toggle"             , "🐞"s);
+                show_regions      = config.take("regions/enabled"          , faux);
                 clip_preview_glow = std::clamp(clip_preview_glow, 0, 10);
             }
 
@@ -3754,7 +3754,7 @@ namespace netxs::ui
             g.menu_white     = config.take("menu_white"            , cell{});
             g.menu_black     = config.take("menu_black"            , cell{});
             g.lucidity       = config.take("lucidity");
-            g.tracking       = config.take("tracking"              , true);
+            g.tracking       = config.take("tracking"              , faux);
             g.bordersz       = config.take("bordersz"              , dot_11);
             g.spd            = config.take("timings/spd"           , 10  );
             g.pls            = config.take("timings/pls"           , 167 );

--- a/src/netxs/desktopio/console.hpp
+++ b/src/netxs/desktopio/console.hpp
@@ -568,7 +568,7 @@ namespace netxs::ui
                     auto fill = [&](cell& c) { c.fuse(mark); };
                     items.foreach([&](sock& item)
                     {
-                        auto area = rect{ item.cursor,dot_00 } + dent{ 6,6,3,3 };
+                        auto area = rect{ item.cursor, dot_00 } + dent{ 6,6,3,3 };
                         area.coor += full.coor;
                         parent_canvas.fill(area.clip(full), fill);
                     });
@@ -2117,6 +2117,7 @@ namespace netxs::ui
 
             sptr<face> coreface;
             byte       lucidity;
+            bool       usecache;
 
         public:
             face& canvas; // cache: Bitmap cache.
@@ -2125,11 +2126,16 @@ namespace netxs::ui
             cache(base& boss, bool rendered = true)
                 : skill{ boss },
                   canvas{*(coreface = ptr::shared<face>())},
-                  lucidity{ 0xFF }
+                  lucidity{ 0xFF },
+                  usecache{ true }
             {
                 canvas.link(boss.bell::id);
                 canvas.move(boss.base::coor());
                 canvas.size(boss.base::size());
+                boss.LISTEN(tier::preview, e2::form::prop::ui::cache, state, memo)
+                {
+                    usecache = state;
+                };
                 boss.LISTEN(tier::anycast, e2::form::prop::lucidity, value, memo)
                 {
                     if (value == -1)
@@ -2153,6 +2159,7 @@ namespace netxs::ui
                 {
                     boss.LISTEN(tier::release, e2::render::prerender, parent_canvas, memo)
                     {
+                        if (!usecache) return;
                         if (boss.base::ruined())
                         {
                             canvas.wipe();
@@ -2184,6 +2191,10 @@ namespace netxs::ui
                   width{ size },
                   alive{ true }
             {
+                boss.LISTEN(tier::preview, e2::form::prop::ui::acryl, state, memo)
+                {
+                    alive = state;
+                };
                 boss.LISTEN(tier::anycast, e2::form::prop::lucidity, lucidity, memo)
                 {
                     if (lucidity != -1) alive = lucidity == 0xFF;

--- a/src/netxs/desktopio/console.hpp
+++ b/src/netxs/desktopio/console.hpp
@@ -517,9 +517,9 @@ namespace netxs::ui
                 boss.LISTEN(tier::release, e2::render::prerender, parent_canvas, memo)
                 {
                     if (focus.empty() || !alive) return;
+                    static constexpr auto title_fg_color = rgba{ 0xFFffffff };
                     //todo revise, too many fillings (mold's artifacts)
                     auto normal = boss.base::color();
-                    auto title_fg_color = rgba{ 0xFFffffff };
                     auto bright = skin::color(tone::brighter);
                     auto shadow = skin::color(tone::shadower);
                     //todo unify, make it more contrast
@@ -553,7 +553,7 @@ namespace netxs::ui
                 {
                     if (lucidity != -1) alive = lucidity == 0xFF;
                 };
-                if (keybd_only) return;
+                if (keybd_only || !skin::globals().tracking) return;
                 // Mouse focus.
                 boss.LISTEN(tier::release, hids::events::mouse::move, gear, memo)
                 {
@@ -3754,6 +3754,7 @@ namespace netxs::ui
             g.menu_white     = config.take("menu_white"            , cell{});
             g.menu_black     = config.take("menu_black"            , cell{});
             g.lucidity       = config.take("lucidity");
+            g.tracking       = config.take("tracking"              , true);
             g.bordersz       = config.take("bordersz"              , dot_11);
             g.spd            = config.take("timings/spd"           , 10  );
             g.pls            = config.take("timings/pls"           , 167 );

--- a/src/netxs/desktopio/console.hpp
+++ b/src/netxs/desktopio/console.hpp
@@ -3453,7 +3453,7 @@ namespace netxs::ui
             }
 
 
-            LISTEN(tier::release, e2::form::quit, initiator, tokens)
+            LISTEN(tier::release, e2::form::proceed::quit::any, initiator, tokens)
             {
                 auto msg = ansi::add("gate: quit message from: ", initiator->id);
                 canal.shut();
@@ -3536,7 +3536,7 @@ namespace netxs::ui
             };
             LISTEN(tier::release, e2::conio::quit, msg, tokens)
             {
-                this->SIGNAL(tier::preview, e2::form::quit, this->This());
+                this->SIGNAL(tier::preview, e2::form::proceed::quit::one, this->This());
                 log("gate: ", msg);
                 canal.shut();
                 paint.stop();

--- a/src/netxs/desktopio/console.hpp
+++ b/src/netxs/desktopio/console.hpp
@@ -3616,9 +3616,10 @@ namespace netxs::ui
             }
             if (direct) // Forward unhandled events outside.
             {
-                LISTEN(tier::release, e2::form::layout::minimize, state, tokens)
+                LISTEN(tier::release, e2::form::layout::minimize, gear, tokens)
                 {
-                    conio.minimize.send(canal, state);
+                    auto [ext_gear_id, gear_ptr] = input.get_foreign_gear_id(gear.id);
+                    if (gear_ptr) conio.minimize.send(canal, ext_gear_id);
                 };
                 LISTEN(tier::release, hids::events::mouse::scroll::any, gear, tokens, (isvtm))
                 {

--- a/src/netxs/desktopio/console.hpp
+++ b/src/netxs/desktopio/console.hpp
@@ -1259,7 +1259,7 @@ namespace netxs::ui
                         auto iter = gears.find(gear.id);
                         if (iter != gears.end())
                         {
-                            if constexpr (debugmode) log("gears cleanup boss:", boss.id, " hid:", gear.id);
+                            //if constexpr (debugmode) log("foci: gears cleanup boss:", boss.id, " hid:", gear.id);
                             auto& route = iter->second;
                             auto  token = std::move(route.token);
                             if (route.active) // Keep only the active branch.
@@ -1295,7 +1295,7 @@ namespace netxs::ui
                 auto fire = [&](auto id)
                 {
                     item_ptr->RISEUP(tier::preview, hids::events::keybd::focus::set, seed, ({ .id = id, .solo = (si32)s, .flip = (bool)f, .skip = skip }));
-                    if constexpr (debugmode) log("foci: focus set gear:", seed.id, " item:", item_ptr->id);
+                    //if constexpr (debugmode) log("foci: focus set gear:", seed.id, " item:", item_ptr->id);
                 };
                 if constexpr (std::is_same_v<id_t, std::decay_t<T>>) fire(gear_id);
                 else                    for (auto next_id : gear_id) fire(next_id);
@@ -1306,7 +1306,7 @@ namespace netxs::ui
                 auto fire = [&](auto id)
                 {
                     item_ptr->RISEUP(tier::preview, hids::events::keybd::focus::off, seed, ({ .id = id }));
-                    if constexpr (debugmode) log("foci: focus off gear:", seed.id, " item:", item_ptr->id);
+                    //if constexpr (debugmode) log("foci: focus off gear:", seed.id, " item:", item_ptr->id);
                 };
                 if constexpr (std::is_same_v<id_t, std::decay_t<T>>) fire(gear_id);
                 else                    for (auto next_id : gear_id) fire(next_id);
@@ -1315,7 +1315,7 @@ namespace netxs::ui
             {
                 item_ptr->RISEUP(tier::request, e2::form::state::keybd::enlist, gear_id_list, ());
                 pro::focus::off(item_ptr, gear_id_list);
-                if constexpr (debugmode) log("foci: full defocus item:", item_ptr->id);
+                //if constexpr (debugmode) log("foci: full defocus item:", item_ptr->id);
             }
             static auto get(sptr<base> item_ptr, bool remove_default = faux)
             {
@@ -1323,7 +1323,7 @@ namespace netxs::ui
                 for (auto next_id : gear_id_list)
                 {
                     item_ptr->RISEUP(tier::preview, hids::events::keybd::focus::get, seed, ({ .id = next_id }));
-                    if constexpr (debugmode) log("foci: focus get gear:", seed.id, " item:", item_ptr->id);
+                    //if constexpr (debugmode) log("foci: focus get gear:", seed.id, " item:", item_ptr->id);
                 }
                 if (remove_default)
                 if (auto parent = item_ptr->parent())
@@ -1365,7 +1365,7 @@ namespace netxs::ui
                 // Subscribe on keybd events.
                 boss.LISTEN(tier::preview, hids::events::keybd::data::post, gear, memo) // Run after keybd::data::any.
                 {
-                    if constexpr (debugmode) log("data::post gear:", gear.id, " hub:", boss.id, " gears.size:", gears.size());
+                    //if constexpr (debugmode) log("foci: data::post gear:", gear.id, " hub:", boss.id, " gears.size:", gears.size());
                     if (!gear) return;
                     auto& route = get_route(gear.id);
                     if (route.active)
@@ -1387,13 +1387,13 @@ namespace netxs::ui
                 {
                     auto& route = get_route(seed.id);
                     auto deed = boss.bell::template protos<tier::release>();
-                    if constexpr (debugmode) log(text(seed.deep++ * 4, ' '), "---bus::any gear:", seed.id, " hub:", boss.id);
+                    //if constexpr (debugmode) log("foci: ", text(seed.deep++ * 4, ' '), "---bus::any gear:", seed.id, " hub:", boss.id);
                     route.foreach([&](auto& nexthop){ nexthop->bell::template signal<tier::release>(deed, seed); });
-                    if constexpr (debugmode) log(text(--seed.deep * 4, ' '), "----------------");
+                    //if constexpr (debugmode) log("foci: ", text(--seed.deep * 4, ' '), "----------------");
                 };
                 boss.LISTEN(tier::release, hids::events::keybd::focus::bus::on, seed, memo)
                 {
-                    if constexpr (debugmode) log(text(seed.deep * 4, ' '), "bus::on gear:", seed.id, " hub:", boss.id, " gears.size:", gears.size());
+                    //if constexpr (debugmode) log("foci: ", text(seed.deep * 4, ' '), "bus::on gear:", seed.id, " hub:", boss.id, " gears.size:", gears.size());
                     auto iter = gears.find(seed.id);
                     if (iter == gears.end())
                     {
@@ -1422,11 +1422,11 @@ namespace netxs::ui
                         boss.SIGNAL(tier::release, e2::form::state::keybd::focus::off, seed.id);
                         signal_state<faux>();
                     }
-                    if constexpr (debugmode) log(text(seed.deep * 4, ' '), "bus::off gear:", seed.id, " hub:", boss.id);
+                    //if constexpr (debugmode) log("foci: ", text(seed.deep * 4, ' '), "bus::off gear:", seed.id, " hub:", boss.id);
                 };
                 boss.LISTEN(tier::release, hids::events::keybd::focus::bus::copy, seed, memo) // Copy default focus route if it is and activate it.
                 {
-                    if constexpr (debugmode) log(text(seed.deep * 4, ' '), "bus::copy gear:", seed.id, " hub:", boss.id);
+                    //if constexpr (debugmode) log("foci: ", text(seed.deep * 4, ' '), "bus::copy gear:", seed.id, " hub:", boss.id);
                     if (!gears.contains(seed.id)) // gears[seed.id] = gears[id_t{}]
                     {
                         auto def_route = gears.find(id_t{}); // Check if the default route is present.
@@ -3376,13 +3376,13 @@ namespace netxs::ui
                 }
 
                 auto deed = this->bell::template protos<tier::release>();
-                if constexpr (debugmode) log(text(seed.deep++ * 4, ' '), "---gate bus::any gear:", seed.id, " hub:", this->id);
+                //if constexpr (debugmode) log("foci: ", text(seed.deep++ * 4, ' '), "foci: ---gate bus::any gear:", seed.id, " hub:", this->id);
                 //if (auto target = local ? applet : base::parent())
                 if (auto target = nexthop.lock())
                 {
                     target->bell::template signal<tier::release>(deed, seed);
                 }
-                if constexpr (debugmode) log(text(--seed.deep * 4, ' '), "----------------gate");
+                //if constexpr (debugmode) log("foci: ", text(--seed.deep * 4, ' '), "foci: ----------------gate");
             };
             LISTEN(tier::preview, hids::events::keybd::focus::cut, seed, tokens)
             {

--- a/src/netxs/desktopio/console.hpp
+++ b/src/netxs/desktopio/console.hpp
@@ -3491,6 +3491,7 @@ namespace netxs::ui
             };
             LISTEN(tier::release, e2::conio::winsz, newsize, tokens)
             {
+                if (applet) applet->SIGNAL(tier::anycast, e2::form::upon::resize, newsize);
                 auto delta = base::resize(newsize);
                 if (delta && direct)
                 if (auto world_ptr = base::parent())
@@ -3499,9 +3500,9 @@ namespace netxs::ui
                     rebuild_scene(*world_ptr, true);
                 }
             };
-            LISTEN(tier::release, e2::size::any, newsz, tokens)
+            LISTEN(tier::release, e2::size::any, newsize, tokens)
             {
-                if (applet) applet->base::resize(newsz);
+                if (applet) applet->base::resize(newsize);
             };
             LISTEN(tier::release, e2::conio::pointer, pointer, tokens)
             {
@@ -3615,6 +3616,10 @@ namespace netxs::ui
             }
             if (direct) // Forward unhandled events outside.
             {
+                LISTEN(tier::release, e2::form::layout::minimize, state, tokens)
+                {
+                    conio.minimize.send(canal, state);
+                };
                 LISTEN(tier::release, hids::events::mouse::scroll::any, gear, tokens, (isvtm))
                 {
                     auto [ext_gear_id, gear_ptr] = input.get_foreign_gear_id(gear.id);

--- a/src/netxs/desktopio/consrv.hpp
+++ b/src/netxs/desktopio/consrv.hpp
@@ -1039,7 +1039,7 @@ struct consrv
                         }
                     }
                 }
-                buffer.clear();
+                buffer.clear(); // Don't try to catch the next events (we are too fast for IME input; ~1ms between events from IME). 
             }
             while (cooked.ustr.empty() && ((void)signal.wait(lock, [&]{ return buffer.size() || closed || cancel; }), !closed && !cancel));
 

--- a/src/netxs/desktopio/consrv.hpp
+++ b/src/netxs/desktopio/consrv.hpp
@@ -907,7 +907,10 @@ struct consrv
                                         {
                                             line.lyric->utf8(cooked.ustr);
                                             cooked.ustr.push_back('\r');
-                                            cooked.ustr.push_back('\n');
+                                            if (server.inpmod & nt::console::inmode::preprocess)
+                                            {
+                                                cooked.ustr.push_back('\n');
+                                            }
                                         }
                                         else
                                         {
@@ -985,7 +988,7 @@ struct consrv
                         using erase = std::decay_t<decltype(server.uiterm)>::commands::erase;
                         term.el(erase::line::wraps);
 
-                        if (done && crlf)
+                        if (done && crlf && server.inpmod & nt::console::inmode::preprocess) // On PROCESSED_INPUT + ECHO_INPUT only.
                         {
                             term.cr();
                             term.lf(crlf);
@@ -2213,6 +2216,7 @@ struct consrv
             "\n\tnamesize: ", namesize,
             "\n\tnameview: ", utf::debase(utf::to_utf(nameview)),
             "\n\treadstep: ", readstep,
+            "\n\treadstop: 0x", utf::to_hex(packet.input.stops),
             "\n\tinitdata: ", ansi::hi(packet.input.utf16 ? utf::debase<faux, faux>(utf::to_utf(wiew((wchr*)initdata.data(), initdata.size() / 2)))
                             : inpenc->codepage == CP_UTF8 ? utf::debase<faux, faux>(initdata)
                                                           : utf::debase<faux, faux>(toUTF8)));

--- a/src/netxs/desktopio/consrv.hpp
+++ b/src/netxs/desktopio/consrv.hpp
@@ -2229,7 +2229,7 @@ struct consrv
     }
     auto api_events_count_get                ()
     {
-        log(prompt, "GetNumberOfInputEvents");
+        log(prompt, "GetNumberOfConsoleInputEvents");
         struct payload : drvpacket<payload>
         {
             struct

--- a/src/netxs/desktopio/consrv.hpp
+++ b/src/netxs/desktopio/consrv.hpp
@@ -1210,7 +1210,7 @@ struct consrv
 
         xcod(ui32 cp)
             : codepage{ CP_UTF8 },
-              lostbyte{         }
+              lastbyte{         }
         {
             load(cp);
         }

--- a/src/netxs/desktopio/consrv.hpp
+++ b/src/netxs/desktopio/consrv.hpp
@@ -2922,7 +2922,7 @@ struct consrv
                 auto recs = wrap<char>::cast(buffer, count);
                 if (codec.codepage == CP_UTF8)
                 {
-                    count = std::min<si32>(count, toUTF8.size());
+                    count = std::min(count, (si32)toUTF8.size());
                     toUTF8.resize(count);
                     std::copy(toUTF8.begin(), toUTF8.end(), recs.begin());
                     log("\treply data: ", ansi::hi(utf::debase<faux, faux>(toUTF8)));
@@ -2932,7 +2932,7 @@ struct consrv
                     toANSI.clear();
                     auto utf8 = netxs::view{ toUTF8 };
                     codec.encode(utf8, toANSI, count);
-                    count = std::min<si32>(count, toANSI.size());
+                    count = std::min(count, (si32)toANSI.size());
                     std::copy(toANSI.begin(), toANSI.end(), recs.begin());
                     log("\treply data: ", ansi::hi(utf::debase<faux, faux>(outenc->decode_log(toANSI))));
                 }
@@ -2943,7 +2943,7 @@ struct consrv
                 toWIDE.clear();
                 utf::to_utf(toUTF8, toWIDE);
                 auto recs = wrap<wchr>::cast(buffer, count);
-                count = std::min<si32>(count, toWIDE.size());
+                count = std::min(count, (si32)toWIDE.size());
                 toWIDE.resize(count);
                 std::copy(toWIDE.begin(), toWIDE.end(), recs.begin());
                 log("\treply data: ", ansi::hi(utf::debase<faux, faux>(utf::to_utf(recs))));

--- a/src/netxs/desktopio/consrv.hpp
+++ b/src/netxs/desktopio/consrv.hpp
@@ -2821,15 +2821,23 @@ struct consrv
                 log("\tfiller: ", ansi::hi(utf::debase<faux, faux>(toUTF8)));
                 auto c = cell{ toUTF8 };
                 auto w = c.wdt();
-                if (w == 1 || w == 2)
+                if ((si32)count > maxsz) count = std::max(0, maxsz);
+                count *= w;
+                filler.kill();
+                filler.size(count, c);
+                if (w == 2)
                 {
-                    if ((si32)count > maxsz) count = std::max(0, maxsz);
-                    filler.kill();
-                    filler.size(count / w, c);
-                    if (!direct(packet.target, [&](auto& scrollback) { scrollback._data(count, filler.pick(), cell::shaders::text); }))
+                    auto head = filler.iter();
+                    auto tail = filler.iend();
+                    while (head != tail)
                     {
-                        count = 0;
+                        (++head)->wdt(3);
+                        (++head);
                     }
+                }
+                if (!direct(packet.target, [&](auto& scrollback) { scrollback._data(count, filler.pick(), cell::shaders::text); }))
+                {
+                    count = 0;
                 }
             }
         }

--- a/src/netxs/desktopio/consrv.hpp
+++ b/src/netxs/desktopio/consrv.hpp
@@ -1155,8 +1155,10 @@ struct consrv
 
     struct xcod
     {
-        std::array<byte, 256> leadbyte; // xcod: .
-        ui32                  codepage; // xcod: .
+        using buff = std::array<byte, 256>;
+        ui32 codepage; // xcod: .
+        byte lastbyte; // xcod: .
+        buff leadbyte; // xcod: .
 
         auto load(ui32 cp)
         {
@@ -1166,6 +1168,7 @@ struct consrv
             if (os::ok(::GetCPInfo(cp, &data), "::GetCPInfo()", os::unexpected_msg))
             {
                 codepage = cp;
+                lastbyte = {};
                 auto head = std::begin(data.LeadByte);
                 auto tail = std::end(data.LeadByte);
                 while (head != tail)
@@ -1189,12 +1192,25 @@ struct consrv
         {
             // ::MultiByteToWideChar() + utf::to_utf()
             // utf::to_utf() + ::WideCharToMultiByte()
+            if (lastbyte)
+            {
+                ;;;
+            }
+            utf8 += toANSI;
+            if (toANSI.size()) log("page: ", codepage, " lead:", test(toANSI.back())? "lead":"single");
+        }
+        auto encode(view toANSI, text& utf8)
+        {
+            // ::MultiByteToWideChar() + utf::to_utf()
+            // utf::to_utf() + ::WideCharToMultiByte()
+            if (lastbyte) ;;;
             utf8 += toANSI;
             if (toANSI.size()) log("page: ", codepage, " lead:", test(toANSI.back())? "lead":"single");
         }
 
         xcod(ui32 cp)
-            : codepage{ CP_UTF8 }
+            : codepage{ CP_UTF8 },
+              lostbyte{         }
         {
             load(cp);
         }

--- a/src/netxs/desktopio/consrv.hpp
+++ b/src/netxs/desktopio/consrv.hpp
@@ -1107,13 +1107,8 @@ struct consrv
         {
             auto lock = std::lock_guard{ locker };
             auto& inpenc = *server.inpenc;
-            if (utf16)
+            if (utf16 || inpenc.codepage == CP_UTF8) // Store UTF-8 as is (I see no reason to decode).
             {
-                buffer.insert(buffer.end(), recs.begin(), recs.end());
-            }
-            else if (inpenc.codepage == CP_UTF8)
-            {
-                //todo inpenc: UTF-8 to UTF-16
                 buffer.insert(buffer.end(), recs.begin(), recs.end());
             }
             else

--- a/src/netxs/desktopio/consrv.hpp
+++ b/src/netxs/desktopio/consrv.hpp
@@ -1608,7 +1608,7 @@ struct consrv
     {
         if (wdt >= 2)
         {
-            attr |= (wdt - 1) << 8; // Apply COMMON_LVB_LEADING_BYTE / COMMON_LVB_TRAILING_BYTE;
+            attr |= (wdt - 1) << 8; // Apply COMMON_LVB_LEADING_BYTE / COMMON_LVB_TRAILING_BYTE.
         }
     }
     template<class RecType, feed Input, class T>

--- a/src/netxs/desktopio/consrv.hpp
+++ b/src/netxs/desktopio/consrv.hpp
@@ -2901,7 +2901,7 @@ struct consrv
                     mark = src;
                 }
                 dst = attr;
-                set_half(src.wdt(), dst);
+                //set_half(src.wdt(), dst);
             }
             answer.send_data(condrv, recs);
         }
@@ -2922,7 +2922,7 @@ struct consrv
                 auto recs = wrap<char>::cast(buffer, count);
                 if (codec.codepage == CP_UTF8)
                 {
-                    count = std::min<size_t>(count, toUTF8.size());
+                    count = std::min<si32>(count, toUTF8.size());
                     toUTF8.resize(count);
                     std::copy(toUTF8.begin(), toUTF8.end(), recs.begin());
                     log("\treply data: ", ansi::hi(utf::debase<faux, faux>(toUTF8)));
@@ -2932,7 +2932,7 @@ struct consrv
                     toANSI.clear();
                     auto utf8 = netxs::view{ toUTF8 };
                     codec.encode(utf8, toANSI, count);
-                    count = std::min<size_t>(count, toANSI.size());
+                    count = std::min<si32>(count, toANSI.size());
                     std::copy(toANSI.begin(), toANSI.end(), recs.begin());
                     log("\treply data: ", ansi::hi(utf::debase<faux, faux>(outenc->decode_log(toANSI))));
                 }
@@ -2943,7 +2943,7 @@ struct consrv
                 toWIDE.clear();
                 utf::to_utf(toUTF8, toWIDE);
                 auto recs = wrap<wchr>::cast(buffer, count);
-                count = std::min<size_t>(count, toWIDE.size());
+                count = std::min<si32>(count, toWIDE.size());
                 toWIDE.resize(count);
                 std::copy(toWIDE.begin(), toWIDE.end(), recs.begin());
                 log("\treply data: ", ansi::hi(utf::debase<faux, faux>(utf::to_utf(recs))));
@@ -3014,7 +3014,7 @@ struct consrv
                     auto wdt = src.wdt();
                     if (wdt != 3) dst.Char.UnicodeChar = toWIDE.size() ? toWIDE.front() : ' ';
                     else          dst.Char.UnicodeChar = toWIDE.size() > 1 ? toWIDE[1]  : ' ';
-                    set_half(wdt, dst.Attributes);
+                    //set_half(wdt, dst.Attributes);
                 });
             }
             else
@@ -3032,7 +3032,7 @@ struct consrv
                         }
                         auto utf8 = src.txt();
                         auto wdt = src.wdt();
-                        set_half(wdt, attr);
+                        //set_half(wdt, attr);
                         dst.Char.AsciiChar = utf8.size() ? utf8.front() : ' ';
                     });
                 }

--- a/src/netxs/desktopio/controls.hpp
+++ b/src/netxs/desktopio/controls.hpp
@@ -1116,7 +1116,7 @@ namespace netxs::ui
 
         auto& lyric(si32 paraid) { return *topic[paraid].lyric; }
         auto& content(si32 paraid) { return topic[paraid]; }
-        auto upload(view utf8, si32 initial_width = 0)
+        auto upload(view utf8, si32 initial_width = 0) // Don't use cell link id here. Apply it to the parent (with a whole rect coverage).
         {
             source = utf8;
             topic = utf8;

--- a/src/netxs/desktopio/controls.hpp
+++ b/src/netxs/desktopio/controls.hpp
@@ -230,9 +230,6 @@ namespace netxs::ui
     {
         enum class action { seize, drag, release };
 
-        static constexpr auto max_ratio = si32{ 0xFFFF      };
-        static constexpr auto mid_ratio = si32{ 0xFFFF >> 1 };
-
         sptr client_1; // fork: 1st object.
         sptr client_2; // fork: 2nd object.
         sptr splitter; // fork: Resizing grip.
@@ -280,9 +277,17 @@ namespace netxs::ui
         }
 
     public:
+        static constexpr auto min_ratio = si32{ 0           };
+        static constexpr auto max_ratio = si32{ 0xFFFF      };
+        static constexpr auto mid_ratio = si32{ 0xFFFF >> 1 };
+
         auto get_ratio()
         {
             return ratio;
+        }
+        auto set_ratio(si32 new_ratio = max_ratio)
+        {
+            ratio = new_ratio;
         }
         void config(si32 s1, si32 s2 = 1)
         {

--- a/src/netxs/desktopio/controls.hpp
+++ b/src/netxs/desktopio/controls.hpp
@@ -898,7 +898,7 @@ namespace netxs::ui
         }
         // park: Create a new item of the specified subtype and attach it.
         template<class T>
-        auto attach(snap hz, snap vt, T item_ptr)
+        auto attach(T item_ptr, snap hz, snap vt)
         {
             subset.push_back({ item_ptr, hz, vt, true });
             item_ptr->SIGNAL(tier::release, e2::form::upon::vtree::attached, This());

--- a/src/netxs/desktopio/directvt.hpp
+++ b/src/netxs/desktopio/directvt.hpp
@@ -658,6 +658,7 @@ namespace netxs::directvt
         STRUCT_macro(warping,           (id_t, window_id) (dent, warpdata))
         STRUCT_macro(vt_command,        (text, command))
         STRUCT_macro(logs,              (ui32, id) (time, guid) (text, data))
+        STRUCT_macro(minimize,          (bool, state))
         STRUCT_macro_lite(expose)
         // Input stream.
         STRUCT_macro(focusbus,          (id_t, gear_id) (time, guid) (hint, cause))
@@ -932,6 +933,7 @@ namespace netxs::directvt
             X(form_header      ) /* Set window title.                             */\
             X(form_footer      ) /* Set window footer.                            */\
             X(warping          ) /* Warp resize.                                  */\
+            X(minimize         ) /* Minimize window.                              */\
             X(expose           ) /* Bring the form to the front.                  */\
             X(vt_command       ) /* Parse following vt-sequences in UTF-8 format. */\
             X(frames           ) /* Received frames.                              */\

--- a/src/netxs/desktopio/directvt.hpp
+++ b/src/netxs/desktopio/directvt.hpp
@@ -658,7 +658,7 @@ namespace netxs::directvt
         STRUCT_macro(warping,           (id_t, window_id) (dent, warpdata))
         STRUCT_macro(vt_command,        (text, command))
         STRUCT_macro(logs,              (ui32, id) (time, guid) (text, data))
-        STRUCT_macro(minimize,          (bool, state))
+        STRUCT_macro(minimize,          (id_t, gear_id))
         STRUCT_macro_lite(expose)
         // Input stream.
         STRUCT_macro(focusbus,          (id_t, gear_id) (time, guid) (hint, cause))

--- a/src/netxs/desktopio/generics.hpp
+++ b/src/netxs/desktopio/generics.hpp
@@ -923,10 +923,10 @@ namespace netxs
         }
     }
     template<class Map, class Key, class FBKey>
-    auto& map_or(Map& map, Key const& key, FBKey const& fallback)
+    auto& map_or(Map& map, Key const& key, FBKey const& fallback) // Note: The map must contain a fallback.
     {
         auto const it = map.find(key);
-        return it == map.end() ? map[fallback]
+        return it == map.end() ? map.at(fallback)
                                : it->second;
     }
 }

--- a/src/netxs/desktopio/generics.hpp
+++ b/src/netxs/desktopio/generics.hpp
@@ -37,9 +37,11 @@ namespace netxs::generics
         static constexpr auto sigbit = unsigned{ 1 << (std::numeric_limits<Item>::digits - 1) };
 
     public:
+        static constexpr auto skip = unsigned{ 0x3fff'ffff };
         static inline bool issub(Item const& value) { return (value & subbit) != (value & sigbit) >> 1; }
         static inline auto desub(Item const& value) { return static_cast<Item>((value & ~subbit) | (value & sigbit) >> 1); }
         static inline auto insub(Item const& value) { return static_cast<Item>((value & ~subbit) | ((value & sigbit) ^ sigbit) >> 1); }
+        static inline auto isdef(Item const& value) { return (value & fifo::skip) == fifo::skip; }
 
         static auto& fake() { static fifo empty; return empty; }
 
@@ -88,9 +90,18 @@ namespace netxs::generics
                 item++;
             }
         }
-        constexpr size_t   length ()    const             { return size;                }
-        constexpr operator bool   ()    const             { return size;                }
-        constexpr Item     front  (Item const& dflt = {}) { return size ? *item : dflt; }
+        constexpr operator bool () const { return size; }
+        constexpr auto length() const { return size; }
+        constexpr Item front(Item const& dflt = {})
+        {
+            if (size)
+            {
+                auto value = *item;
+                return isdef(value) ? issub(value) ? insub(dflt) : dflt
+                                    : value;
+            }
+            else return dflt;
+        }
         constexpr
         Item operator () (Item const& dflt = {})
         {
@@ -98,7 +109,8 @@ namespace netxs::generics
             {
                 size--;
                 auto result = *item++;
-                return issub(result) ? desub(result)
+                return isdef(result) ? dflt :
+                       issub(result) ? desub(result)
                                      : result;
             }
             else return dflt;
@@ -129,7 +141,7 @@ namespace netxs::generics
                 {
                     size--;
                     item++;
-                    return desub(result);
+                    return isdef(result) ? dflt : desub(result);
                 }
                 else return dflt;
             }

--- a/src/netxs/desktopio/geometry.hpp
+++ b/src/netxs/desktopio/geometry.hpp
@@ -206,6 +206,7 @@ namespace netxs
         }
         bool operator == (rect const&) const = default;
         explicit operator bool ()              const { return size.x != 0 && size.y != 0;       }
+        auto   center          ()              const { return coor + size / 2;                  }
         auto   area            ()              const { return size.x * size.y;                  }
         twod   map             (twod const& p) const { return p - coor;                         }
         rect   shift           (twod const& p) const { return { coor + p, size };               }

--- a/src/netxs/desktopio/input.hpp
+++ b/src/netxs/desktopio/input.hpp
@@ -1001,7 +1001,7 @@ namespace netxs::input
         }
         void take(sysfocus& f)
         {
-            if constexpr (debugmode) log("take focus hid:", id, " state:", f.state ? "on":"off");
+            //if constexpr (debugmode) log("foci: take focus hid:", id, " state:", f.state ? "on":"off");
             //todo focus<->seed
             if (f.state) owner.SIGNAL(tier::release, hids::events::focus::set, *this);
             else         owner.SIGNAL(tier::release, hids::events::focus::off, *this);

--- a/src/netxs/desktopio/intmath.hpp
+++ b/src/netxs/desktopio/intmath.hpp
@@ -32,6 +32,7 @@ namespace netxs
 
     constexpr size_t operator "" _sz (unsigned long long i)	{ return i; }
     static constexpr auto maxsi32 = std::numeric_limits<si32>::max();
+    static constexpr auto maxui32 = std::numeric_limits<ui32>::max();
     static constexpr auto debugmode
         #if defined(_DEBUG)
         = true;

--- a/src/netxs/desktopio/intmath.hpp
+++ b/src/netxs/desktopio/intmath.hpp
@@ -554,8 +554,8 @@ namespace netxs
     // intmath: Intersect two sprites and
     //          invoking handle(sprite1_element, sprite2_element)
     //          for each elem in the intersection.
-    template<bool RtoL, class T, class D, class R, class C, class P>
-    void inbody(T& canvas, D const& bitmap, R const& region, C const& base2, P handle)
+    template<bool RtoL, class T, class D, class R, class C, class P, class NewlineFx = noop>
+    void inbody(T& canvas, D const& bitmap, R const& region, C const& base2, P handle, NewlineFx online = NewlineFx())
     {
         auto& base1 = region.coor;
 
@@ -588,6 +588,7 @@ namespace netxs
             }
             data1 += skip1;
             data2 += skip2;
+            online();
         }
     }
 
@@ -612,8 +613,8 @@ namespace netxs
     // intmath: Intersect two sprites and invoking
     //          handle(sprite1_element, sprite2_element)
     //          for each elem in the intersection.
-    template<class T, class D, class P>
-    void onbody(T& canvas, D const& bitmap, P handle)
+    template<class T, class D, class P, class NewlineFx = noop>
+    void onbody(T& canvas, D const& bitmap, P handle, NewlineFx online = NewlineFx())
     {
         auto& rect1 = canvas.area();
         auto& rect2 = bitmap.area();
@@ -623,7 +624,7 @@ namespace netxs
             auto basis = joint.coor - rect2.coor;
             joint.coor-= rect1.coor;
 
-            inbody<faux>(canvas, bitmap, joint, basis, handle);
+            inbody<faux>(canvas, bitmap, joint, basis, handle, online);
         }
     }
 

--- a/src/netxs/desktopio/system.hpp
+++ b/src/netxs/desktopio/system.hpp
@@ -1915,22 +1915,19 @@ namespace netxs::os
             #if defined(_WIN32)
 
                 auto handle = ::GetCurrentProcess();
-                auto buffer = std::vector<char>(MAX_PATH);
-
+                auto buffer = wide(MAX_PATH, 0);
                 while (buffer.size() <= 32768)
                 {
-                    auto length = ::GetModuleFileNameEx(handle,         // hProcess
-                                                        NULL,           // hModule
-                                                        buffer.data(),  // lpFilename
-                                     static_cast<DWORD>(buffer.size()));// nSize
+                    auto length = ::GetModuleFileNameExW(handle,         // hProcess
+                                                         NULL,           // hModule
+                                                         buffer.data(),  // lpFilename
+                                      static_cast<DWORD>(buffer.size()));// nSize
                     if (length == 0) break;
-
                     if (buffer.size() > length + 1)
                     {
-                        result = text(buffer.data(), length);
+                        result = utf::to_utf(buffer.data(), length);
                         break;
                     }
-
                     buffer.resize(buffer.size() << 1);
                 }
 

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -443,19 +443,22 @@ namespace netxs::ui
             // w_tracking: Get terminal window property.
             auto& get(text const& property)
             {
-                return props[property];
+                auto& utf8 = props[property];
+                if (property == ansi::osc_title)
+                {
+                    owner.RISEUP(tier::request, e2::form::prop::ui::header, utf8);
+                }
+                return utf8;
             }
             // w_tracking: Set terminal window property.
             void set(text const& property, qiew txt)
             {
                 if (txt.empty()) txt = owner.cmdarg; // Deny empty titles.
-                static const auto jet_left = ansi::jet(bias::left);
                 owner.target->flush();
                 if (property == ansi::osc_label_title)
                 {
                                   props[ansi::osc_label] = txt;
                     auto& utf8 = (props[ansi::osc_title] = txt);
-                    utf8 = jet_left + utf8;
                     owner.RISEUP(tier::preview, e2::form::prop::ui::header, utf8);
                 }
                 else
@@ -463,7 +466,6 @@ namespace netxs::ui
                     auto& utf8 = (props[property] = txt);
                     if (property == ansi::osc_title)
                     {
-                        utf8 = jet_left + utf8;
                         owner.RISEUP(tier::preview, e2::form::prop::ui::header, utf8);
                     }
                 }

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -7378,7 +7378,11 @@ namespace netxs::ui
                 auto& m = lock.thing;
                 netxs::events::enqueue(owner.This(), [&](auto& boss)
                 {
-                    owner.RISEUP(tier::release, e2::form::layout::minimize, m.state);
+                    if (auto gear_ptr = bell::getref<hids>(m.gear_id))
+                    {
+                        auto& gear = *gear_ptr;
+                        owner.RISEUP(tier::release, e2::form::layout::minimize, gear);
+                    }
                 });
             }
             void handle(s11n::xs::expose              lock)

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -838,7 +838,7 @@ namespace netxs::ui
                 vt.intro[ctrl::esc][esc_pm    ] = V{ p->msg(esc_pm , q); }; // ESC ^ ... ST  PM.
 
                 vt.intro[ctrl::bs ] = V{ p->cub(q.pop_all(ctrl::bs )); };
-                vt.intro[ctrl::del] = V{ p->del(q.pop_all(ctrl::del)); };
+                vt.intro[ctrl::del] = V{ p->del(q.pop_all(ctrl::del)); }; // Move backward and delete character under cursor with wrapping.
                 vt.intro[ctrl::tab] = V{ p->tab(q.pop_all(ctrl::tab)); };
                 vt.intro[ctrl::eol] = V{ p->lf (q.pop_all(ctrl::eol)); }; // LF
                 vt.intro[ctrl::vt ] = V{ p->lf (q.pop_all(ctrl::vt )); }; // VT same as LF

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -7373,6 +7373,14 @@ namespace netxs::ui
                     }
                 });
             }
+            void handle(s11n::xs::minimize            lock)
+            {
+                auto& m = lock.thing;
+                netxs::events::enqueue(owner.This(), [&](auto& boss)
+                {
+                    owner.RISEUP(tier::release, e2::form::layout::minimize, m.state);
+                });
+            }
             void handle(s11n::xs::expose              lock)
             {
                 netxs::events::enqueue(owner.This(), [&](auto& boss)

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -6454,7 +6454,7 @@ namespace netxs::ui
                 {
                     netxs::events::enqueue(This(), [&](auto& boss)
                     {
-                        this->SIGNAL(tier::preview, e2::form::quit, This()); //todo VS2019 requires `this`
+                        this->SIGNAL(tier::preview, e2::form::proceed::quit::one, This()); //todo VS2019 requires `this`
                     });
                 };
                 auto chose_proc = [&]
@@ -7648,7 +7648,7 @@ namespace netxs::ui
             netxs::events::enqueue(This(), [&](auto& boss)
             {
                 //this->SIGNAL(tier::preview, e2::config::plugins::sizer::alive, faux); //todo VS2019 requires `this`
-                this->SIGNAL(tier::preview, e2::form::quit, This()); //todo VS2019 requires `this`
+                this->SIGNAL(tier::preview, e2::form::proceed::quit::one, This()); //todo VS2019 requires `this`
             });
         }
         // dtvt: Shutdown callback handler.

--- a/src/netxs/desktopio/utf.hpp
+++ b/src/netxs/desktopio/utf.hpp
@@ -814,7 +814,7 @@ namespace netxs::utf
     }
     void to_utf(wchr const* wide_text, size_t size, text& utf8)
     {
-        utf8.reserve(utf8.size() + (size << 2));
+        utf8.reserve(utf8.size() + size * 3/*worst case*/);
         auto code = utfx{ 0 };
         auto tail = wide_text + size;
         while (wide_text < tail)

--- a/src/netxs/desktopio/utf.hpp
+++ b/src/netxs/desktopio/utf.hpp
@@ -60,7 +60,6 @@ namespace netxs::utf
               cpcount { 0    },
               cdpoint { 0    }
         { }
-
         prop(utfx code, size_t size)
             : unidata ( code ),
               utf8len { size },
@@ -68,7 +67,6 @@ namespace netxs::utf
               cpcount { 0    },
               cdpoint { code }
         { }
-
         constexpr
         prop(prop const& attr)
             : unidata (attr),
@@ -756,6 +754,25 @@ namespace netxs::utf
         }
         return code;
     }
+    // Return faux only on first part of surrogate pair.
+    inline bool tocode(wchr c, utfx& code)
+    {
+        auto first_part = c >= 0xd800 && c <= 0xdbff;
+        if (first_part) // First part of surrogate pair.
+        {
+            code = ((c - 0xd800) << 10) + 0x10000;
+        }
+        else
+        {
+            if (c >= 0xdc00 && c <= 0xdfff) // Second part of surrogate pair.
+            {
+                if (code) code |= c - 0xdc00;
+                else      code = utf::replacement_code; // Broken pair.
+            }
+            else code = c;
+        }
+        return !first_part;
+    }
 
     namespace
     {
@@ -1072,6 +1089,13 @@ namespace netxs::utf
                 utf8.resize(dest - base);
             }
         }
+    }
+    template<class W, class R>
+    auto change(view utf8, W const& what, R const& replace)
+    {
+        auto crop = text{ utf8 };
+        change(crop, what, replace);
+        return crop;
     }
 
     template<class TextOrView, class T>

--- a/src/vtm.cpp
+++ b/src/vtm.cpp
@@ -283,10 +283,10 @@ int main(int argc, char* argv[])
                 });
             }
         }
+        logger->stop(); // Logger must be stopped first to prevent reconnection.
         domain->SIGNAL(tier::general, e2::conio::quit, "main: server shutdown");
         events::dequeue();
         domain->shutdown();
-        logger->stop();
         stdlog.join();
     }
 }

--- a/src/vtm.hpp
+++ b/src/vtm.hpp
@@ -130,6 +130,10 @@ namespace netxs::app::vtm
                 boss.SIGNAL(tier::preview, e2::form::prop::ui::header, newhead);
                 boss.SIGNAL(tier::preview, e2::form::prop::ui::footer, newfoot);
 
+                boss.LISTEN(tier::preview, e2::form::quit, boss_ptr, memo)
+                {
+                    unbind(type::full);
+                };
                 boss.LISTEN(tier::release, e2::size::any, size, memo, (pads))
                 {
                     what.applet->base::resize(size + pads);
@@ -138,9 +142,13 @@ namespace netxs::app::vtm
                 {
                     if (memo) unbind();
                 };
-                boss.LISTEN(tier::preview, e2::form::quit, boss_ptr, memo)
+                window_ptr->LISTEN(tier::release, e2::form::layout::minimize, gear, memo)
                 {
-                    unbind(type::full);
+                    if (memo)
+                    {
+                        what.applet->bell::expire<tier::release>(); // Suppress minimization.
+                        unbind();
+                    }
                 };
                 window_ptr->LISTEN(tier::release, e2::form::quit, any_ptr, memo)
                 {

--- a/src/vtm.hpp
+++ b/src/vtm.hpp
@@ -771,8 +771,7 @@ namespace netxs::app::vtm
 
                     if (item_ptr)
                     {
-                        auto& area = item_ptr->area();
-                        auto center = area.coor + (area.size / 2);
+                        auto center = item_ptr->center();
                         this->SIGNAL(tier::release, e2::form::layout::shift, center);
                         pro::focus::set(item_ptr, gear.id, pro::focus::solo::on, pro::focus::flip::off);
                     }
@@ -815,7 +814,7 @@ namespace netxs::app::vtm
             LISTEN(tier::release, e2::form::layout::shift, newpos, tokens)
             {
                 this->SIGNAL(tier::request, e2::form::prop::viewport, viewport, ());
-                auto oldpos = viewport.coor + (viewport.size / 2);
+                auto oldpos = viewport.center();
 
                 auto path = oldpos - newpos;
                 auto time = skin::globals().switching;
@@ -966,7 +965,7 @@ namespace netxs::app::vtm
             void fasten(face& canvas)
             {
                 auto window = canvas.area();
-                auto center = region.coor + region.size / 2;
+                auto center = region.center();
                 if (window.hittest(center)) return;
                 auto origin = window.size / 2;
                 center -= window.coor;
@@ -1219,15 +1218,16 @@ namespace netxs::app::vtm
                                 parent->SIGNAL(tier::request, e2::form::state::keybd::next, gear_test, (gear.id, 0));
                                 if (gear_test.second == 1) // If it is the last focused item.
                                 {
-                                    auto next = e2::form::layout::goprev.param();
+                                    auto viewport = gear.owner.base::area();
+                                    auto window = e2::form::layout::goprev.param();
                                     do
                                     {
-                                        parent->SIGNAL(tier::request, e2::form::layout::goprev, next);
+                                        parent->SIGNAL(tier::request, e2::form::layout::goprev, window);
                                     }
-                                    while (next->size().y == 1 && next != This);
-                                    if (next != This)
+                                    while (window != This && (window->size().y == 1 || !viewport.hittest(window->center())));
+                                    if (window != This)
                                     {
-                                        pro::focus::set(next, gear.id, pro::focus::solo::on, pro::focus::flip::off);
+                                        pro::focus::set(window, gear.id, pro::focus::solo::on, pro::focus::flip::off);
                                         This.reset();
                                     }
                                 }
@@ -1247,11 +1247,10 @@ namespace netxs::app::vtm
                     };
                     boss.LISTEN(tier::release, hids::events::mouse::button::click::left, gear)
                     {
-                        auto area = boss.base::area();
-                        auto home = rect{ -dot_21, area.size + dot_21 * 2}; // Including resizer grips.
+                        auto home = rect{ -dot_21, boss.base::size() + dot_21 * 2 }; // Including resizer grips.
                         if (!home.hittest(gear.coord))
                         {
-                            auto center = area.coor + (area.size / 2);
+                            auto center = boss.base::center();
                             gear.owner.SIGNAL(tier::release, e2::form::layout::shift, center);
                             boss.base::deface();
                         }

--- a/src/vtm.hpp
+++ b/src/vtm.hpp
@@ -1198,28 +1198,31 @@ namespace netxs::app::vtm
                     };
                     boss.LISTEN(tier::release, e2::form::layout::minimize, gear, -, (size_state = dot_11, min_size = dot_00))
                     {
+                        auto This = boss.This();
                         auto size = boss.base::size();
                         if (size.y == min_size.y)
                         {
                             boss.base::resize({ size.x, size_state.y });
-                            pro::focus::set(boss.This(), gear.id, gear.meta(hids::anyCtrl) ? pro::focus::solo::off
-                                                                                           : pro::focus::solo::on, pro::focus::flip::off, true);
+                            pro::focus::set(This, gear.id, gear.meta(hids::anyCtrl) ? pro::focus::solo::off
+                                                                                    : pro::focus::solo::on, pro::focus::flip::off, true);
                         }
                         else
                         {
                             size_state = size;
                             boss.base::resize({ size.x, 1 });
                             min_size = boss.base::size();
-                            if (auto parent = boss.parent()) // Pass focus to the next desktop window.
+                            // Refocusing.
+                            boss.RISEUP(tier::request, e2::form::state::keybd::find, gear_test, (gear.id, 0));
+                            if (auto parent = boss.parent())
+                            if (gear_test.second) // If it is focused pass the focus to the next desktop window.
                             {
-                                auto This = boss.This();
                                 parent->SIGNAL(tier::request, e2::form::state::keybd::next, gear_test, (gear.id, 0));
                                 if (gear_test.second == 1) // If it is the last focused item.
                                 {
-                                    auto next = e2::form::layout::gonext.param();
+                                    auto next = e2::form::layout::goprev.param();
                                     do
                                     {
-                                        parent->SIGNAL(tier::request, e2::form::layout::gonext, next);
+                                        parent->SIGNAL(tier::request, e2::form::layout::goprev, next);
                                     }
                                     while (next->size().y == 1 && next != This);
                                     if (next != This)

--- a/src/vtm.hpp
+++ b/src/vtm.hpp
@@ -1192,6 +1192,25 @@ namespace netxs::app::vtm
                             what.menuid = menuid;
                         }
                     };
+                    boss.LISTEN(tier::release, e2::size::any, new_size)
+                    {
+                        boss.SIGNAL(tier::anycast, e2::form::upon::resize, new_size);
+                    };
+                    boss.LISTEN(tier::release, e2::form::layout::minimize, minimize_state, -, (size_state = dot_11, min_size = dot_00))
+                    {
+                        auto size = boss.base::size();
+                        if (minimize_state == (size.y == min_size.y)) minimize_state = !minimize_state;
+                        if (size.y == min_size.y)
+                        {
+                            boss.base::resize({ size.x, size_state.y });
+                        }
+                        else
+                        {
+                            size_state = size;
+                            boss.base::resize({ size.x, 1 });
+                            min_size = boss.base::size();
+                        }
+                    };
                     boss.LISTEN(tier::release, e2::form::prop::ui::header, title)
                     {
                         auto tooltip = " " + title + " ";

--- a/src/vtm.xml
+++ b/src/vtm.xml
@@ -98,7 +98,7 @@ R"==(
             <fps      = 60   />
             <bordersz = 1,1  />
             <lucidity = 0xff /> <!-- not implemented -->
-            <tracking = on   /> <!-- Mouse cursor highlighting. -->
+            <tracking = off  /> <!-- Mouse cursor highlighting. -->
             <brighter   fgc=purewhite bgc=purewhite alpha=60 /> <!-- Highlighter. -->
             <kb_focus   fgc=bluelt    bgc=bluelt    alpha=60 /> <!-- Keyboard focus indicator. -->
             <shadower   bgc=0xB4202020 />                       <!-- Darklighter. -->
@@ -171,10 +171,10 @@ R"==(
             </preview>
         </clipboard>
         <mouse dblclick=500ms/>
-        <tooltip timeout=500ms enabled=true fgc=pureblack bgc=purewhite/>
+        <tooltips timeout=2000ms enabled=true fgc=pureblack bgc=purewhite/>
         <glowfx=true/>                      <!-- Show glow effect around selected item. -->
-        <debug overlay=faux toggle="🐞"/>  <!-- Display console debug info. -->
-        <regions enabled=faux/>             <!-- Highlight UI objects boundaries. -->
+        <debug overlay=off toggle="🐞"/>  <!-- Display console debug info. -->
+        <regions enabled=0/>             <!-- Highlight UI objects boundaries. -->
     </client>
     <term>      <!-- Base configuration for the Term app. It can be partially overridden by the menu item's config subarg. -->
         <scrollback>
@@ -274,7 +274,7 @@ R"==(
         </menu>
         <selection>
             <mode="text"/> <!-- text | ansi | rich | html | protected | none -->
-            <rect=faux/>  <!-- Preferred selection form: Rectangular: true, Linear false. -->
+            <rect=false/>  <!-- Preferred selection form: Rectangular: true, Linear: false. -->
         </selection>
         <atexit = auto/>  <!-- auto:    Stay open and ask if exit code != 0. (default)
                                ask:     Stay open and ask.
@@ -288,7 +288,7 @@ R"==(
     </term>
     <defapp>
         <menu>
-            <autohide=faux/>
+            <autohide=off/>
             <enabled="on"/>
             <slim=true/>
         </menu>

--- a/src/vtm.xml
+++ b/src/vtm.xml
@@ -98,6 +98,7 @@ R"==(
             <fps      = 60   />
             <bordersz = 1,1  />
             <lucidity = 0xff /> <!-- not implemented -->
+            <tracking = on   /> <!-- Mouse cursor highlighting. -->
             <brighter   fgc=purewhite bgc=purewhite alpha=60 /> <!-- Highlighter. -->
             <kb_focus   fgc=bluelt    bgc=bluelt    alpha=60 /> <!-- Keyboard focus indicator. -->
             <shadower   bgc=0xB4202020 />                       <!-- Darklighter. -->


### PR DESCRIPTION
Changes
- Terminal
  - Code pages support on Windows #175
  - Fix Alt+Numpad input on Windows #375
- Minimization by right click on window menu #376
- Add missing '-static' option to CMakeLists.txt notes #378
- VT-parser: Handle the case with color space parameter: `\x1b[38:2::255:255:255:::m`===`\x1b[38:2:255:255:255m`
- Add an option to disable mouse cursor tracking #379
- Disable mouse cursor highlighting by default and increase tooltip timeout to 2s #212
- Reword configuration section name `<config/client/tooltip/>` to `<...tooltips/>`
- Stability improvements

Closes #175
Closes #375
Closes #376
Closes #379