### PR TITLE
Fix `ReadConsole` and `ReadConsoleInput` on Windows

### DIFF
--- a/.resources/status/freebsd.svg
+++ b/.resources/status/freebsd.svg
@@ -18,8 +18,8 @@
     <text x="1000" y="140" transform="scale(.1)" text-anchor="end"
     >FreeBSD amd64</text>
     <text x="1230" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" text-anchor="start"
-    >v0.9.9k</text>
+    >v0.9.9l</text>
     <text x="1230" y="140" transform="scale(.1)" text-anchor="start"
-    >v0.9.9k</text>
+    >v0.9.9l</text>
   </g>
 </svg>

--- a/.resources/status/linux.svg
+++ b/.resources/status/linux.svg
@@ -18,8 +18,8 @@
     <text x="1000" y="140" transform="scale(.1)" text-anchor="end"
     >Linux amd64</text>
     <text x="1230" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" text-anchor="start"
-    >v0.9.9k</text>
+    >v0.9.9l</text>
     <text x="1230" y="140" transform="scale(.1)" text-anchor="start"
-    >v0.9.9k</text>
+    >v0.9.9l</text>
   </g>
 </svg>

--- a/.resources/status/macos.svg
+++ b/.resources/status/macos.svg
@@ -18,8 +18,8 @@
     <text x="1000" y="140" transform="scale(.1)" text-anchor="end"
     >macOS any</text>
     <text x="1230" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" text-anchor="start"
-    >v0.9.9k</text>
+    >v0.9.9l</text>
     <text x="1230" y="140" transform="scale(.1)" text-anchor="start"
-    >v0.9.9k</text>
+    >v0.9.9l</text>
   </g>
 </svg>

--- a/.resources/status/netbsd.svg
+++ b/.resources/status/netbsd.svg
@@ -18,8 +18,8 @@
     <text x="1000" y="140" transform="scale(.1)" text-anchor="end"
     >NetBSD amd64</text>
     <text x="1230" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" text-anchor="start"
-    >v0.9.9k</text>
+    >v0.9.9l</text>
     <text x="1230" y="140" transform="scale(.1)" text-anchor="start"
-    >v0.9.9k</text>
+    >v0.9.9l</text>
   </g>
 </svg>

--- a/.resources/status/openbsd.svg
+++ b/.resources/status/openbsd.svg
@@ -18,8 +18,8 @@
     <text x="1000" y="140" transform="scale(.1)" text-anchor="end"
     >OpenBSD amd64</text>
     <text x="1230" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" text-anchor="start"
-    >v0.9.9k</text>
+    >v0.9.9l</text>
     <text x="1230" y="140" transform="scale(.1)" text-anchor="start"
-    >v0.9.9k</text>
+    >v0.9.9l</text>
   </g>
 </svg>

--- a/.resources/status/windows.svg
+++ b/.resources/status/windows.svg
@@ -18,8 +18,8 @@
     <text x="1000" y="140" transform="scale(.1)" text-anchor="end"
     >Windows amd64</text>
     <text x="1230" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" text-anchor="start"
-    >v0.9.9k</text>
+    >v0.9.9l</text>
     <text x="1230" y="140" transform="scale(.1)" text-anchor="start"
-    >v0.9.9k</text>
+    >v0.9.9l</text>
   </g>
 </svg>

--- a/src/netxs/apps.hpp
+++ b/src/netxs/apps.hpp
@@ -453,7 +453,7 @@ namespace netxs::app::shared
         };
         auto build_ANSIVT        = [](text cwd, text param, xmls& config, text patch)
         {
-            if (param.empty()) log("apps: nothing to run, use 'type=SHELL' to run instance without arguments");
+            if (param.empty()) log(prompt::apps, "Nothing to run, use 'type=SHELL' to run instance without arguments");
 
             auto args = os::process::binary();
             if (args.find(' ') != text::npos) args = "\"" + args + "\"";

--- a/src/netxs/apps/calc.cpp
+++ b/src/netxs/apps/calc.cpp
@@ -30,13 +30,13 @@ int main(int argc, char* argv[])
             cfpath = getopt.next();
             if (cfpath.empty())
             {
-                errmsg = "config file path not specified";
+                errmsg = "Config file path not specified";
                 break;
             }
         }
         else if (getopt.match("-?", "-h", "--help"))
         {
-            errmsg = ansi::nil().add("show help message");
+            errmsg = ansi::nil().add("Show help message");
             break;
         }
         else if (getopt.match("-v", "--version"))
@@ -50,7 +50,7 @@ int main(int argc, char* argv[])
         }
         else
         {
-            errmsg = utf::concat("unknown option '", getopt.next(), "'");
+            errmsg = utf::concat("Unknown option '", getopt.next(), "'");
             break;
         }
     }
@@ -86,7 +86,7 @@ int main(int argc, char* argv[])
         if (result) return 0;
         else
         {
-            log("main: app initialization error");
+            log(prompt::main, "App initialization error");
             return 1;
         }
     }

--- a/src/netxs/apps/calc.hpp
+++ b/src/netxs/apps/calc.hpp
@@ -192,7 +192,7 @@ namespace netxs::ui
                     data = " =SUM(" + ansi::fgc(bluedk).add(data).fgc(blacklt).add(")");
                 }
                 else data = " =SUM(" + ansi::itc(true).fgc(reddk).add("select cells by dragging").itc(faux).fgc(blacklt).add(")");
-                log("calc: DATA ", data, ansi::nil());
+                log(prompt::calc, "DATA ", data, ansi::nil());
                 boss.SIGNAL(tier::release, e2::data::utf8, data);
             }
             // pro::cell_highlight: Configuring the mouse button to operate.

--- a/src/netxs/apps/desk.hpp
+++ b/src/netxs/apps/desk.hpp
@@ -331,13 +331,13 @@ namespace netxs::app::desk
             auto user_info = utf::divide(v, ";");
             if (user_info.size() < 2)
             {
-                log("desk: bad window arguments: args=", utf::debase(v));
+                log(prompt::desk, "Bad window arguments: args=", utf::debase(v));
                 return window;
             }
             auto& user_id___view = user_info[0];
             auto& user_name_view = user_info[1];
             auto& menu_selected  = user_info[2];
-            log("desk: id: ", user_id___view, ", user name: ", user_name_view);
+            log(prompt::desk, "Id: ", user_id___view, ", user name: ", user_name_view);
 
             if (auto value = utf::to_int(user_id___view)) my_id = value.value();
             else return window;
@@ -579,7 +579,7 @@ namespace netxs::app::desk
                     {
                         boss.LISTEN(tier::release, hids::events::mouse::button::click::left, gear)
                         {
-                            gear.owner.SIGNAL(tier::preview, e2::conio::quit, "taskbar: logout by button");
+                            gear.owner.SIGNAL(tier::preview, e2::conio::quit, msg, (utf::concat(prompt::desk, "Logout by button")));
                             gear.dismiss();
                         };
                     });
@@ -592,7 +592,7 @@ namespace netxs::app::desk
                     {
                         boss.LISTEN(tier::release, hids::events::mouse::button::click::left, gear)
                         {
-                            boss.SIGNAL(tier::general, e2::shutdown, "desk: server shutdown");
+                            boss.SIGNAL(tier::general, e2::shutdown, msg, (utf::concat(prompt::desk, "Server shutdown")));
                         };
                     });
                 auto shutdown_area = shutdown_park->attach(ui::pads::ctor(dent{ 2,3,1,1 }), snap::tail, snap::center);

--- a/src/netxs/apps/term.cpp
+++ b/src/netxs/apps/term.cpp
@@ -30,13 +30,13 @@ int main(int argc, char* argv[])
             cfpath = getopt.next();
             if (cfpath.empty())
             {
-                errmsg = "config file path not specified";
+                errmsg = "Config file path not specified";
                 break;
             }
         }
         else if (getopt.match("-?", "-h", "--help"))
         {
-            errmsg = ansi::nil().add("show help message");
+            errmsg = ansi::nil().add("Show help message");
             break;
         }
         else if (getopt.match("-v", "--version"))
@@ -50,7 +50,7 @@ int main(int argc, char* argv[])
         }
         else
         {
-            errmsg = utf::concat("unknown option '", getopt.next(), "'");
+            errmsg = utf::concat("Unknown option '", getopt.next(), "'");
             break;
         }
     }
@@ -86,7 +86,7 @@ int main(int argc, char* argv[])
         if (result) return 0;
         else
         {
-            log("main: app initialization error");
+            log(prompt::main, "App initialization error");
             return 1;
         }
     }

--- a/src/netxs/apps/term.hpp
+++ b/src/netxs/apps/term.hpp
@@ -611,7 +611,7 @@ namespace netxs::app::term
             }
             if (item.views.empty())
             {
-                log(ansi::err("term: menu item without label"));
+                log(ansi::err(prompt::term, "Menu item without label"));
                 continue;
             }
             auto setup = [route](ui::pads& boss, menu::item& item)

--- a/src/netxs/apps/tile.hpp
+++ b/src/netxs/apps/tile.hpp
@@ -157,7 +157,7 @@ namespace netxs::app::tile
                 client->clear();
                 depth = 0;
                 boss.template riseup<tier::request>(e2::depth, depth, true);
-                log("tile: start depth=", depth);
+                log(prompt::tile, "Start depth ", depth);
             };
         }
        ~items()
@@ -540,7 +540,7 @@ namespace netxs::app::tile
                     {
                         if (boss.count() == 1) // Only empty slot available.
                         {
-                            log("tile: empty_slot swap: defective structure, count=", boss.count());
+                            if constexpr (debugmode) log(prompt::tile, "Empty slot swap: defective structure, count=", boss.count());
                         }
                         else if (boss.count() == 2)
                         {
@@ -553,7 +553,10 @@ namespace netxs::app::tile
                             else item_ptr = boss.This();
                             pro::focus::set(boss.back(), gear_id_list, pro::focus::solo::off, pro::focus::flip::off);
                         }
-                        else log("tile: empty_slot swap: defective structure, count=", boss.count());
+                        else
+                        {
+                            if constexpr (debugmode) log(prompt::tile, "Empty slot swap: defective structure, count=", boss.count());
+                        }
                     };
                     boss.LISTEN(tier::release, e2::form::upon::vtree::attached, parent)
                     {
@@ -572,7 +575,10 @@ namespace netxs::app::tile
                                     item_ptr = boss.pop_back();
                                     pro::focus::set(boss.back(), gear_id_list, pro::focus::solo::off, pro::focus::flip::off);
                                 }
-                                else log("tile: empty_slot: defective structure, count=", boss.count());
+                                else
+                                {
+                                    if constexpr (debugmode) log(prompt::tile, "Empty slot: defective structure, count=", boss.count());
+                                }
                                 if (auto parent = boss.parent())
                                 {
                                     parent->bell::template expire<tier::request>();
@@ -640,7 +646,7 @@ namespace netxs::app::tile
                         {
                             auto depth = e2::depth.param();
                             boss.template riseup<tier::request>(e2::depth, depth, true);
-                            if constexpr (debugmode) log("tile: depth=", depth);
+                            if constexpr (debugmode) log(prompt::tile, "Depth ", depth);
                             if (depth > inheritance_limit) return;
 
                             auto heading = deed == app::tile::events::ui::split::vt.id;
@@ -718,7 +724,7 @@ namespace netxs::app::tile
                         config.applet->LISTEN(tier::release, e2::dtor, id)
                         {
                             insts_count--;
-                            log("tile: inst: detached: ", insts_count, " id=", id);
+                            if constexpr (debugmode) log(prompt::tile, "Instance detached: id:", id, "; left:", insts_count);
                         };
 
                         app->SIGNAL(tier::anycast, e2::form::upon::started, app);
@@ -949,8 +955,8 @@ namespace netxs::app::tile
             {
                 auto err = std::error_code{};
                 fs::current_path(cwd, err);
-                if (err) log("tile: failed to change current working directory to '", cwd, "', error code: ", err.value());
-                else     log("tile: change current working directory to '", cwd, "'");
+                if (err) log(prompt::tile, "Failed to change current working directory to '", cwd, "', error code: ", err.value());
+                else     log(prompt::tile, "Change current working directory to '", cwd, "'");
             }
 
             object->attach(slot::_2, parse_data(parse_data, param, ui::fork::min_ratio))
@@ -974,7 +980,7 @@ namespace netxs::app::tile
                             boss.attach(fullscreen_item);
                             fullscreen_item.reset();
                         }
-                        else log("tile: fullscreen_item is empty");
+                        else log(prompt::tile, "Fullscreen item is empty");
                     };
                     boss.LISTEN(tier::anycast, app::tile::events::ui::any, gear)
                     {
@@ -998,11 +1004,11 @@ namespace netxs::app::tile
                                 });
                                 boss.SIGNAL(tier::general, e2::form::proceed::functor, proc);
                                 auto slots_count = empty_slot_list.size();
-                                log("tile: slots count=", slots_count);
+                                log(prompt::tile, "Slots count:", slots_count);
                                 if (slots_count >= 2) // Swap selected panes cyclically.
                                 {
                                     using slot = sptr<base>;
-                                    log("tile: Swap slots cyclically");
+                                    log(prompt::tile, "Swap slots cyclically");
                                     auto i = 0;
                                     auto emp_slot = slot{};
                                     auto app_slot = slot{};

--- a/src/netxs/desktopio/application.hpp
+++ b/src/netxs/desktopio/application.hpp
@@ -21,7 +21,7 @@ namespace netxs::app
 
 namespace netxs::app::shared
 {
-    static const auto version = "v0.9.9k";
+    static const auto version = "v0.9.9l";
     static const auto desktopio = "desktopio";
     static const auto logsuffix = "_log";
     static const auto usr_config = "~/.config/vtm/settings.xml";

--- a/src/netxs/desktopio/application.hpp
+++ b/src/netxs/desktopio/application.hpp
@@ -430,8 +430,7 @@ namespace netxs::app::shared
                   "   type = Group    \n"
                   "   type = Region   \n\n"
                 + ansi::nil().wrp(wrap::on).fgc(whitelt)
-                + "apps: See logs for details."
-                );
+                 .add(prompt::apps, "See logs for details."));
             auto placeholder = ui::park::ctor()
                 ->colors(whitelt, rgba{ 0x7F404040 })
                 ->attach(msg, snap::stretch, snap::stretch);
@@ -443,7 +442,7 @@ namespace netxs::app::shared
         const auto it = map.find(app_typename);
         if (it == map.end())
         {
-            log("apps: unknown app type - '", app_typename, "'");
+            log(prompt::apps, "Unknown app type - '", app_typename, "'");
             return empty;
         }
         else return it->second;
@@ -454,7 +453,6 @@ namespace netxs::app::shared
         auto settings(view defaults, view cli_config_path, view patch)
         {
             auto conf = xmls{ defaults };
-            auto pads = "      ";
             auto load = [&](view shadow)
             {
                 if (shadow.empty()) return faux;
@@ -469,18 +467,18 @@ namespace netxs::app::shared
                     }
                     else
                     {
-                        log("apps: failed to get configuration from :", shadow);
+                        log(prompt::apps, "Failed to get configuration from :", shadow);
                         return faux;
                     }
                 }
                 auto path = text{ shadow };
-                log("apps: loading configuration from ", path, "...");
+                log(prompt::apps, "Loading configuration from ", path, "...");
                 if (path.starts_with("$"))
                 {
                     auto temp = path.substr(1);
                     path = os::env::get(temp);
                     if (path.empty()) return faux;
-                    log(pads, temp, " = ", path);
+                    log(prompt::pads, temp, " = ", path);
                 }
                 auto config_path = path.starts_with("~") ? os::env::homepath() / path.substr(2 /* trim `~/` */)
                                                          : fs::path{ path };
@@ -493,12 +491,12 @@ namespace netxs::app::shared
                     auto file = std::ifstream(config_file.path(), std::ios::binary | std::ios::in);
                     if (file.seekg(0, std::ios::end).fail())
                     {
-                        log(pads, "failed\n\tunable to get configuration file size, skip it: ", config_path_str);
+                        log(prompt::pads, "Failed\n\tUnable to get configuration file size, skip it: ", config_path_str);
                         return faux;
                     }
                     else
                     {
-                        log(pads, "reading configuration: ", config_path_str);
+                        log(prompt::pads, "Reading configuration: ", config_path_str);
                         auto size = file.tellg();
                         auto buff = text(size, '\0');
                         file.seekg(0, std::ios::beg);
@@ -507,14 +505,14 @@ namespace netxs::app::shared
                         return true;
                     }
                 }
-                log(pads, "no configuration found, try another source");
+                log(prompt::pads, "No configuration found, try another source");
                 return faux;
             };
             if (!load(cli_config_path)
              && !load(app::shared::env_config)
              && !load(app::shared::usr_config))
             {
-                log(pads, "fallback to hardcoded configuration");
+                log(prompt::pads, "Fallback to hardcoded configuration");
             }
 
             os::env::set(app::shared::env_config.substr(1)/*remove $*/, conf.document->page.file);

--- a/src/netxs/desktopio/baseui.hpp
+++ b/src/netxs/desktopio/baseui.hpp
@@ -1111,7 +1111,7 @@ namespace netxs::ui
         // base: Initiate redrawing.
         virtual void redraw(face& canvas)
         {
-            SIGNAL(tier::general, e2::shutdown, "base: rendering is not provided");
+            SIGNAL(tier::general, e2::shutdown, msg, (utf::concat(prompt::base, "Rendering not supported")));
         }
         // base: Syntax sugar helper.
         void _saveme()

--- a/src/netxs/desktopio/baseui.hpp
+++ b/src/netxs/desktopio/baseui.hpp
@@ -43,7 +43,7 @@ namespace netxs::events::userland
             EVENT_XS( postrender, ui::face       ), // release: UI-tree post-rendering. Draw debug overlay, maker, titles, etc.
             EVENT_XS( nextframe , bool           ), // general: Signal for rendering the world, the parameter indicates whether the world has been modified since the last rendering.
             EVENT_XS( depth     , si32           ), // request: Determine the depth of the hierarchy.
-            EVENT_XS( shutdown  , const view     ), // general: Server shutdown.
+            EVENT_XS( shutdown  , const text     ), // general: Server shutdown.
             GROUP_XS( extra     , si32           ), // Event extension slot.
             GROUP_XS( timer     , time           ), // timer tick, arg: current moment (now).
             GROUP_XS( render    , ui::face       ), // release: UI-tree rendering.
@@ -140,7 +140,6 @@ namespace netxs::events::userland
             };
             SUBSET_XS( command )
             {
-                EVENT_XS( quit       , const view  ), // return bye msg, arg: errcode.
                 EVENT_XS( cout       , const text  ), // Append extra data to output.
                 EVENT_XS( custom     , si32        ), // Custom command, arg: cmd_id.
                 EVENT_XS( printscreen, input::hids ), // Copy screen area to clipboard.
@@ -1205,7 +1204,7 @@ namespace netxs::ui
         }
         friend auto& operator << (flux& s, pipe const& sock)
         {
-            return sock.show(s << "{ xipc: ") << " }";
+            return sock.show(s << "{ " << prompt::xipc) << " }";
         }
         friend auto& operator << (flux& s, xipc const& sock)
         {

--- a/src/netxs/desktopio/canvas.hpp
+++ b/src/netxs/desktopio/canvas.hpp
@@ -1396,7 +1396,7 @@ namespace netxs
                 template<class C> constexpr inline auto operator () (C brush) const { return func<C>(brush); }
                 template<class D, class S>  inline void operator () (D& dst, S& src) const { dst = src; }
             };
-            struct nonzero_t : public brush_t<nonzero_t>
+            struct skipnuls_t : public brush_t<skipnuls_t>
             {
                 template<class C> constexpr inline auto operator () (C brush) const { return func<C>(brush); }
                 template<class D, class S>  inline void operator () (D& dst, S& src) const { if (!src.isnul()) dst = src; }
@@ -1514,7 +1514,7 @@ namespace netxs
             static constexpr auto     fuse =     fuse_t{};
             static constexpr auto     flat =     flat_t{};
             static constexpr auto     full =     full_t{};
-            static constexpr auto  nonzero =  nonzero_t{};
+            static constexpr auto skipnuls = skipnuls_t{};
             static constexpr auto     text =     text_t{};
             static constexpr auto     meta =     meta_t{};
             static constexpr auto   xlight =   xlight_t{};

--- a/src/netxs/desktopio/console.hpp
+++ b/src/netxs/desktopio/console.hpp
@@ -1176,7 +1176,7 @@ namespace netxs::ui
             hook pong; // watch: Alibi subsciption token.
             hook ping; // watch: Zombie check countdown token.
             time stop; // watch: Timeout for zombies.
-            text desc = "no mouse clicking events";
+            text desc = "No mouse clicking events";
 
         public:
             watch(base&&) = delete;
@@ -2549,7 +2549,7 @@ namespace netxs::ui
             template<class Bitmap>
             void render()
             {
-                log(prompt::diff, "Id:", std::this_thread::get_id(), ' ', "rendering thread started");
+                log(prompt::diff, "Rendering thread started", ' ', utf::to_hex_0x(std::this_thread::get_id()));
                 auto start = time{};
                 auto image = Bitmap{};
                 auto guard = std::unique_lock{ mutex };
@@ -2569,7 +2569,7 @@ namespace netxs::ui
                     }
                     debug.watch = datetime::now() - start;
                 }
-                log(prompt::diff, "Id:", std::this_thread::get_id(), ' ', "rendering thread ended");
+                log(prompt::diff, "Rendering thread ended", ' ', utf::to_hex_0x(std::this_thread::get_id()));
             }
             // diff: Get rendering statistics.
             auto status()
@@ -2647,7 +2647,7 @@ namespace netxs::ui
                     std::this_thread::yield();
                 }
                 paint.join();
-                log(prompt::diff, "Id:", id, ' ', "rendering thread joined");
+                log(prompt::diff, "Rendering thread joined", ' ', utf::to_hex_0x(id));
             }
         };
 
@@ -3281,7 +3281,7 @@ namespace netxs::ui
         {
             SIGNAL(tier::anycast, e2::form::upon::started, This());
             directvt::binary::stream::reading_loop(canal, [&](view data){ conio.sync(data); });
-            SIGNAL(tier::release, e2::conio::quit, "exit from a stream reading loop");
+            SIGNAL(tier::release, e2::conio::quit, "DirectVT I/O session complete");
         }
 
     protected:
@@ -3456,7 +3456,7 @@ namespace netxs::ui
 
             LISTEN(tier::release, e2::form::proceed::quit::any, initiator, tokens)
             {
-                auto msg = ansi::add(prompt::gate, "Quit message from id:", initiator->id);
+                auto msg = utf::concat(prompt::gate, "Quit message from id:", initiator->id);
                 canal.shut();
                 this->SIGNAL(tier::general, e2::shutdown, msg);
             };
@@ -3551,7 +3551,7 @@ namespace netxs::ui
             };
             LISTEN(tier::general, e2::conio::quit, msg, tokens)
             {
-                log(prompt::gate, "Global shutdown: ", msg);
+                log(prompt::gate, msg);
                 canal.shut();
             };
             LISTEN(tier::anycast, e2::form::upon::started, item_ptr, tokens)
@@ -3575,12 +3575,12 @@ namespace netxs::ui
                     auto window_id = 0;
                     conio.form_header.send(canal, window_id, newheader);
                 }
-                else
+                else if (newheader.length())
                 {
                     auto temp = text{};
                     temp.reserve(newheader.length());
                     para{ newheader }.lyric->utf8(temp);
-                    log(prompt::gate, "Title changed to ", ansi::hi(utf::debase<faux, faux>(temp)));
+                    log(prompt::gate, "Console title changed to ", ansi::hi(utf::debase<faux, faux>(temp)));
                     conio.output(ansi::header(temp));
                 }
             };
@@ -3817,7 +3817,7 @@ namespace netxs::ui
             };
             LISTEN(tier::general, e2::shutdown, msg, tokens)
             {
-                log(prompt::host, "Shutdown: ", msg);
+                log(prompt::host, msg);
                 canal.stop();
             };
             LISTEN(tier::general, hids::events::device::user::login, props, tokens)
@@ -3834,7 +3834,7 @@ namespace netxs::ui
             };
 
             quartz.ignite(maxfps);
-            log(prompt::host, "Started at ", maxfps, "fps");
+            log(prompt::host, "Started at ", maxfps, " fps");
         }
         // host: Mark dirty region.
         void denote(rect const& updateregion)

--- a/src/netxs/desktopio/console.hpp
+++ b/src/netxs/desktopio/console.hpp
@@ -65,7 +65,7 @@ namespace netxs::ui
 
                     if constexpr (ConstWarn)
                     {
-                        log("sock: error: access to unregistered input device, ", gear.id);
+                        log(prompt::sock, "Access to unregistered input device, ", gear.id);
                     }
 
                     return items.emplace_back(gear.id);
@@ -1259,7 +1259,7 @@ namespace netxs::ui
                         auto iter = gears.find(gear.id);
                         if (iter != gears.end())
                         {
-                            //if constexpr (debugmode) log("foci: gears cleanup boss:", boss.id, " hid:", gear.id);
+                            //if constexpr (debugmode) log(prompt::foci, "Gears cleanup boss:", boss.id, " hid:", gear.id);
                             auto& route = iter->second;
                             auto  token = std::move(route.token);
                             if (route.active) // Keep only the active branch.
@@ -1295,7 +1295,7 @@ namespace netxs::ui
                 auto fire = [&](auto id)
                 {
                     item_ptr->RISEUP(tier::preview, hids::events::keybd::focus::set, seed, ({ .id = id, .solo = (si32)s, .flip = (bool)f, .skip = skip }));
-                    //if constexpr (debugmode) log("foci: focus set gear:", seed.id, " item:", item_ptr->id);
+                    //if constexpr (debugmode) log(prompt::foci, "Focus set gear:", seed.id, " item:", item_ptr->id);
                 };
                 if constexpr (std::is_same_v<id_t, std::decay_t<T>>) fire(gear_id);
                 else                    for (auto next_id : gear_id) fire(next_id);
@@ -1306,7 +1306,7 @@ namespace netxs::ui
                 auto fire = [&](auto id)
                 {
                     item_ptr->RISEUP(tier::preview, hids::events::keybd::focus::off, seed, ({ .id = id }));
-                    //if constexpr (debugmode) log("foci: focus off gear:", seed.id, " item:", item_ptr->id);
+                    //if constexpr (debugmode) log(prompt::foci, "Focus off gear:", seed.id, " item:", item_ptr->id);
                 };
                 if constexpr (std::is_same_v<id_t, std::decay_t<T>>) fire(gear_id);
                 else                    for (auto next_id : gear_id) fire(next_id);
@@ -1315,7 +1315,7 @@ namespace netxs::ui
             {
                 item_ptr->RISEUP(tier::request, e2::form::state::keybd::enlist, gear_id_list, ());
                 pro::focus::off(item_ptr, gear_id_list);
-                //if constexpr (debugmode) log("foci: full defocus item:", item_ptr->id);
+                //if constexpr (debugmode) log(prompt::foci, "Full defocus item:", item_ptr->id);
             }
             static auto get(sptr<base> item_ptr, bool remove_default = faux)
             {
@@ -1323,7 +1323,7 @@ namespace netxs::ui
                 for (auto next_id : gear_id_list)
                 {
                     item_ptr->RISEUP(tier::preview, hids::events::keybd::focus::get, seed, ({ .id = next_id }));
-                    //if constexpr (debugmode) log("foci: focus get gear:", seed.id, " item:", item_ptr->id);
+                    //if constexpr (debugmode) log(prompt::foci, "Focus get gear:", seed.id, " item:", item_ptr->id);
                 }
                 if (remove_default)
                 if (auto parent = item_ptr->parent())
@@ -1365,7 +1365,7 @@ namespace netxs::ui
                 // Subscribe on keybd events.
                 boss.LISTEN(tier::preview, hids::events::keybd::data::post, gear, memo) // Run after keybd::data::any.
                 {
-                    //if constexpr (debugmode) log("foci: data::post gear:", gear.id, " hub:", boss.id, " gears.size:", gears.size());
+                    //if constexpr (debugmode) log(prompt::foci, "data::post gear:", gear.id, " hub:", boss.id, " gears.size:", gears.size());
                     if (!gear) return;
                     auto& route = get_route(gear.id);
                     if (route.active)
@@ -1387,13 +1387,13 @@ namespace netxs::ui
                 {
                     auto& route = get_route(seed.id);
                     auto deed = boss.bell::template protos<tier::release>();
-                    //if constexpr (debugmode) log("foci: ", text(seed.deep++ * 4, ' '), "---bus::any gear:", seed.id, " hub:", boss.id);
+                    //if constexpr (debugmode) log(prompt::foci, text(seed.deep++ * 4, ' '), "---bus::any gear:", seed.id, " hub:", boss.id);
                     route.foreach([&](auto& nexthop){ nexthop->bell::template signal<tier::release>(deed, seed); });
-                    //if constexpr (debugmode) log("foci: ", text(--seed.deep * 4, ' '), "----------------");
+                    //if constexpr (debugmode) log(prompt::foci, text(--seed.deep * 4, ' '), "----------------");
                 };
                 boss.LISTEN(tier::release, hids::events::keybd::focus::bus::on, seed, memo)
                 {
-                    //if constexpr (debugmode) log("foci: ", text(seed.deep * 4, ' '), "bus::on gear:", seed.id, " hub:", boss.id, " gears.size:", gears.size());
+                    //if constexpr (debugmode) log(prompt::foci, text(seed.deep * 4, ' '), "bus::on gear:", seed.id, " hub:", boss.id, " gears.size:", gears.size());
                     auto iter = gears.find(seed.id);
                     if (iter == gears.end())
                     {
@@ -1422,11 +1422,11 @@ namespace netxs::ui
                         boss.SIGNAL(tier::release, e2::form::state::keybd::focus::off, seed.id);
                         signal_state<faux>();
                     }
-                    //if constexpr (debugmode) log("foci: ", text(seed.deep * 4, ' '), "bus::off gear:", seed.id, " hub:", boss.id);
+                    //if constexpr (debugmode) log(prompt::foci, text(seed.deep * 4, ' '), "bus::off gear:", seed.id, " hub:", boss.id);
                 };
                 boss.LISTEN(tier::release, hids::events::keybd::focus::bus::copy, seed, memo) // Copy default focus route if it is and activate it.
                 {
-                    //if constexpr (debugmode) log("foci: ", text(seed.deep * 4, ' '), "bus::copy gear:", seed.id, " hub:", boss.id);
+                    //if constexpr (debugmode) log(prompt::foci, text(seed.deep * 4, ' '), "bus::copy gear:", seed.id, " hub:", boss.id);
                     if (!gears.contains(seed.id)) // gears[seed.id] = gears[id_t{}]
                     {
                         auto def_route = gears.find(id_t{}); // Check if the default route is present.
@@ -2549,7 +2549,7 @@ namespace netxs::ui
             template<class Bitmap>
             void render()
             {
-                log("diff: id: ", std::this_thread::get_id(), " rendering thread started");
+                log(prompt::diff, "Id:", std::this_thread::get_id(), ' ', "Rendering thread started");
                 auto start = time{};
                 auto image = Bitmap{};
                 auto guard = std::unique_lock{ mutex };
@@ -2569,7 +2569,7 @@ namespace netxs::ui
                     }
                     debug.watch = datetime::now() - start;
                 }
-                log("diff: id: ", std::this_thread::get_id(), " rendering thread ended");
+                log(prompt::diff, "Id:", std::this_thread::get_id(), ' ', "Rendering thread ended");
             }
             // diff: Get rendering statistics.
             auto status()
@@ -2647,7 +2647,7 @@ namespace netxs::ui
                     std::this_thread::yield();
                 }
                 paint.join();
-                log("diff: id: ", id, " rendering thread joined");
+                log(prompt::diff, "Id:", id, ' ', "Rendering thread joined");
             }
         };
 
@@ -3377,13 +3377,13 @@ namespace netxs::ui
                 }
 
                 auto deed = this->bell::template protos<tier::release>();
-                //if constexpr (debugmode) log("foci: ", text(seed.deep++ * 4, ' '), "foci: ---gate bus::any gear:", seed.id, " hub:", this->id);
+                //if constexpr (debugmode) log(prompt::foci, text(seed.deep++ * 4, ' '), "---gate bus::any gear:", seed.id, " hub:", this->id);
                 //if (auto target = local ? applet : base::parent())
                 if (auto target = nexthop.lock())
                 {
                     target->bell::template signal<tier::release>(deed, seed);
                 }
-                //if constexpr (debugmode) log("foci: ", text(--seed.deep * 4, ' '), "foci: ----------------gate");
+                //if constexpr (debugmode) log(prompt::foci, text(--seed.deep * 4, ' '), "----------------gate");
             };
             LISTEN(tier::preview, hids::events::keybd::focus::cut, seed, tokens)
             {
@@ -3456,7 +3456,7 @@ namespace netxs::ui
 
             LISTEN(tier::release, e2::form::proceed::quit::any, initiator, tokens)
             {
-                auto msg = ansi::add("gate: quit message from: ", initiator->id);
+                auto msg = ansi::add(prompt::gate, "Quit message from id:", initiator->id);
                 canal.shut();
                 this->SIGNAL(tier::general, e2::shutdown, msg);
             };
@@ -3531,14 +3531,13 @@ namespace netxs::ui
             };
             LISTEN(tier::release, e2::conio::error, errcode, tokens)
             {
-                auto msg = ansi::bgc(reddk).fgc(whitelt).add("\n\rgate: Term error: ", errcode, "\r\n");
-                log("gate: error byemsg: ", msg);
+                log(prompt::gate, "Console error: ", errcode);
                 canal.shut();
             };
             LISTEN(tier::release, e2::conio::quit, msg, tokens)
             {
                 this->SIGNAL(tier::preview, e2::form::proceed::quit::one, this->This());
-                log("gate: ", msg);
+                log(prompt::gate, msg);
                 canal.shut();
                 paint.stop();
                 mouse.reset(); // Reset active mouse clients to avoid hanging pointers.
@@ -3547,12 +3546,12 @@ namespace netxs::ui
             };
             LISTEN(tier::preview, e2::conio::quit, msg, tokens)
             {
-                log("gate: ", msg);
+                log(prompt::gate, msg);
                 canal.shut();
             };
             LISTEN(tier::general, e2::conio::quit, msg, tokens)
             {
-                log("gate: global shutdown: ", msg);
+                log(prompt::gate, "Global shutdown: ", msg);
                 canal.shut();
             };
             LISTEN(tier::anycast, e2::form::upon::started, item_ptr, tokens)
@@ -3581,7 +3580,7 @@ namespace netxs::ui
                     auto temp = text{};
                     temp.reserve(newheader.length());
                     para{ newheader }.lyric->utf8(temp);
-                    log("gate: title changed to '", temp, ansi::nil().add("'"));
+                    log(prompt::gate, "Title changed to ", ansi::hi(utf::debase<faux, faux>(temp)));
                     conio.output(ansi::header(temp));
                 }
             };
@@ -3602,7 +3601,7 @@ namespace netxs::ui
                 auto [ext_gear_id, gear_ptr] = input.get_foreign_gear_id(myid);
                 if (gear_ptr && !conio.request_clip_data(ext_gear_id, gear_ptr->clip_rawdata))
                 {
-                    log("gate: timeout: no clipboard data reply");
+                    log(prompt::gate, "Timeout: no clipboard data reply");
                 }
             };
             LISTEN(tier::preview, hids::events::mouse::button::tplclick::leftright, gear, tokens)
@@ -3818,7 +3817,7 @@ namespace netxs::ui
             };
             LISTEN(tier::general, e2::shutdown, msg, tokens)
             {
-                log("host: shutdown: ", msg);
+                log(prompt::host, "Shutdown: ", msg);
                 canal.stop();
             };
             LISTEN(tier::general, hids::events::device::user::login, props, tokens)
@@ -3831,11 +3830,11 @@ namespace netxs::ui
             LISTEN(tier::general, hids::events::device::user::logout, props, tokens)
             {
                 if (props < user_numbering.size()) user_numbering[props] = faux;
-                else log(ansi::err("hall: user accounting error: ring size:", user_numbering.size(), " user_number:", props));
+                else log(ansi::err(prompt::host, "User accounting error: ring size:", user_numbering.size(), " user_number:", props));
             };
 
             quartz.ignite(maxfps);
-            log("host: started at ", maxfps, "fps");
+            log(prompt::host, "Started at ", maxfps, "fps");
         }
         // host: Mark dirty region.
         void denote(rect const& updateregion)

--- a/src/netxs/desktopio/console.hpp
+++ b/src/netxs/desktopio/console.hpp
@@ -2549,7 +2549,7 @@ namespace netxs::ui
             template<class Bitmap>
             void render()
             {
-                log(prompt::diff, "Id:", std::this_thread::get_id(), ' ', "Rendering thread started");
+                log(prompt::diff, "Id:", std::this_thread::get_id(), ' ', "rendering thread started");
                 auto start = time{};
                 auto image = Bitmap{};
                 auto guard = std::unique_lock{ mutex };
@@ -2569,7 +2569,7 @@ namespace netxs::ui
                     }
                     debug.watch = datetime::now() - start;
                 }
-                log(prompt::diff, "Id:", std::this_thread::get_id(), ' ', "Rendering thread ended");
+                log(prompt::diff, "Id:", std::this_thread::get_id(), ' ', "rendering thread ended");
             }
             // diff: Get rendering statistics.
             auto status()
@@ -2647,7 +2647,7 @@ namespace netxs::ui
                     std::this_thread::yield();
                 }
                 paint.join();
-                log(prompt::diff, "Id:", id, ' ', "Rendering thread joined");
+                log(prompt::diff, "Id:", id, ' ', "rendering thread joined");
             }
         };
 

--- a/src/netxs/desktopio/console.hpp
+++ b/src/netxs/desktopio/console.hpp
@@ -2440,6 +2440,11 @@ namespace netxs::ui
                 auto& item = lock.thing;
                 notify(e2::conio::clipdata, clip{ dot_00, item.data, static_cast<clip::mime>(item.mimetype) });
             }
+            void handle(s11n::xs::logs        lock)
+            {
+                auto& logs = lock.thing;
+                log(logs.data);
+            }
             void handle(s11n::xs::syskeybd    lock)
             {
                 auto& keybd = lock.thing;
@@ -3446,7 +3451,6 @@ namespace netxs::ui
                                                           gear.pressed,
                                                           gear.imitate,
                                                           gear.cluster,
-                                                          gear.winchar,
                                                           gear.handled);
                         }
                     }

--- a/src/netxs/desktopio/consrv.hpp
+++ b/src/netxs/desktopio/consrv.hpp
@@ -989,8 +989,6 @@ struct consrv
                         data.crop(line.length() + 1, zero); // To avoid pending cursor.
                         term.move(-coor);
                         term.data(data);
-                        using erase = std::decay_t<decltype(server.uiterm)>::commands::erase;
-                        term.el(erase::line::wraps);
 
                         if (done && crlf && server.inpmod & nt::console::inmode::preprocess) // On PROCESSED_INPUT + ECHO_INPUT only.
                         {

--- a/src/netxs/desktopio/consrv.hpp
+++ b/src/netxs/desktopio/consrv.hpp
@@ -825,11 +825,11 @@ struct consrv
                     {
                         if (rec.EventType == KEY_EVENT)
                         log(prompt::cin, ansi::hi(utf::debase<faux, faux>(utf::to_utf(rec.Event.KeyEvent.uChar.UnicodeChar))),
-                            " ", rec.Event.KeyEvent.bKeyDown ? "dn" : "up",
-                            " ctrl: 0x",  utf::to_hex(rec.Event.KeyEvent.dwControlKeyState),
-                            " char: 0x",  utf::to_hex(rec.Event.KeyEvent.uChar.UnicodeChar),
-                            " virt: 0x",  utf::to_hex(rec.Event.KeyEvent.wVirtualKeyCode),
-                            " scan: 0x",  utf::to_hex(rec.Event.KeyEvent.wVirtualScanCode),
+                            " ", rec.Event.KeyEvent.bKeyDown ? "Pressed " : "Released",
+                            " ctrl: ", utf::to_hex_0x(rec.Event.KeyEvent.dwControlKeyState),
+                            " char: ", utf::to_hex_0x(rec.Event.KeyEvent.uChar.UnicodeChar),
+                            " virt: ", utf::to_hex_0x(rec.Event.KeyEvent.wVirtualKeyCode),
+                            " scan: ", utf::to_hex_0x(rec.Event.KeyEvent.wVirtualScanCode),
                             " rept: ",                rec.Event.KeyEvent.wRepeatCount);
                     }
 
@@ -1962,7 +1962,7 @@ struct consrv
         { };
         auto& packet = payload::cast(upload);
         auto client_ptr = packet.client;
-        log(prompt, "Detach process from console: 0x", utf::to_hex(client_ptr));
+        log(prompt, "Detach process from console: ", utf::to_hex_0x(client_ptr));
         auto iter = std::find_if(joined.begin(), joined.end(), [&](auto& client){ return client_ptr == &client; });
         if (iter != joined.end())
         {
@@ -1971,7 +1971,7 @@ struct consrv
             for (auto& handle : client.tokens)
             {
                 auto handle_ptr = &handle;
-                log("\tdeactivate handle: 0x", utf::to_hex(handle_ptr));
+                log("\tdeactivate handle: ", utf::to_hex_0x(handle_ptr));
                 events.abort(handle_ptr);
             }
             uiterm.target->brush = client.backup;
@@ -1985,9 +1985,9 @@ struct consrv
             }
             client.tokens.clear();
             joined.erase(iter);
-            log("\tprocess 0x", utf::to_hex(client_ptr), " detached");
+            log("\tprocess ", utf::to_hex_0x(client_ptr), " detached");
         }
-        else log("\trequested process 0x", utf::to_hex(client_ptr), " not found");
+        else log("\trequested process ", utf::to_hex_0x(client_ptr), " not found");
     }
     auto api_process_enlist                  ()
     {
@@ -2347,7 +2347,7 @@ struct consrv
         auto& packet = payload::cast(upload);
         log(prompt, packet.input.flags & payload::peek ? "PeekConsoleInput"
                                                        : "ReadConsoleInput",
-            "\n\tinput.flags: ", utf::to_hex(packet.input.flags),
+            "\n\tinput.flags: 0x", utf::to_hex(packet.input.flags),
             "\n\t", show_page(packet.input.utf16, inpenc->codepage));
         auto client_ptr = packet.client;
         if (client_ptr == nullptr)
@@ -3353,7 +3353,7 @@ struct consrv
         log("\tbuffer size: ", buffsize);
         log("\tcursor coor: ", twod{ packet.input.cursorposx, packet.input.cursorposy });
         log("\twindow coor: ", twod{ packet.input.windowposx, packet.input.windowposy });
-        log("\tattributes : ", utf::to_hex(packet.input.attributes));
+        log("\tattributes : ", utf::to_hex_0x(packet.input.attributes));
         log("\twindow size: ", windowsz);
         log("\tmaxwin size: ", twod{ packet.input.maxwinsz_x, packet.input.maxwinsz_y });
         log("\tpopup color: ", packet.input.popupcolor);
@@ -4136,7 +4136,7 @@ struct consrv
                     default:                       log(prompt, "Unexpected nt::ioctl result ", rc); break;
                 }
             }
-            log(prompt, "Console server thread ended");
+            log(prompt, "Server thread ended");
         }};
     }
     void resize(twod const& newsize)
@@ -4149,7 +4149,7 @@ struct consrv
         signal.reset();
         if (window.joinable()) window.join();
         if (server.joinable()) server.join();
-        log(prompt, "Console server stopped");
+        log(prompt, "Console API server shut down");
     }
     template<class T>
     auto size_check(T upto, T from)

--- a/src/netxs/desktopio/consrv.hpp
+++ b/src/netxs/desktopio/consrv.hpp
@@ -824,7 +824,7 @@ struct consrv
                     if (server.io_log)
                     {
                         if (rec.EventType == KEY_EVENT)
-                        log(prompt::cinp, ansi::hi(utf::debase<faux, faux>(utf::to_utf(rec.Event.KeyEvent.uChar.UnicodeChar))),
+                        log(prompt::cin, ansi::hi(utf::debase<faux, faux>(utf::to_utf(rec.Event.KeyEvent.uChar.UnicodeChar))),
                             " ", rec.Event.KeyEvent.bKeyDown ? "dn" : "up",
                             " ctrl: 0x",  utf::to_hex(rec.Event.KeyEvent.dwControlKeyState),
                             " char: 0x",  utf::to_hex(rec.Event.KeyEvent.uChar.UnicodeChar),
@@ -4029,7 +4029,7 @@ struct consrv
     fd_t&       condrv; // consrv: Console driver handle.
     bool&       io_log; // consrv: Stdio logging state.
     evnt        events; // consrv: Input event list.
-    view        prompt; // consrv: Log prompt.
+    text        prompt; // consrv: Log prompt.
     list        joined; // consrv: Attached processes list.
     std::thread server; // consrv: Main thread.
     std::thread window; // consrv: Win32 window message loop.
@@ -4061,7 +4061,7 @@ struct consrv
             auto wndname = text{ "vtmConsoleWindowClass" };
             auto wndproc = [](auto hwnd, auto uMsg, auto wParam, auto lParam)
             {
-                ok<faux>(!debugmode, netxs::prompt::vtty, netxs::prompt::consrv, "GUI message: hwnd=0x", utf::to_hex(hwnd), " uMsg=0x", utf::to_hex(uMsg), " wParam=0x", utf::to_hex(wParam), " lParam=0x", utf::to_hex(lParam));
+                ok<faux>(!debugmode, netxs::prompt::win32, "GUI message: hwnd=0x", utf::to_hex(hwnd), " uMsg=0x", utf::to_hex(uMsg), " wParam=0x", utf::to_hex(wParam), " lParam=0x", utf::to_hex(lParam));
                 switch (uMsg)
                 {
                     case WM_CREATE: break;
@@ -4190,7 +4190,7 @@ struct consrv
           impcls{ faux   },
           answer{        },
           winhnd{        },
-          prompt{ utf::concat(netxs::prompt::vtty, netxs::prompt::consrv) },
+          prompt{ utf::concat(netxs::prompt::win32) },
           inpenc{ std::make_shared<decoder>(*this, os::codepage) },
           outenc{ inpenc }
     {

--- a/src/netxs/desktopio/consrv.hpp
+++ b/src/netxs/desktopio/consrv.hpp
@@ -301,7 +301,7 @@ struct consrv
             auto rc = nt::ioctl(nt::console::op::read_input, condrv, request);
             if (rc != ERROR_SUCCESS)
             {
-                if constexpr (debugmode) log("\tabort: read_input (condrv, request) rc=", rc);
+                if constexpr (debugmode) log("\tAbort reading input (condrv, request) rc=", rc);
                 status = nt::status::unsuccessful;
                 return faux;
             }
@@ -334,7 +334,7 @@ struct consrv
         {
             status = nt::status::invalid_handle;
             auto rc = nt::ioctl(nt::console::op::complete_io, condrv, *this);
-            if constexpr (debugmode) log("\tpending operation aborted");
+            if constexpr (debugmode) log("\tPending operation aborted");
         }
     };
 
@@ -418,7 +418,7 @@ struct consrv
                 log(server.prompt, what == CTRL_C_EVENT     ? "Ctrl+C"
                                  : what == CTRL_BREAK_EVENT ? "Ctrl+Break"
                                  : what == CTRL_CLOSE_EVENT ? "CtrlClose"
-                                                            : "unknown", " event");
+                                                            : "Unknown", " event");
             }
             for (auto& client : server.joined)
             {
@@ -824,7 +824,7 @@ struct consrv
                     if (server.io_log)
                     {
                         if (rec.EventType == KEY_EVENT)
-                        log("stdin: ", ansi::hi(utf::debase<faux, faux>(utf::to_utf(rec.Event.KeyEvent.uChar.UnicodeChar))),
+                        log(prompt::cinp, ansi::hi(utf::debase<faux, faux>(utf::to_utf(rec.Event.KeyEvent.uChar.UnicodeChar))),
                             " ", rec.Event.KeyEvent.bKeyDown ? "dn" : "up",
                             " ctrl: 0x",  utf::to_hex(rec.Event.KeyEvent.dwControlKeyState),
                             " char: 0x",  utf::to_hex(rec.Event.KeyEvent.uChar.UnicodeChar),
@@ -1821,7 +1821,7 @@ struct consrv
     }
     auto api_unsupported                     ()
     {
-        log(prompt, "unsupported consrv request code ", upload.fxtype);
+        log(prompt, "Unsupported consrv request code ", upload.fxtype);
         answer.status = nt::status::illegal_function;
     }
     auto api_system_langid_get               ()
@@ -1865,7 +1865,7 @@ struct consrv
     }
     auto api_process_attach                  ()
     {
-        log(prompt, "attach process to console");
+        log(prompt, "Attach process to console");
         struct payload : wrap<payload>
         {
             ui64 taskid;
@@ -1962,7 +1962,7 @@ struct consrv
         { };
         auto& packet = payload::cast(upload);
         auto client_ptr = packet.client;
-        log(prompt, "detach process from console: 0x", utf::to_hex(client_ptr));
+        log(prompt, "Detach process from console: 0x", utf::to_hex(client_ptr));
         auto iter = std::find_if(joined.begin(), joined.end(), [&](auto& client){ return client_ptr == &client; });
         if (iter != joined.end())
         {
@@ -2023,7 +2023,7 @@ struct consrv
     }
     auto api_process_create_handle           ()
     {
-        log(prompt, "create console handle");
+        log(prompt, "Create console handle");
         enum type : ui32
         {
             undefined,
@@ -2078,7 +2078,7 @@ struct consrv
         struct payload : drvpacket<payload>
         { };
         auto& packet = payload::cast(upload);
-        log(prompt, "delete console handle");
+        log(prompt, "Delete console handle");
         auto handle_ptr = packet.target;
         if (handle_ptr == nullptr)
         {
@@ -4061,7 +4061,7 @@ struct consrv
             auto wndname = text{ "vtmConsoleWindowClass" };
             auto wndproc = [](auto hwnd, auto uMsg, auto wParam, auto lParam)
             {
-                ok<faux>(!debugmode, "vtty: consrv: GUI message: hwnd=0x", utf::to_hex(hwnd), " uMsg=0x", utf::to_hex(uMsg), " wParam=0x", utf::to_hex(wParam), " lParam=0x", utf::to_hex(lParam));
+                ok<faux>(!debugmode, netxs::prompt::vtty, netxs::prompt::consrv, "GUI message: hwnd=0x", utf::to_hex(hwnd), " uMsg=0x", utf::to_hex(uMsg), " wParam=0x", utf::to_hex(wParam), " lParam=0x", utf::to_hex(lParam));
                 switch (uMsg)
                 {
                     case WM_CREATE: break;
@@ -4097,7 +4097,7 @@ struct consrv
             }
             else
             {
-                os::fail(prompt, "failed to create win32 window object");
+                os::fail(prompt, "Failed to create win32 window object");
                 winhnd = reinterpret_cast<HWND>(-1);
                 return;
             }
@@ -4131,12 +4131,12 @@ struct consrv
                         });
                         break;
                     }
-                    case ERROR_IO_PENDING:         log(prompt, "operation has not completed"); ::WaitForSingleObject(condrv, 0); break;
-                    case ERROR_PIPE_NOT_CONNECTED: log(prompt, "client disconnected"); return;
-                    default:                       log(prompt, "unexpected nt::ioctl result ", rc); break;
+                    case ERROR_IO_PENDING:         log(prompt, "Operation has not completed"); ::WaitForSingleObject(condrv, 0); break;
+                    case ERROR_PIPE_NOT_CONNECTED: log(prompt, "Client disconnected"); return;
+                    default:                       log(prompt, "Unexpected nt::ioctl result ", rc); break;
                 }
             }
-            log(prompt, "condrv main loop ended");
+            log(prompt, "Console server thread ended");
         }};
     }
     void resize(twod const& newsize)
@@ -4149,7 +4149,7 @@ struct consrv
         signal.reset();
         if (window.joinable()) window.join();
         if (server.joinable()) server.join();
-        log(prompt, "stop()");
+        log(prompt, "Console server stopped");
     }
     template<class T>
     auto size_check(T upto, T from)
@@ -4190,7 +4190,7 @@ struct consrv
           impcls{ faux   },
           answer{        },
           winhnd{        },
-          prompt{ "vtty: consrv: " },
+          prompt{ utf::concat(netxs::prompt::vtty, netxs::prompt::consrv) },
           inpenc{ std::make_shared<decoder>(*this, os::codepage) },
           outenc{ inpenc }
     {

--- a/src/netxs/desktopio/controls.hpp
+++ b/src/netxs/desktopio/controls.hpp
@@ -1613,7 +1613,7 @@ namespace netxs::ui
         // rail: Update nested object.
         void update(sptr old_item_ptr, sptr new_item_ptr)
         {
-            if (client != old_item_ptr) log(" rail: WARNING! Wrong DOM structure. rail.id=", id);
+            if (client != old_item_ptr) log(prompt::rail, "Wrong DOM structure. rail.id=", id);
             if (client)
             {
                 auto current_position = client->base::coor();

--- a/src/netxs/desktopio/directvt.hpp
+++ b/src/netxs/desktopio/directvt.hpp
@@ -8,16 +8,15 @@
 
 namespace netxs::prompt
 {
-    static constexpr auto pads = "      "sv;
-    static constexpr auto   os = "  os: "sv;
-    static constexpr auto  tty = " tty: "sv;
-    static constexpr auto  ack = " ack: "sv;
-    static constexpr auto  xml = " xml: "sv;
-    static constexpr auto  vtm = " vtm: "sv;
-    static constexpr auto consrv = "consrv: "sv;
-    static constexpr auto bitmap = "bitmap: "sv;
-    static constexpr auto cout = "stdout: "sv;
-    static constexpr auto cinp = "stdin: "sv;
+    static constexpr auto  pads = "      "sv;
+    static constexpr auto    os = "  os: "sv;
+    static constexpr auto   tty = " tty: "sv;
+    static constexpr auto   ack = " ack: "sv;
+    static constexpr auto   xml = " xml: "sv;
+    static constexpr auto   vtm = " vtm: "sv;
+    static constexpr auto   cin = "stdin: "sv;
+    static constexpr auto  cout = "stdout: "sv;
+    static constexpr auto win32 = "win32: "sv;
 
     #define prompt_list \
         X(apps) /* */ \
@@ -928,7 +927,7 @@ namespace netxs::directvt
                         auto [count] = stream::take<sz_t>(data);
                         if (count > tail - iter)
                         {
-                            log(prompt::dtvt, prompt::bitmap, "Corrupted data, subtype: ", what);
+                            log(prompt::dtvt, "bitmap: ", "Corrupted data, subtype: ", what);
                             break;
                         }
                         auto from = iter;
@@ -940,14 +939,14 @@ namespace netxs::directvt
                         auto [offset] = stream::take<sz_t>(data);
                         if (offset >= size)
                         {
-                            log(prompt::dtvt, prompt::bitmap, "Corrupted data, subtype: ", what);
+                            log(prompt::dtvt, "bitmap: ", "Corrupted data, subtype: ", what);
                             break;
                         }
                         iter = head + offset;
                     }
                     else // Unknown subtype.
                     {
-                        log(prompt::dtvt, prompt::bitmap, "Unknown data, subtype: ", what);
+                        log(prompt::dtvt, "bitmap: ", "Unknown data, subtype: ", what);
                         break;
                     }
                 }

--- a/src/netxs/desktopio/directvt.hpp
+++ b/src/netxs/desktopio/directvt.hpp
@@ -697,7 +697,7 @@ namespace netxs::directvt
         STRUCT_macro(jgc_element,       (ui64, token) (text, cluster))
         STRUCT_macro(tooltip_element,   (id_t, gear_id) (text, tip_text) (bool, update))
         STRUCT_macro(mouse_event,       (id_t, gear_id) (hint, cause) (twod, coord) (twod, delta) (ui32, buttons))
-        STRUCT_macro(keybd_event,       (id_t, gear_id) (ui32, ctlstat) (ui32, winctrl) (ui32, virtcod) (ui32, scancod) (bool, pressed) (ui32, imitate) (text, cluster) (wchr, winchar) (bool, handled))
+        STRUCT_macro(keybd_event,       (id_t, gear_id) (ui32, ctlstat) (ui32, winctrl) (ui32, virtcod) (ui32, scancod) (bool, pressed) (ui32, imitate) (text, cluster) (bool, handled))
         STRUCT_macro(set_clipboard,     (id_t, gear_id) (twod, clip_prev_size) (text, clipdata) (si32, mimetype))
         STRUCT_macro(request_clipboard, (id_t, gear_id))
         //STRUCT_macro(focus,             (id_t, gear_id) (bool, state) (bool, focus_combine) (bool, focus_force_group))
@@ -714,7 +714,7 @@ namespace netxs::directvt
         // Input stream.
         STRUCT_macro(focusbus,          (id_t, gear_id) (time, guid) (hint, cause))
         STRUCT_macro(sysfocus,          (id_t, gear_id) (bool, state) (bool, focus_combine) (bool, focus_force_group))
-        STRUCT_macro(syskeybd,          (id_t, gear_id) (ui32, ctlstat) (ui32, winctrl) (ui32, virtcod) (ui32, scancod) (bool, pressed) (ui32, imitate) (text, cluster) (wchr, winchar) (bool, handled))
+        STRUCT_macro(syskeybd,          (id_t, gear_id) (ui32, ctlstat) (ui32, winctrl) (ui32, virtcod) (ui32, scancod) (bool, pressed) (ui32, imitate) (text, cluster) (bool, handled))
         STRUCT_macro(sysmouse,          (id_t, gear_id)  // sysmouse: Devide id.
                                         (ui32, enabled)  // sysmouse: Mouse device health status.
                                         (ui32, ctlstat)  // sysmouse: Keybd modifiers state.

--- a/src/netxs/desktopio/directvt.hpp
+++ b/src/netxs/desktopio/directvt.hpp
@@ -16,7 +16,7 @@ namespace netxs::prompt
     static constexpr auto   vtm = " vtm: "sv;
     static constexpr auto   cin = "stdin: "sv;
     static constexpr auto  cout = "stdout: "sv;
-    static constexpr auto win32 = "win32: "sv;
+    static constexpr auto win32 = "win32api: "sv;
 
     #define prompt_list \
         X(apps) /* */ \

--- a/src/netxs/desktopio/input.hpp
+++ b/src/netxs/desktopio/input.hpp
@@ -1017,7 +1017,7 @@ namespace netxs::input
         void take(sysfocus& f)
         {
             tooltip_stop = true;
-            //if constexpr (debugmode) log("foci: take focus hid:", id, " state:", f.state ? "on":"off");
+            //if constexpr (debugmode) log(prompt::foci, "Take focus hid:", id, " state:", f.state ? "on":"off");
             //todo focus<->seed
             if (f.state) owner.SIGNAL(tier::release, hids::events::focus::set, *this);
             else         owner.SIGNAL(tier::release, hids::events::focus::off, *this);
@@ -1051,7 +1051,7 @@ namespace netxs::input
                     last->SIGNAL(tier::release, events::notify::mouse::leave, *this);
                     mouse::start = start;
                 }
-                else log("hids: error condition: Clients count is broken, dangling ", last_id);
+                else log(prompt::hids, "Error condition: Clients count is broken, dangling ", last_id);
             }
         }
         void redirect_mouse_focus(base& boss)

--- a/src/netxs/desktopio/input.hpp
+++ b/src/netxs/desktopio/input.hpp
@@ -679,7 +679,6 @@ namespace netxs::input
             };
         };
 
-        wchr winchar = {}; // MS Windows specific.
         text cluster = {};
         bool pressed = {};
         ui16 imitate = {};
@@ -696,7 +695,6 @@ namespace netxs::input
             virtcod = k.virtcod;
             scancod = k.scancod;
             cluster = k.cluster;
-            winchar = k.winchar;
             handled = k.handled;
             fire_keybd();
         }

--- a/src/netxs/desktopio/richtext.hpp
+++ b/src/netxs/desktopio/richtext.hpp
@@ -1331,8 +1331,8 @@ namespace netxs::ui
                         insert(*iter2);
                         return true;
                     }
-                    if ((iter1++)->wdt() == 2 && iter1 != end_1 && (iter1++)->wdt() != 3) log("para: corrupted glyph");
-                    if ((iter2++)->wdt() == 2 && iter2 != end_2 && (iter2++)->wdt() != 3) log("para: corrupted glyph");
+                    if ((iter1++)->wdt() == 2 && iter1 != end_1 && (iter1++)->wdt() != 3) log(prompt::para, "Corrupted glyph");
+                    if ((iter2++)->wdt() == 2 && iter2 != end_2 && (iter2++)->wdt() != 3) log(prompt::para, "Corrupted glyph");
                 }
             }
             return faux;
@@ -2062,13 +2062,11 @@ namespace netxs::ui
         auto& operator  = (view utf8) { clear(); ansi::parse(utf8, this); return *this; }
         auto& operator += (view utf8) {          ansi::parse(utf8, this); return *this; }
 
-        void tabs(si32) { log("Tabs are not supported"); }
+        void tabs(si32) { if constexpr (debugmode) log(prompt::page, "Tabs not supported"); }
     };
 
-    class tone
+    struct tone
     {
-    public:
-
         #define prop_list                              \
         X(kb_focus  , "Keyboard focus indicator")      \
         X(brighter  , "Highlighter modificator")       \

--- a/src/netxs/desktopio/system.hpp
+++ b/src/netxs/desktopio/system.hpp
@@ -2354,7 +2354,7 @@ namespace netxs::os
             {
                 log(prompt::vtty, "Destructor started");
                 stop();
-                log(prompt::vtty, "Destructor ended");
+                log(prompt::vtty, "Destructor complete");
             }
 
             operator bool () { return connected(); }
@@ -2862,7 +2862,7 @@ namespace netxs::os
             {
                 log(prompt::vtty, "Destructor started");
                 cleanup();
-                log(prompt::vtty, "Destructor ended");
+                log(prompt::vtty, "Destructor complete");
             }
 
             operator bool () { return termlink; }

--- a/src/netxs/desktopio/system.hpp
+++ b/src/netxs/desktopio/system.hpp
@@ -3025,7 +3025,7 @@ namespace netxs::os
                 stdinput = std::thread([&] { read_socket_thread(); });
                 stdwrite = std::thread([&] { send_socket_thread(); });
 
-                if (termlink) log(prompt::dtvt, "Console created: proc_pid ", proc_pid);
+                if (termlink) log(prompt::dtvt, "Console created: pid ", proc_pid);
                 writesyn.notify_one(); // Flush temp buffer.
 
                 return proc_pid;

--- a/src/netxs/desktopio/system.hpp
+++ b/src/netxs/desktopio/system.hpp
@@ -136,7 +136,7 @@ namespace netxs::os
     template<class ...Args>
     auto fail(Args&&... msg)
     {
-        log("  os: ", ansi::err(msg..., " (", os::error(), ") "));
+        log(prompt::os, ansi::err(msg..., " (", os::error(), ") "));
     };
     template<bool Alert = true, class T, class ...Args>
     auto ok(T error_condition, Args&&... msg)
@@ -280,7 +280,7 @@ namespace netxs::os
                                                                     | FILE_SHARE_DELETE, opts);
                 if (status != nt::status::success)
                 {
-                    log("  os: unexpected result when access system object '", path, "', ntstatus ", status);
+                    log(prompt::os, "Unexpected result when access system object '", path, "', ntstatus ", status);
                     return os::invalid_fd;
                 }
                 else return hndl;
@@ -367,7 +367,7 @@ namespace netxs::os
                     if (ok) return handle_clone;
                     else
                     {
-                        log("  os: unexpected result when duplicate system object handle, errcode ", os::error());
+                        log(prompt::os, "Unexpected result when duplicate system object handle, errcode ", os::error());
                         return os::invalid_fd;
                     }
                 }
@@ -757,7 +757,7 @@ namespace netxs::os
                     ::GetUserProfileDirectoryW(handle, buffer.data(), &length);
                     if (buffer.back() == '\0') buffer.pop_back(); // Pop terminating null.
                 }
-                else os::fail("can't detect user profile path");
+                else os::fail("Can't detect user profile path");
                 return fs::path{ utf::to_utf(buffer) };
             #else
                 return fs::path{ os::env::get("HOME") };
@@ -777,7 +777,7 @@ namespace netxs::os
                  || shell.ends_with("vtm"))
                 {
                     shell = "bash"; //todo request it from user if empty; or make it configurable
-                    log("  os: using '", shell, "' as a fallback login shell");
+                    log(prompt::os, "Using '", shell, "' as a fallback login shell");
                 }
                 return shell;
 
@@ -880,10 +880,10 @@ namespace netxs::os
                                 ::GlobalUnlock(gmem);
                                 ok(::SetClipboardData(cf_format, gmem) && (success = true), "::SetClipboardData()", os::unexpected_msg, ", cf_format=", cf_format);
                             }
-                            else log("  os: ::GlobalLock()", os::unexpected_msg);
+                            else log(prompt::os, "::GlobalLock()", os::unexpected_msg);
                             ::GlobalFree(gmem);
                         }
-                        else log("  os: ::GlobalAlloc()", os::unexpected_msg);
+                        else log(prompt::os, "::GlobalAlloc()", os::unexpected_msg);
                     };
                     cf_format == cf_text ? _send(utf::to_utf(data))
                                          : _send(data);
@@ -1311,11 +1311,11 @@ namespace netxs::os
 
                     if (cred.uid && id != utf::concat(cred.uid))
                     {
-                        fail("sock: foreign users are not allowed to the session");
+                        fail(prompt::sock, "Foreign users are not allowed to the session");
                         return faux;
                     }
 
-                    log("sock: creds from SO_PEERCRED:",
+                    log(prompt::sock, "Creds from SO_PEERCRED:",
                       "\n      pid : ", cred.pid,
                       "\n      euid: ", cred.uid,
                       "\n      egid: ", cred.gid);
@@ -1332,11 +1332,11 @@ namespace netxs::os
 
                     if (euid && id != utf::concat(euid))
                     {
-                        fail("sock: foreign users are not allowed to the session");
+                        fail(prompt::sock, "Foreign users are not allowed to the session");
                         return faux;
                     }
 
-                    log("sock: creds from ::getpeereid():",
+                    log(prompt::sock, "Creds from ::getpeereid():",
                       "\n      pid : ", id,
                       "\n      euid: ", euid,
                       "\n      egid: ", egid);
@@ -1378,7 +1378,7 @@ namespace netxs::os
                             //       members of the Everyone group and the anonymous account.
                             //       Without write access, the desktop will be inaccessible to non-owners.
                         }
-                        else if (pipe::active) os::fail("meet: not active");
+                        else if (pipe::active) os::fail(prompt::meet, "Not active");
 
                         return next_waiting_point;
                     };
@@ -1386,7 +1386,7 @@ namespace netxs::os
                     auto r = next_link(handle.r, to_server, PIPE_ACCESS_INBOUND);
                     if (r == os::invalid_fd)
                     {
-                        if (pipe::active) os::fail("meet: ::CreateNamedPipe(r)", os::unexpected_msg);
+                        if (pipe::active) os::fail(prompt::meet, "::CreateNamedPipe(r)", os::unexpected_msg);
                     }
                     else
                     {
@@ -1394,7 +1394,7 @@ namespace netxs::os
                         if (w == os::invalid_fd)
                         {
                             ::CloseHandle(r);
-                            if (pipe::active) os::fail("meet: ::CreateNamedPipe(w)", os::unexpected_msg);
+                            if (pipe::active) os::fail(prompt::meet, "::CreateNamedPipe(w)", os::unexpected_msg);
                         }
                         else
                         {
@@ -1413,7 +1413,7 @@ namespace netxs::os
                     };
                     auto f_proc = [&]
                     {
-                        log("meet: signal fired");
+                        log(prompt::meet, "Signal fired");
                         signal.flush();
                     };
                     io::select(handle.r, h_proc,
@@ -1427,7 +1427,7 @@ namespace netxs::os
                 auto state = pipe::stop();
                 if (state)
                 {
-                    log("xipc: server shuts down: ", handle);
+                    log(prompt::xipc, "Server shuts down: ", handle);
                     #if defined(_WIN32)
                         auto to_client = os::wr_pipe_path + scpath;
                         auto to_server = os::rd_pipe_path + scpath;
@@ -1444,7 +1444,7 @@ namespace netxs::os
                 auto state = pipe::shut();
                 if (state)
                 {
-                    log("xipc: client disconnects: ", handle);
+                    log(prompt::xipc, "Client disconnects: ", handle);
                     #if defined(_WIN32)
                         ::DisconnectNamedPipe(handle.w);
                         handle.shutdown(); // To trigger the read end to close.
@@ -1474,7 +1474,7 @@ namespace netxs::os
                     {
                         if (!retry_proc())
                         {
-                           if constexpr (Log) os::fail("failed to start server");
+                           if constexpr (Log) os::fail("Failed to start server");
                         }
                         else
                         {
@@ -1493,7 +1493,7 @@ namespace netxs::os
                 #if defined(_WIN32)
 
                     //security_descriptor pipe_acl(security_descriptor_string);
-                    //log("pipe: DACL=", pipe_acl.security_string);
+                    //log(prompt::pipe, "DACL=", pipe_acl.security_string);
                     // https://docs.microsoft.com/en-us/windows/win32/secauthz/sid-strings
 
                     auto to_server = os::rd_pipe_path + path;
@@ -1513,14 +1513,14 @@ namespace netxs::os
                                 do hits = next.cFileName == name;
                                 while (!hits && ::FindNextFileW(hndl, &next));
 
-                                if (hits) log("path: ", path);
+                                if (hits) log(prompt::path, path);
                                 ::FindClose(hndl);
                             }
                             return hits;
                         };
                         if (test(to_server))
                         {
-                            os::fail("server already running");
+                            os::fail("Server already running");
                             return socket;
                         }
 
@@ -1599,7 +1599,7 @@ namespace netxs::os
                         };
                         if (!try_start(play, retry_proc))
                         {
-                            if constexpr (Log) os::fail("connection error");
+                            if constexpr (Log) os::fail("Connection error");
                         }
                     }
 
@@ -1607,7 +1607,7 @@ namespace netxs::os
 
                     if (!ok(::signal(SIGPIPE, SIG_IGN)))
                     {
-                        if constexpr (Log) log("failed to set SIG_IGN");
+                        if constexpr (Log) log("Failed to set SIG_IGN");
                     }
 
                     auto addr = sockaddr_un{};
@@ -1618,23 +1618,23 @@ namespace netxs::os
                         auto home = os::env::homepath() / ".config/vtm";
                         if (!fs::exists(home))
                         {
-                            if constexpr (Log) log("path: create home directory '", home.string(), "'");
+                            if constexpr (Log) log(prompt::path, "Create home directory '", home.string(), "'");
                             auto ec = std::error_code{};
                             fs::create_directory(home, ec);
-                            if (ec && Log) log("path: directory '", home.string(), "' creation error ", ec.value());
+                            if (ec && Log) log(prompt::path, "Directory '", home.string(), "' creation error ", ec.value());
                         }
                         path = (home / path).string() + ".sock";
                         sun_path--; // File system unix domain socket.
-                        if constexpr (Log) log("open: file system socket ", path);
+                        if constexpr (Log) log(prompt::open, "File system socket ", path);
                     #endif
 
                     if (path.size() > sizeof(sockaddr_un::sun_path) - 2)
                     {
-                        if constexpr (Log) os::fail("unix socket path too long");
+                        if constexpr (Log) os::fail("Unix socket path too long");
                     }
                     else if ((w = ::socket(AF_UNIX, SOCK_STREAM, 0)) == os::invalid_fd)
                     {
-                        if constexpr (Log) os::fail("unix socket opening error");
+                        if constexpr (Log) os::fail("Unix socket opening error");
                     }
                     else
                     {
@@ -1655,12 +1655,12 @@ namespace netxs::os
                                 {
                                     if (play())
                                     {
-                                        os::fail("server already running");
+                                        os::fail("Server already running");
                                         io::close(r);
                                     }
                                     else
                                     {
-                                        log("path: removing file system socket file ", path);
+                                        log(prompt::path, "Removing filesystem socket file ", path);
                                         ::unlink(path.c_str()); // Cleanup file system socket.
                                     }
                                 }
@@ -1668,12 +1668,12 @@ namespace netxs::os
 
                             if (r != os::invalid_fd && ::bind(r, (struct sockaddr*)&addr, sock_addr_len) == -1)
                             {
-                                os::fail("unix socket binding error for ", path);
+                                os::fail("Unix socket binding error for ", path);
                                 io::close(r);
                             }
                             else if (::listen(r, 5) == -1)
                             {
-                                os::fail("unix socket listening error for ", path);
+                                os::fail("Unix socket listening error for ", path);
                                 io::close(r);
                             }
                         }
@@ -1682,7 +1682,7 @@ namespace netxs::os
                             path.clear(); // No need to unlink a file system socket on client disconnect.
                             if (!try_start(play, retry_proc))
                             {
-                                if constexpr (Log) os::fail("connection failed");
+                                if constexpr (Log) os::fail("Connection failed");
                                 io::close(r);
                             }
                         }
@@ -1834,7 +1834,7 @@ namespace netxs::os
             void worker()
             {
                 auto guard = std::unique_lock{ mutex };
-                log("pool: session control started");
+                log(prompt::pool, "Session control started");
 
                 while (alive || index.size())
                 {
@@ -1850,7 +1850,7 @@ namespace netxs::os
                                 guard.unlock();
                                 guest.join();
                                 guard.lock();
-                                log("pool: id: ", sid, " session joined");
+                                log(prompt::pool, "Id: ", sid, " session joined");
                             }
                             it = index.erase(it);
                         }
@@ -1864,7 +1864,7 @@ namespace netxs::os
                 auto session_id = std::this_thread::get_id();
                 index[session_id].state = faux;
                 synch.notify_one();
-                log("pool: id: ", session_id, " session deleted");
+                log(prompt::pool, "Id: ", session_id, " session deleted");
             }
 
         public:
@@ -1881,7 +1881,7 @@ namespace netxs::os
                 });
                 auto session_id = session.get_id();
                 index[session_id] = { true, std::move(session) };
-                log("pool: id: ", session_id, " session created");
+                log(prompt::pool, "Id: ", session_id, " session created");
             }
             auto size()
             {
@@ -1902,10 +1902,10 @@ namespace netxs::os
 
                 if (agent.joinable())
                 {
-                    log("pool: joining agent");
+                    log(prompt::pool, "Joining agent");
                     agent.join();
                 }
-                log("pool: session control ended");
+                log(prompt::pool, "Session control ended");
             }
         };
 
@@ -1989,7 +1989,7 @@ namespace netxs::os
             #endif
             if (result.empty())
             {
-                os::fail("can't get current module file path, fallback to '", process::arg0, "`");
+                os::fail("Can't get current module file path, fallback to '", process::arg0, "`");
                 result = process::arg0;
             }
             if constexpr (NameOnly)
@@ -2054,7 +2054,7 @@ namespace netxs::os
         template<bool Logs = true, bool Daemon = faux>
         auto exec(text cmdline)
         {
-            if constexpr (Logs) log("exec: '" + cmdline + "'");
+            if constexpr (Logs) log(prompt::exec, "'", cmdline, "'");
             #if defined(_WIN32)
                 
                 auto shadow = view{ cmdline };
@@ -2086,7 +2086,7 @@ namespace netxs::os
                     }
                     os::process::execvp(cmdline);
                     auto errcode = errno;
-                    if constexpr (Logs) os::fail("exec: failed to spawn '", cmdline, "'");
+                    if constexpr (Logs) os::fail(prompt::exec, "Failed to spawn '", cmdline, "'");
                     os::process::exit(errcode);
                 }
                 else if (p_id > 0) // Parent branch.
@@ -2100,7 +2100,7 @@ namespace netxs::os
                 }
 
             #endif
-            if constexpr (Logs) os::fail("exec: failed to spawn '", cmdline, "'");
+            if constexpr (Logs) os::fail(prompt::exec, "Failed to spawn '", cmdline, "'");
             return faux;
         }
         auto fork(bool& result, view prefix, view config)
@@ -2136,7 +2136,7 @@ namespace netxs::os
                 {
                     io::close(proinf.hProcess);
                     io::close(proinf.hThread);
-                    log("  os: process forked");
+                    log(prompt::os, "Process forked");
                     return faux; // Success. The fork concept is not supported on Windows.
                 }
 
@@ -2164,14 +2164,14 @@ namespace netxs::os
                     ::waitpid(p_id, &stat, 0);
                     if (WIFEXITED(stat) && (WEXITSTATUS(stat) == 0))
                     {
-                        log("  os: process forked");
+                        log(prompt::os, "Process forked");
                         result = true;
                         return faux; // Child forked and exited successfully.
                     }
                 }
 
             #endif
-            os::fail("  os: can't fork process");
+            os::fail(prompt::os, "Can't fork process");
             return faux;
         }
     }
@@ -2313,7 +2313,7 @@ namespace netxs::os
                         dstmap.entry_ct += std::size(new_recs);
                         if (!ok(::ioctl(os::stdout_fd, PIO_UNIMAP, &dstmap), "::ioctl(os::stdout_fd, PIO_UNIMAP)", os::unexpected_msg)) return;
                     }
-                    else log("  os: vgafont loading failed - UNIMAP is full");
+                    else log(prompt::os, "VGA font loading failed - 'UNIMAP' is full");
                 }
 
             #endif
@@ -2352,9 +2352,9 @@ namespace netxs::os
             { }
            ~vtty()
             {
-                log("vtty: dtor started");
+                log(prompt::vtty, "Destructor started");
                 stop();
-                log("vtty: dtor complete");
+                log(prompt::vtty, "Destructor ended");
             }
 
             operator bool () { return connected(); }
@@ -2373,17 +2373,17 @@ namespace netxs::os
                 if (stdwrite.joinable())
                 {
                     writesyn.notify_one();
-                    log("vtty: id: ", stdwrite.get_id(), " writing thread joining");
+                    log(prompt::vtty, "Id: ", stdwrite.get_id(), " writing thread joining");
                     stdwrite.join();
                 }
                 if (stdinput.joinable())
                 {
-                    log("vtty: id: ", stdinput.get_id(), " reading thread joining");
+                    log(prompt::vtty, "Id: ", stdinput.get_id(), " reading thread joining");
                     stdinput.join();
                 }
                 if (waitexit.joinable())
                 {
-                    log("vtty: id: ", waitexit.get_id(), " child process waiter thread joining");
+                    log(prompt::vtty, "Id: ", waitexit.get_id(), " child process waiter thread joining");
                     waitexit.join();
                 }
                 auto guard = std::lock_guard{ writemtx };
@@ -2394,7 +2394,7 @@ namespace netxs::os
             {
                 auto guard = std::lock_guard{ writemtx };
                 auto exit_code = si32{};
-                log("vtty: wait child process ", proc_pid);
+                log(prompt::vtty, "Wait child process ", proc_pid);
 
                 if (proc_pid != 0)
                 {
@@ -2406,11 +2406,11 @@ namespace netxs::os
                     auto code = DWORD{ 0 };
                     if (!::GetExitCodeProcess(prochndl, &code))
                     {
-                        log("vtty: ::GetExitCodeProcess() return code: ", ::GetLastError());
+                        log(prompt::vtty, "::GetExitCodeProcess() return code: ", ::GetLastError());
                     }
                     else if (code == STILL_ACTIVE)
                     {
-                        log("vtty: child process still running");
+                        log(prompt::vtty, "Child process still running");
                         auto result = WAIT_OBJECT_0 == ::WaitForSingleObject(prochndl, app_wait_timeout /*10 seconds*/);
                         if (!result || !::GetExitCodeProcess(prochndl, &code))
                         {
@@ -2418,7 +2418,7 @@ namespace netxs::os
                             code = 0;
                         }
                     }
-                    else log("vtty: child process exit code 0x", utf::to_hex(code), " (", code, ")");
+                    else log(prompt::vtty, "Child process exit code 0x", utf::to_hex(code), " (", code, ")");
                     exit_code = code;
                     io::close(prochndl);
 
@@ -2431,17 +2431,17 @@ namespace netxs::os
                     if (WIFEXITED(status))
                     {
                         exit_code = WEXITSTATUS(status);
-                        log("vtty: child process exit code ", exit_code);
+                        log(prompt::vtty, "Child process exit code ", exit_code);
                     }
                     else
                     {
                         exit_code = 0;
-                        log("vtty: warning: child process exit code not detected");
+                        log(prompt::vtty, "Child process exit code not detected");
                     }
 
                 #endif
                 }
-                log("vtty: child waiting complete");
+                log(prompt::vtty, "Child waiting complete");
                 return exit_code;
             }
             void start(twod winsz)
@@ -2449,7 +2449,7 @@ namespace netxs::os
                 auto cwd     = terminal.curdir;
                 auto cmdline = terminal.cmdarg;
                 utf::change(cmdline, "\\\"", "\"");
-                log("vtty: new child process: '", utf::debase(cmdline), "' at the ", cwd.empty() ? "current working directory"s
+                log(prompt::vtty, "New child process: '", utf::debase(cmdline), "' at the ", cwd.empty() ? "current working directory"s
                                                                                                  : "'" + cwd + "'");
                 #if defined(_WIN32)
 
@@ -2465,7 +2465,7 @@ namespace netxs::os
                     if (ERROR_SUCCESS != nt::ioctl(nt::console::op::set_server_information, srv_hndl, con_serv.events.ondata))
                     {
                         auto errcode = os::error();
-                        os::fail("vtty: console server creation error");
+                        os::fail(prompt::vtty, "Console server creation error");
                         terminal.onexit(errcode, "Console server creation error");
                         return;
                     }
@@ -2519,7 +2519,7 @@ namespace netxs::os
                     if (ret == 0)
                     {
                         auto errcode = os::error();
-                        os::fail("vtty: child process creation error");
+                        os::fail(prompt::vtty, "Child process creation error");
                         io::close( srv_hndl );
                         io::close( ref_hndl );
                         con_serv.stop();
@@ -2534,13 +2534,13 @@ namespace netxs::os
                     proc_pid = procsinf.dwProcessId;
                     waitexit = std::thread([&]
                     {
-                        io::select(prochndl, []{ log("vtty: child process terminated"); });
+                        io::select(prochndl, []{ log(prompt::vtty, "Child process terminated"); });
                         if (srv_hndl != os::invalid_fd)
                         {
                             auto exit_code = wait_child();
                             terminal.onexit(exit_code);
                         }
-                        log("vtty: child process waiter ended");
+                        log(prompt::vtty, "Child process waiter ended");
                     });
 
                 #else
@@ -2578,8 +2578,8 @@ namespace netxs::os
                         {
                             auto err = std::error_code{};
                             fs::current_path(cwd, err);
-                            if (err) std::cerr << "vtty: failed to change current working directory to '" << cwd << "', error code: " << err.value() << "\n" << std::flush;
-                            else     std::cerr << "vtty: change current working directory to '" << cwd << "'" << "\n" << std::flush;
+                            if (err) std::cerr << prompt::vtty << "Failed to change current working directory to '" << cwd << "', error code: " << err.value() << "\n" << std::flush;
+                            else     std::cerr << prompt::vtty << "Change current working directory to '" << cwd << "'" << "\n" << std::flush;
                         }
 
                         ::dup2(fds, os::stdin_fd ); // Assign stdio lines atomically
@@ -2611,7 +2611,7 @@ namespace netxs::os
                 stdwrite = std::thread([&] { send_socket_thread(); });
                 writesyn.notify_one(); // Flush temp buffer.
 
-                log("vtty: new vtty created with size ", winsz);
+                log(prompt::vtty, "New vtty created with size ", winsz);
             }
             void stop()
             {
@@ -2625,7 +2625,7 @@ namespace netxs::os
             {
                 #if not defined(_WIN32)
 
-                    log("vtty: id: ", stdinput.get_id(), " reading thread started");
+                    log(prompt::vtty, "Id: ", stdinput.get_id(), " reading thread started");
                     auto flow = text{};
                     while (termlink)
                     {
@@ -2644,13 +2644,13 @@ namespace netxs::os
                         auto exit_code = wait_child();
                         terminal.onexit(exit_code);
                     }
-                    log("vtty: id: ", stdinput.get_id(), " reading thread ended");
+                    log(prompt::vtty, "Id: ", stdinput.get_id(), " reading thread ended");
 
                 #endif
             }
             void send_socket_thread()
             {
-                log("vtty: id: ", stdwrite.get_id(), " writing thread started");
+                log(prompt::vtty, "Id: ", stdwrite.get_id(), " writing thread started");
                 auto guard = std::unique_lock{ writemtx };
                 auto cache = text{};
                 while ((void)writesyn.wait(guard, [&]{ return writebuf.size() || !connected(); }), connected())
@@ -2670,7 +2670,7 @@ namespace netxs::os
                     #endif
                     guard.lock();
                 }
-                log("vtty: id: ", stdwrite.get_id(), " writing thread ended");
+                log(prompt::vtty, "Id: ", stdwrite.get_id(), " writing thread ended");
             }
             void resize(twod const& newsize)
             {
@@ -2860,9 +2860,9 @@ namespace netxs::os
         public:
            ~vtty()
             {
-                log("dtvt: dtor started");
+                log(prompt::vtty, "Destructor started");
                 cleanup();
-                log("dtvt: dtor complete");
+                log(prompt::vtty, "Destructor ended");
             }
 
             operator bool () { return termlink; }
@@ -2875,7 +2875,7 @@ namespace netxs::os
                 preclose = preclose_hndl;
                 shutdown = shutdown_hndl;
                 utf::change(cmdline, "\\\"", "'");
-                log("dtvt: new child process: '", utf::debase(cmdline), "' at the ", cwd.empty() ? "current working directory"s
+                log(prompt::vtty, "New child process: '", utf::debase(cmdline), "' at the ", cwd.empty() ? "current working directory"s
                                                                                                  : "'" + cwd + "'");
                 #if defined(_WIN32)
 
@@ -2960,7 +2960,7 @@ namespace netxs::os
                         proc_pid = procsinf.dwProcessId;
                         termlink = { m_pipe_r, m_pipe_w };
                     }
-                    else os::fail("dtvt: child process creation error");
+                    else os::fail(prompt::vtty, "Child process creation error");
 
                     io::close(s_pipe_w); // Close inheritable handles to avoid deadlocking at process exit.
                     io::close(s_pipe_r); // Only when all write handles to the pipe are closed, the ReadFile function returns zero.
@@ -2997,14 +2997,14 @@ namespace netxs::os
                             auto err = std::error_code{};
                             fs::current_path(cwd, err);
                             //todo use dtvt to log
-                            //if (err) os::fail("dtvt: failed to change current working directory to '", cwd, "', error code: ", err.value());
-                            //else     log("dtvt: change current working directory to '", cwd, "'");
+                            //if (err) os::fail(prompt::dtvt, "Failed to change current working directory to '", cwd, "', error code: ", err.value());
+                            //else          log(prompt::dtvt, "Change current working directory to '", cwd, "'");
                         }
 
                         os::process::execvp(cmdline);
                         auto errcode = errno;
                         //todo use dtvt to log
-                        //os::fail("dtvt: exec error");
+                        //os::fail(prompt::dtvt, "Exec error");
                         ::close(os::stdout_fd);
                         ::close(os::stdin_fd );
                         os::process::exit(errcode);
@@ -3025,7 +3025,7 @@ namespace netxs::os
                 stdinput = std::thread([&] { read_socket_thread(); });
                 stdwrite = std::thread([&] { send_socket_thread(); });
 
-                if (termlink) log("dtvt: vtty created: proc_pid ", proc_pid);
+                if (termlink) log(prompt::dtvt, "Console created: proc_pid ", proc_pid);
                 writesyn.notify_one(); // Flush temp buffer.
 
                 return proc_pid;
@@ -3034,7 +3034,7 @@ namespace netxs::os
             {
                 //auto guard = std::lock_guard{ writemtx };
                 auto exit_code = si32{};
-                log("dtvt: wait child process, tty=", termlink);
+                log(prompt::dtvt, "Wait child process, tty=", termlink);
                 if (proc_pid)
                 {
                     #if defined(_WIN32)
@@ -3042,11 +3042,11 @@ namespace netxs::os
                         auto code = DWORD{ 0 };
                         if (!::GetExitCodeProcess(prochndl, &code))
                         {
-                            log("dtvt: ::GetExitCodeProcess() return code: ", ::GetLastError());
+                            log(prompt::dtvt, "::GetExitCodeProcess() return code: ", ::GetLastError());
                         }
                         else if (code == STILL_ACTIVE)
                         {
-                            log("dtvt: child process still running");
+                            log(prompt::dtvt, "Child process still running");
                             auto result = WAIT_OBJECT_0 == ::WaitForSingleObject(prochndl, app_wait_timeout /*10 seconds*/);
                             if (!result || !::GetExitCodeProcess(prochndl, &code))
                             {
@@ -3054,7 +3054,7 @@ namespace netxs::os
                                 code = 0;
                             }
                         }
-                        else log("dtvt: child process exit code ", code);
+                        else log(prompt::dtvt, "Child process exit code ", code);
                         exit_code = code;
                         io::close(prochndl);
 
@@ -3067,18 +3067,18 @@ namespace netxs::os
                         if (WIFEXITED(status))
                         {
                             exit_code = WEXITSTATUS(status);
-                            log("dtvt: child process exit code ", exit_code);
+                            log(prompt::dtvt, "Child process exit code ", exit_code);
                         }
                         else
                         {
                             exit_code = 0;
-                            log("dtvt: warning: child process exit code not detected");
+                            log(prompt::dtvt, "Child process exit code not detected");
                         }
 
                     #endif
                     proc_pid = 0;
                 }
-                log("dtvt: child waiting complete");
+                log(prompt::dtvt, "Child waiting complete");
                 return exit_code;
             }
             void cleanup()
@@ -3086,12 +3086,12 @@ namespace netxs::os
                 if (stdwrite.joinable())
                 {
                     writesyn.notify_one();
-                    log("dtvt: id: ", stdwrite.get_id(), " writing thread joining");
+                    log(prompt::dtvt, "Id: ", stdwrite.get_id(), " writing thread joining");
                     stdwrite.join();
                 }
                 if (stdinput.joinable())
                 {
-                    log("dtvt: id: ", stdinput.get_id(), " reading thread joining");
+                    log(prompt::dtvt, "Id: ", stdinput.get_id(), " reading thread joining");
                     stdinput.join();
                 }
                 auto guard = std::lock_guard{ writemtx };
@@ -3107,16 +3107,16 @@ namespace netxs::os
             }
             void read_socket_thread()
             {
-                log("dtvt: id: ", stdinput.get_id(), " reading thread started");
+                log(prompt::dtvt, "Id: ", stdinput.get_id(), " reading thread started");
                 directvt::binary::stream::reading_loop(termlink, receiver);
                 preclose(0);
                 auto exit_code = wait_child();
                 shutdown(exit_code);
-                log("dtvt: id: ", stdinput.get_id(), " reading thread ended");
+                log(prompt::dtvt, "Id: ", stdinput.get_id(), " reading thread ended");
             }
             void send_socket_thread()
             {
-                log("dtvt: id: ", stdwrite.get_id(), " writing thread started");
+                log(prompt::dtvt, "Id: ", stdwrite.get_id(), " writing thread started");
                 auto guard = std::unique_lock{ writemtx };
                 auto cache = text{};
                 while ((void)writesyn.wait(guard, [&]{ return writebuf.size() || !termlink; }), termlink)
@@ -3128,7 +3128,7 @@ namespace netxs::os
                     guard.lock();
                 }
                 //if (termlink) termlink.shut();
-                log("dtvt: id: ", stdwrite.get_id(), " writing thread ended");
+                log(prompt::dtvt, "Id: ", stdwrite.get_id(), " writing thread ended");
             }
             void output(view data)
             {
@@ -3172,7 +3172,7 @@ namespace netxs::os
             auto mode = si32{ vt::clean };
             if (os::dtvt::peek(os::stdin_fd))
             {
-                log("  os: DirectVT detected");
+                log(prompt::os, "DirectVT detected");
                 mode |= vt::direct;
             }
             else
@@ -3202,7 +3202,7 @@ namespace netxs::os
 
                     if (!ok(::tcgetattr(os::stdin_fd, &state), "::tcgetattr(os::stdin_fd)", os::unexpected_msg))
                     {
-                        os::fail("warning: check you are using the proper tty device, try `ssh -tt ...` option");
+                        os::fail("Check you are using the proper tty device, try `ssh -tt ...` option");
                     }
 
                 #endif
@@ -3210,7 +3210,7 @@ namespace netxs::os
 
                 if (auto term = os::env::get("TERM"); term.size())
                 {
-                    log("  os: terminal type \"", term, "\"");
+                    log(prompt::os, "Terminal type \"", term, "\"");
 
                     auto vga16colors = { // https://github.com//termstandard/colors
                         "ansi",
@@ -3252,16 +3252,16 @@ namespace netxs::os
 
                     if (os::env::get("TERM_PROGRAM") == "Apple_Terminal")
                     {
-                        log("  os: macOS Apple_Terminal detected");
+                        log(prompt::os, "macOS Apple Terminal detected");
                         if (!(mode & vt::vga16)) mode |= vt::vga256;
                     }
 
                     if (os::vt::console()) mode |= vt::mouse;
 
-                    log("  os: color mode: ", mode & vt::vga16  ? "16-color"
-                                            : mode & vt::vga256 ? "256-color"
-                                                                : "true-color");
-                    log("  os: mouse mode: ", mode & vt::mouse ? "console" : "vt-style");
+                    log(prompt::os, "Color mode: ", mode & vt::vga16  ? "16-color"
+                                                  : mode & vt::vga256 ? "256-color"
+                                                                      : "true-color");
+                    log(prompt::os, "Mouse mode: ", mode & vt::mouse ? "console" : "vt-style");
                 }
             }
             return mode;
@@ -3295,7 +3295,7 @@ namespace netxs::os
 
             if (winsz == dot_00)
             {
-                log("xtty: fallback tty window size ", winsz_fallback, " (consider using 'ssh -tt ...')");
+                log(prompt::tty, "Fallback tty window size ", winsz_fallback, " (consider using 'ssh -tt ...')");
                 winsz(winsz_fallback);
             }
             wired.winsz.send(ipcio, 0, winsz.last);
@@ -3356,9 +3356,9 @@ namespace netxs::os
                 switch (what)
                 {
                     case SIGWINCH: resize(); return;
-                    case SIGHUP:   log(" tty: SIGHUP");  shutdown(what); break;
-                    case SIGTERM:  log(" tty: SIGTERM"); shutdown(what); break;
-                    default:       log(" tty: signal ", what); break;
+                    case SIGHUP:   log(prompt::tty, "SIGHUP");  shutdown(what); break;
+                    case SIGTERM:  log(prompt::tty, "SIGTERM"); shutdown(what); break;
+                    default:       log(prompt::tty, "Signal ", what); break;
                 }
 
             #endif
@@ -3386,7 +3386,7 @@ namespace netxs::os
         }
         void reader(si32 mode)
         {
-            log(" tty: id: ", std::this_thread::get_id(), " reading thread started");
+            log(prompt::tty, "Id: ", std::this_thread::get_id(), " reading thread started");
             auto& g = globals();
             auto& ipcio =*g.ipcio;
             auto& wired = g.wired;
@@ -3408,7 +3408,7 @@ namespace netxs::os
                         // ERROR_PIPE_NOT_CONNECTED
                         // 233 (0xE9)
                         // No process is on the other end of the pipe.
-                        os::process::exit(-1, " tty: ::GetNumberOfConsoleInputEvents()", os::unexpected_msg, " ", ::GetLastError());
+                        os::process::exit(-1, prompt::tty, "::GetNumberOfConsoleInputEvents()", os::unexpected_msg, " ", ::GetLastError());
                         break;
                     }
                     else if (count)
@@ -3418,7 +3418,7 @@ namespace netxs::os
                         if (!::ReadConsoleInputW(os::stdin_fd, reply.data(), (DWORD)reply.size(), &count))
                         {
                             //ERROR_PIPE_NOT_CONNECTED = 0xE9 - it's means that the console is gone/crashed
-                            os::process::exit(-1, " tty: ::ReadConsoleInput()", os::unexpected_msg, " ", ::GetLastError());
+                            os::process::exit(-1, prompt::tty, "::ReadConsoleInput()", os::unexpected_msg, " ", ::GetLastError());
                             break;
                         }
                         else
@@ -3502,19 +3502,19 @@ namespace netxs::os
                 };
                 ok(::ttyname_r(os::stdout_fd, buffer.data(), buffer.size()), "::ttyname_r(os::stdout_fd)", os::unexpected_msg);
                 auto tty_name = view(buffer.data());
-                log(" tty: pseudoterminal ", tty_name);
+                log(prompt::tty, "Pseudoterminal ", tty_name);
                 if (legacy_mouse)
                 {
-                    log(" tty: compatibility mode");
+                    log(prompt::tty, "Compatibility mode");
                     auto imps2_init_string = "\xf3\xc8\xf3\x64\xf3\x50"sv;
                     auto mouse_device = "/dev/input/mice";
                     auto mouse_fallback1 = "/dev/input/mice.vtm";
                     auto mouse_fallback2 = "/dev/input/mice_vtm"; //todo deprecated
                     auto fd = ::open(mouse_device, O_RDWR);
                     if (fd == -1) fd = ::open(mouse_fallback1, O_RDWR);
-                    if (fd == -1) log(" tty: error opening ", mouse_device, " and ", mouse_fallback1, ", error ", errno, errno == 13 ? " - permission denied" : "");
+                    if (fd == -1) log(prompt::tty, "Error opening ", mouse_device, " and ", mouse_fallback1, ", error ", errno, errno == 13 ? " - permission denied" : "");
                     if (fd == -1) fd = ::open(mouse_fallback2, O_RDWR);
-                    if (fd == -1) log(" tty: error opening ", mouse_device, " and ", mouse_fallback2, ", error ", errno, errno == 13 ? " - permission denied" : "");
+                    if (fd == -1) log(prompt::tty, "Error opening ", mouse_device, " and ", mouse_fallback2, ", error ", errno, errno == 13 ? " - permission denied" : "");
                     else if (io::send(fd, imps2_init_string))
                     {
                         char ack;
@@ -3531,12 +3531,12 @@ namespace netxs::os
                             }
                         }
                         wired.mouse_show.send(ipcio, true);
-                        if (ack == '\xfa') log(" tty: ImPS/2 mouse connected, fd: ", fd);
-                        else               log(" tty: unknown PS/2 mouse connected, fd: ", fd, " ack: ", (int)ack);
+                        if (ack == '\xfa') log(prompt::tty, "ImPS/2 mouse connected, fd: ", fd);
+                        else               log(prompt::tty, "Unknown PS/2 mouse connected, fd: ", fd, " ack: ", (int)ack);
                     }
                     else
                     {
-                        log(" tty: mouse initialization error");
+                        log(prompt::tty, "Mouse initialization error");
                         io::close(fd);
                     }
                 }
@@ -3752,9 +3752,9 @@ namespace netxs::os
                                 // Pass SIGINT inside the desktop
                                 //if (strv.at(i) == 3 /*3 - SIGINT*/)
                                 //{
-                                //	log(" - SIGINT in stdin");
-                                //	owner.SIGNAL(tier::release, e2::conio::quit, "pipe: SIGINT");
-                                //	return;
+                                //   log(" - SIGINT in stdin");
+                                //   owner.SIGNAL(tier::release, e2::conio::quit, msg, (utf::concat(prompt::pipe, "SIGINT")));
+                                //   return;
                                 //}
                                 i++;
                             }
@@ -3841,14 +3841,14 @@ namespace netxs::os
 
             #endif
 
-            log(" tty: id: ", std::this_thread::get_id(), " reading thread ended");
+            log(prompt::tty, "Id: ", std::this_thread::get_id(), " reading thread ended");
         }
         void clipbd(si32 mode)
         {
             using namespace os::clipboard;
 
             if (mode & vt::direct) return;
-            log(" tty: id: ", std::this_thread::get_id(), " clipboard watcher thread started");
+            log(prompt::tty, "Id: ", std::this_thread::get_id(), " clipboard watcher thread started");
 
             #if defined(_WIN32)
 
@@ -3971,7 +3971,7 @@ namespace netxs::os
 
             #endif
 
-            log(" tty: id: ", std::this_thread::get_id(), " clipboard watcher thread ended");
+            log(prompt::tty, "Id: ", std::this_thread::get_id(), " clipboard watcher thread ended");
         }
         void ignite(xipc pipe, si32 mode)
         {

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -7399,7 +7399,7 @@ namespace netxs::ui
                         auto basis = gear.owner.base::coor();
                         owner.global(basis);
                         gear.replay(m.cause, m.coord - basis, m.delta, m.buttons);
-                        gear.pass<tier::release>(parent_ptr, basis);
+                        gear.pass<tier::release>(parent_ptr, dot_00, true);
                         if (gear && !gear.captured()) // Forward the event to the gate as if it was initiated there.
                         {
                             gear.coord -= basis; // Restore gate mouse position.

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -7376,7 +7376,6 @@ namespace netxs::ui
                         gear.pressed  = k.pressed;
                         gear.imitate  = k.imitate;
                         gear.cluster  = k.cluster;
-                        gear.winchar  = k.winchar;
                         gear.handled  = k.handled;
                         do
                         {
@@ -7586,7 +7585,6 @@ namespace netxs::ui
                                                gear.pressed,
                                                gear.imitate,
                                                gear.cluster,
-                                               gear.winchar,
                                                gear.handled);
                     gear.dismiss();
                 };

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -7145,7 +7145,7 @@ namespace netxs::ui
                             d << (si32)(byte)v.front() << " ";
                             v.remove_prefix(1);
                         }
-                        log(prompt::cinp, d.str());
+                        log(prompt::cin, d.str());
                     }
 
                 #endif

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -6449,7 +6449,7 @@ namespace netxs::ui
         {
             bell::trysync(active, [&]
             {
-                log(prompt::term, "Exit code 0x", utf::to_hex(code));
+                log(prompt::term, "Exit code ", utf::to_hex_0x(code));
                 auto close_proc = [&]
                 {
                     netxs::events::enqueue(This(), [&](auto& boss)
@@ -6460,7 +6460,7 @@ namespace netxs::ui
                 auto chose_proc = [&]
                 {
                     auto error = ansi::bgc(code ? rgba{ reddk } : rgba{}).fgc(whitelt).add(msg)
-                        .add("\r\n", prompt::term, "Exit code 0x", utf::to_hex(code), " ").nil()
+                        .add("\r\n", prompt::term, "Exit code ", utf::to_hex_0x(code), " ").nil()
                         .add("\r\nPress Esc to close or press Enter to restart the session.").add("\r\n\n");
                     ondata(error);
                     this->LISTEN(tier::release, hids::events::keybd::data::post, gear, onerun) //todo VS2019 requires `this`
@@ -6478,7 +6478,7 @@ namespace netxs::ui
                 auto start_proc = [&]
                 {
                     auto error = ansi::bgc(code ? rgba{ reddk } : rgba{}).fgc(whitelt).add(msg)
-                        .add("\r\nterm: exit code 0x", utf::to_hex(code), " ").nil().add("\r\n\n");
+                        .add("\r\n", prompt::term, "Exit code ", utf::to_hex_0x(code), " ").nil().add("\r\n\n");
                     ondata(error);
                     netxs::events::enqueue(This(), [&](auto& boss)
                     {
@@ -7665,7 +7665,7 @@ namespace netxs::ui
         {
             netxs::events::enqueue(This(), [&, code](auto& boss) mutable
             {
-                if (code) log(ansi::bgc(reddk).fgc(whitelt).add('\n', prompt::term, "Exit code 0x", utf::to_hex(code), ' ').nil());
+                if (code) log(ansi::bgc(reddk).fgc(whitelt).add('\n', prompt::term, "Exit code ", utf::to_hex_0x(code), ' ').nil());
                 else      log(prompt::dtvt, "Exit code 0");
                 backup.reset(); // Call dtvt::dtor.
             });

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -2727,11 +2727,12 @@ namespace netxs::ui
                 // buff: Clear scrollback, add one empty line, and reset all metrics.
                 void clear()
                 {
+                    auto auto_wrap = current().wrapped();
                     ring::clear();
                     caret = 0;
                     basis = 0;
                     slide = 0;
-                    invite(0); // At least one line must exist.
+                    invite(0, deco{}.wrp(auto_wrap)); // At least one line must exist.
                     ancid = back().index;
                     ancdy = 0;
                     set_width(width);
@@ -2771,7 +2772,7 @@ namespace netxs::ui
                        shore{ boss.config.def_margin }
             {
                 parser::style.wrp(boss.config.def_wrpmod);
-                batch.invite(0); // At least one line must exist.
+                batch.invite(0, boss.config.def_wrpmod == wrap::on); // At least one line must exist.
                 batch.set_width(1);
                 index_rebuild();
 

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -565,7 +565,7 @@ namespace netxs::ui
                         break;
                     }
                     default:
-                        log("term: CSI ", option, "... t (XTWINOPS) is not supported");
+                        log(prompt::term, "CSI ", option, "... t (XTWINOPS) is not supported");
                         break;
                 }
             }
@@ -614,7 +614,7 @@ namespace netxs::ui
             }
             void notsupported(text const& property, view data)
             {
-                log("term: not supported: OSC=", property, " DATA=", data, " SIZE=", data.length(), " HEX=", utf::to_hex(data));
+                log(prompt::term, "Not supported: OSC=", property, " DATA=", data, " SIZE=", data.length(), " HEX=", utf::to_hex(data));
             }
 
             c_tracking(term& owner)
@@ -717,7 +717,7 @@ namespace netxs::ui
                 {
                     proc->second(data);
                 }
-                else log("term: not supported: OSC=", property, " DATA=", data, " HEX=", utf::to_hex(data));
+                else log(prompt::term, "Not supported: OSC=", property, " DATA=", data, " HEX=", utf::to_hex(data));
             }
             void fgc(tint c) { owner.target->brush.fgc(color[c]); }
             void bgc(tint c) { owner.target->brush.bgc(color[c]); }
@@ -1203,7 +1203,7 @@ namespace netxs::ui
             void task(ansi::rule const& property)
             {
                 parser::flush();
-                log("term: bufferbase: locus extensions are not supported");
+                log(prompt::term, "Desktopio extensions are not supported");
                 //auto& cur_line = batch.current();
                 //if (cur_line.busy())
                 //{
@@ -1231,7 +1231,7 @@ namespace netxs::ui
             template<class T>
             void na(T&& note)
             {
-                log("term: not implemented: ", note);
+                log(prompt::term, "Not implemented: ", note);
             }
             void not_implemented_CSI(si32 i, fifo& q)
             {
@@ -1246,7 +1246,7 @@ namespace netxs::ui
                         params.push_back(delim);
                     }
                 }
-                log("term: CSI ", params, " ", (unsigned char)i, "(", i, ") is not implemented");
+                log(prompt::term, "CSI ", params, " ", (unsigned char)i, "(", i, ") is not implemented");
             }
             void not_implemented_ESC(si32 c, qiew& q)
             {
@@ -1260,7 +1260,7 @@ namespace netxs::ui
                     case ansi::esc_pm    :
                     case ansi::esc_apc   :
                     case ansi::esc_st    :
-                        log("term: ESC ", (char)c, " (", c, ") is unexpected");
+                        log(prompt::term, "ESC ", (char)c, " (", c, ") is unexpected");
                         break;
                     // Unsupported ESC + byte + rest
                     case ansi::esc_g0set :
@@ -1274,7 +1274,7 @@ namespace netxs::ui
                     case ansi::esc_decdhl:
                     case ansi::esc_chrset:
                     {
-                        if (!q) log("term: ESC ", (char)c, " (", c, ") is incomplete");
+                        if (!q) log(prompt::term, "ESC ", (char)c, " (", c, ") is incomplete");
                         auto b = q.front();
                         q.pop_front();
                         switch (b)
@@ -1303,7 +1303,7 @@ namespace netxs::ui
                             case '9':
                             case '`':
                             case 'U':
-                                log("term: ESC ", (char)c, " ", (char)b, " (", c, " ", b, ") is unsupported");
+                                log(prompt::term, "ESC ", (char)c, " ", (char)b, " (", c, " ", b, ") is unsupported");
                                 break;
                             case '%':
                             case '"':
@@ -1311,18 +1311,18 @@ namespace netxs::ui
                                 if (q.size() < 2)
                                 {
                                     if (q) q.pop_front();
-                                    log("term: ESC ", (char)c, " ", (char)b, " (", c, " ", b, ") is incomplete");
+                                    log(prompt::term, "ESC ", (char)c, " ", (char)b, " (", c, " ", b, ") is incomplete");
                                 }
                                 else
                                 {
                                      auto d = q.front();
                                      q.pop_front();
-                                     log("term: ESC ", (char)c, " ", (char)b, " ", (char)d, " (", c, " ", b, " ", d, ") is unsupported");
+                                     log(prompt::term, "ESC ", (char)c, " ", (char)b, " ", (char)d, " (", c, " ", b, " ", d, ") is unsupported");
                                 }
                                 break;
                             }
                             default:
-                                log("term: ESC ", (char)c, " ", (char)b, " (", c, " ", b, ") is unknown");
+                                log(prompt::term, "ESC ", (char)c, " ", (char)b, " (", c, " ", b, ") is unknown");
                                 break;
                         }
                         break;
@@ -1353,10 +1353,10 @@ namespace netxs::ui
                     case ansi::esc_spa   :
                     case ansi::esc_epa   :
                     case ansi::esc_rid   :
-                        log("term: ESC ", (char)c, " (", c, ") is unsupported");
+                        log(prompt::term, "ESC ", (char)c, " (", c, ") is unsupported");
                         break;
                     default:
-                        log("term: ESC ", (char)c, " (", c, ") is unknown");
+                        log(prompt::term, "ESC ", (char)c, " (", c, ") is unknown");
                         break;
                 }
             }
@@ -1369,13 +1369,13 @@ namespace netxs::ui
                 switch (c)
                 {
                     case -1:
-                        log("term: ESC #  is unexpected");
+                        log(prompt::term, "ESC #  is unexpected");
                         break;
                     case '3':
                     case '4':
                     case '5':
                     case '6':
-                        log("term: ESC # ", (char)c, " (", c, ") is unsupported");
+                        log(prompt::term, "ESC # ", (char)c, " (", c, ") is unsupported");
                         break;
                     case '8':
                     {
@@ -1390,7 +1390,7 @@ namespace netxs::ui
                         break;
                     }
                     default:
-                        log("term: ESC # ", (char)c, " (", c, ") is unknown");
+                        log(prompt::term, "ESC # ", (char)c, " (", c, ") is unknown");
                         break;
                 }
             }
@@ -1415,7 +1415,7 @@ namespace netxs::ui
                         }
                     }
                 }
-                log("term: Unsupported Message/Command: '\\e", (char)c, utf::debase<faux>(data), "'");
+                log(prompt::term, "Unsupported message/command: '\\e", (char)c, utf::debase<faux>(data), "'");
             }
             // bufferbase: Clear buffer.
     virtual void clear_all()
@@ -1731,7 +1731,7 @@ namespace netxs::ui
             // bufferbase: Shift left n columns(s).
             void shl(si32 n)
             {
-                log("term: bufferbase: SHL(n=", n, ") is not implemented.");
+                log(prompt::term, "SHL(n=", n, ") is not implemented.");
             }
             // bufferbase: CSI n X  Erase/put n chars after cursor. Don't change cursor pos.
     virtual void ech(si32 n, char c = '\0') = 0;
@@ -3365,7 +3365,7 @@ namespace netxs::ui
             {
                 if (batch.basis >= batch.vsize)
                 {
-                    assert((log("term: batch.basis >= batch.vsize  batch.basis=", batch.basis, " batch.vsize=", batch.vsize), true));
+                    assert((log(prompt::term, "batch.basis >= batch.vsize  batch.basis=", batch.basis, " batch.vsize=", batch.vsize), true));
                     batch.basis = batch.vsize - 1;
                 }
 
@@ -6184,13 +6184,13 @@ namespace netxs::ui
                     cursor.show();
                     break;
                 case 9:    // Enable X10 mouse reporting protocol.
-                    log("term: decset: CSI ? 9 h  X10 Mouse reporting protocol is not supported");
+                    log(prompt::term, "CSI ? 9 h  X10 Mouse reporting protocol is not supported");
                     break;
                 case 1000: // Enable mouse buttons reporting mode.
                     mtrack.enable(m_tracking::buttons_press);
                     break;
                 case 1001: // Use Hilite mouse tracking mode.
-                    log("term: decset: CSI ? 1001 h  Hilite mouse tracking mode is not supported");
+                    log(prompt::term, "CSI ? 1001 h  Hilite mouse tracking mode is not supported");
                     break;
                 case 1002: // Enable mouse buttons and drags reporting mode.
                     mtrack.enable(m_tracking::buttons_drags);
@@ -6214,10 +6214,10 @@ namespace netxs::ui
                     mtrack.enable(m_tracking::negative_args);
                     break;
                 case 1015: // Enable URXVT mouse reporting protocol.
-                    log("term: decset: CSI ? 1015 h  URXVT mouse reporting protocol is not supported");
+                    log(prompt::term, "CSI ? 1015 h  URXVT mouse reporting protocol is not supported");
                     break;
                 case 1016: // Enable Pixels (subcell) mouse mode.
-                    log("term: decset: CSI ? 1016 h  Pixels (subcell) mouse mode is not supported");
+                    log(prompt::term, "CSI ? 1016 h  Pixels (subcell) mouse mode is not supported");
                     break;
                 case 1048: // Save cursor pos.
                     target->scp();
@@ -6294,13 +6294,13 @@ namespace netxs::ui
                     cursor.hide();
                     break;
                 case 9:    // Disable X10 mouse reporting protocol.
-                    log("term: decset: CSI ? 9 l  X10 Mouse tracking protocol is not supported");
+                    log(prompt::term, "CSI ? 9 l  X10 Mouse tracking protocol is not supported");
                     break;
                 case 1000: // Disable mouse buttons reporting mode.
                     mtrack.disable(m_tracking::buttons_press);
                     break;
                 case 1001: // Don't use Hilite(c) mouse tracking mode.
-                    log("term: decset: CSI ? 1001 l  Hilite mouse tracking mode is not supported");
+                    log(prompt::term, "CSI ? 1001 l  Hilite mouse tracking mode is not supported");
                     break;
                 case 1002: // Disable mouse buttons and drags reporting mode.
                     mtrack.disable(m_tracking::buttons_drags);
@@ -6325,10 +6325,10 @@ namespace netxs::ui
                     mtrack.disable(m_tracking::negative_args);
                     break;
                 case 1015: // Disable URXVT mouse reporting protocol.
-                    log("term: decset: CSI ? 1015 l  URXVT mouse reporting protocol is not supported");
+                    log(prompt::term, "CSI ? 1015 l  URXVT mouse reporting protocol is not supported");
                     break;
                 case 1016: // Disable Pixels (subcell) mouse mode.
-                    log("term: decset: CSI ? 1016 l  Pixels (subcell) mouse mode is not supported");
+                    log(prompt::term, "CSI ? 1016 l  Pixels (subcell) mouse mode is not supported");
                     break;
                 case 1048: // Restore cursor pos.
                     target->rcp();
@@ -6431,7 +6431,7 @@ namespace netxs::ui
         {
             update([&]
             {
-                if (io_log && data.size()) log("stdout:\n\t", utf::change(ansi::hi(utf::debase(data)), "\n", ansi::pushsgr().nil().add("\n\t").popsgr()));
+                if (io_log && data.size()) log(prompt::cout, "\n\t", utf::change(ansi::hi(utf::debase(data)), "\n", ansi::pushsgr().nil().add("\n\t").popsgr()));
                 ansi::parse(data, target);
             });
         }
@@ -6440,7 +6440,7 @@ namespace netxs::ui
         {
             update([&]
             {
-                if (io_log && data.size()) log("stdout:\n\t", utf::change(ansi::hi(utf::debase(data)), "\n", ansi::pushsgr().nil().add("\n\t").popsgr()));
+                if (io_log && data.size()) log(prompt::cout, "\n\t", utf::change(ansi::hi(utf::debase(data)), "\n", ansi::pushsgr().nil().add("\n\t").popsgr()));
                 ansi::parse(data, target);
             });
         }
@@ -6449,7 +6449,7 @@ namespace netxs::ui
         {
             bell::trysync(active, [&]
             {
-                log("term: exit code 0x", utf::to_hex(code));
+                log(prompt::term, "Exit code 0x", utf::to_hex(code));
                 auto close_proc = [&]
                 {
                     netxs::events::enqueue(This(), [&](auto& boss)
@@ -6460,7 +6460,7 @@ namespace netxs::ui
                 auto chose_proc = [&]
                 {
                     auto error = ansi::bgc(code ? rgba{ reddk } : rgba{}).fgc(whitelt).add(msg)
-                        .add("\r\nterm: exit code 0x", utf::to_hex(code), " ").nil()
+                        .add("\r\n", prompt::term, "Exit code 0x", utf::to_hex(code), " ").nil()
                         .add("\r\nPress Esc to close or press Enter to restart the session.").add("\r\n\n");
                     ondata(error);
                     this->LISTEN(tier::release, hids::events::keybd::data::post, gear, onerun) //todo VS2019 requires `this`
@@ -6932,7 +6932,7 @@ namespace netxs::ui
         }
         void exec_cmd(commands::ui::commands cmd)
         {
-            log("term: tier::preview, ui::commands, ", cmd);
+            if constexpr (debugmode) log(prompt::term, "tier::preview, ui::commands, ", cmd);
             auto& console = *target;
             //todo reorganize - group commands
             if (console.selection_active())
@@ -7145,7 +7145,7 @@ namespace netxs::ui
                             d << (si32)(byte)v.front() << " ";
                             v.remove_prefix(1);
                         }
-                        log("stdin: ", d.str());
+                        log(prompt::cinp, d.str());
                     }
 
                 #endif
@@ -7287,7 +7287,7 @@ namespace netxs::ui
                 for (auto& jgc : lock.thing)
                 {
                     cell::gc_set_data(jgc.token, jgc.cluster);
-                    log("term: new gc token: ", jgc.token, " cluster size ", jgc.cluster.size(), " data: ", jgc.cluster);
+                    if constexpr (debugmode) log(prompt::term, "New gc token: ", jgc.token, " cluster size ", jgc.cluster.size(), " data: ", jgc.cluster);
                 }
                 netxs::events::enqueue(owner.This(), [&](auto& boss) mutable
                 {
@@ -7665,8 +7665,8 @@ namespace netxs::ui
         {
             netxs::events::enqueue(This(), [&, code](auto& boss) mutable
             {
-                if (code) log(ansi::bgc(reddk).fgc(whitelt).add("\ndtvt: exit code 0x", utf::to_hex(code), " ").nil());
-                else      log("dtvt: exit code 0");
+                if (code) log(ansi::bgc(reddk).fgc(whitelt).add('\n', prompt::term, "Exit code 0x", utf::to_hex(code), ' ').nil());
+                else      log(prompt::dtvt, "Exit code 0");
                 backup.reset(); // Call dtvt::dtor.
             });
         }

--- a/src/netxs/desktopio/utf.hpp
+++ b/src/netxs/desktopio/utf.hpp
@@ -29,6 +29,8 @@ namespace netxs
     using namespace std::literals;
 
     static constexpr auto whitespaces = " \n\r\t"sv;
+    static constexpr auto alphabetic  = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_"sv;
+    static constexpr auto base64code  = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
     static constexpr auto whitespace  = ' '; // '.';
     static constexpr auto emptyspace  = "\0"sv;
 }
@@ -1421,8 +1423,7 @@ namespace netxs::utf
 
     auto base64(view utf8)
     {
-        static constexpr auto code = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
-
+        auto code = base64code;
         auto data = text{};
         if (auto size = utf8.size())
         {
@@ -1469,7 +1470,7 @@ namespace netxs::utf
 
     auto unbase64(view bs64)
     {
-        static constexpr auto code = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+        auto code = base64code;
         auto is64 = [](auto c) { return (c > 0x2E && c < 0x3A) // '/' and digits
                                      || (c > 0x40 && c < 0x5B) // Uppercase letters
                                      || (c > 0x60 && c < 0x7B) // Lowercase letters

--- a/src/netxs/desktopio/utf.hpp
+++ b/src/netxs/desktopio/utf.hpp
@@ -1804,7 +1804,8 @@ namespace netxs::utf
         auto result = (flux{} << std::hex << num).str();
         auto shadow = view{ result };
         trim_front(shadow, '0');
-        return "0x" + text{ shadow };
+        return shadow.empty() ? "0x0"s
+                              : "0x" + text{ shadow };
     }
     auto to_hex_0x(wchr num)
     {

--- a/src/netxs/desktopio/utf.hpp
+++ b/src/netxs/desktopio/utf.hpp
@@ -1238,7 +1238,7 @@ namespace netxs::utf
     }
     // utf: to_hex without allocations (the crop should has a reserved capacity).
     template<bool UpperCase = faux, class V, class = typename std::enable_if<std::is_integral<V>::value>::type>
-    auto to_hex(text& crop, V number, size_t width = sizeof(V) * 2, char filler = '0')
+    auto to_hex(text& crop, V number, size_t width = sizeof(V) * 2)
     {
         static constexpr auto nums = UpperCase ? "0123456789ABCDEF"
                                                : "0123456789abcdef";
@@ -1631,11 +1631,11 @@ namespace netxs::utf
         trim_front_if(utf8, [&](char c){ return delims.find(c) == text::npos; });
         return temp.substr(0, temp.size() - utf8.size());
     }
-    auto trim_front(view& utf8)
+    auto trim_front(view& utf8, char c = ' ')
     {
         auto head = utf8.begin();
         auto tail = utf8.end();
-        while (head != tail && *head == ' ')
+        while (head != tail && *head == c)
         {
             ++head;
         }
@@ -1797,6 +1797,18 @@ namespace netxs::utf
             utf8.replace(spot, what_sz, fill);
             spot += what_sz;
         }
+    }
+    template<class V>
+    auto to_hex_0x(V const& num)
+    {
+        auto result = (flux{} << std::hex << num).str();
+        auto shadow = view{ result };
+        trim_front(shadow, '0');
+        return "0x" + text{ shadow };
+    }
+    auto to_hex_0x(wchr num)
+    {
+        return to_hex_0x((int)num);
     }
 }
 

--- a/src/vtm.cpp
+++ b/src/vtm.cpp
@@ -22,7 +22,7 @@ int main(int argc, char* argv[])
     #include "vtm.xml"
 
     auto vtmode = os::tty::vtmode();
-    auto banner = [&]{ log(app::vtm::desc, ' ', app::shared::version); };
+    auto banner = [&]{ log(prompt::vtm, app::shared::version); };
     auto whoami = type::client;
     auto params = text{};
     auto cfpath = text{};
@@ -53,7 +53,7 @@ int main(int argc, char* argv[])
             vtpipe = getopt.next();
             if (vtpipe.empty())
             {
-                errmsg = "custom pipe not specified";
+                errmsg = "Custom pipe not specified";
                 break;
             }
         }
@@ -70,13 +70,13 @@ int main(int argc, char* argv[])
             cfpath = getopt.next();
             if (cfpath.empty())
             {
-                errmsg = "config file path not specified";
+                errmsg = "Config file path not specified";
                 break;
             }
         }
         else if (getopt.match("-?", "-h", "--help"))
         {
-            errmsg = ansi::nil().add("show help message");
+            errmsg = ansi::nil().add("Show help message");
             break;
         }
         else if (getopt.match("-v", "--version"))
@@ -91,7 +91,7 @@ int main(int argc, char* argv[])
         }
         else
         {
-            errmsg = utf::concat("unknown option '", getopt.next(), "'");
+            errmsg = utf::concat("Unknown option '", getopt.next(), "'");
             break;
         }
     }
@@ -139,12 +139,12 @@ int main(int argc, char* argv[])
     {
         auto userid = os::env::user();
         auto prefix = (vtpipe.empty() ? utf::concat(app::shared::desktopio, '_', userid) : vtpipe) + app::shared::logsuffix;
-        log("main: waiting for server...");
+        log(prompt::main, "Waiting for server...");
         while (true)
         {
             if (auto stream = os::ipc::socket::open<os::role::client, faux>(prefix))
             {
-                log("main: connected");
+                log(prompt::main, "Connected");
                 while (os::io::send(stream->recv()))
                 { }
                 return 0;
@@ -174,7 +174,7 @@ int main(int argc, char* argv[])
         auto success = app::shared::start(params, app::vtm::id, vtmode, config);
         if (!success)
         {
-            os::fail("console initialization error");
+            os::fail("Console initialization error");
             return 1;
         }
     }
@@ -188,7 +188,7 @@ int main(int argc, char* argv[])
         {
             auto client = os::ipc::socket::open<os::role::client>(prefix, 10s, [&]
             {
-                log("main: new vtm session for ", userid);
+                log(prompt::main, "New vtm session for ", userid);
                 auto success = faux;
                 if (os::process::fork(success, prefix, config.utf8())) whoami = type::server;
                 return success;
@@ -209,7 +209,7 @@ int main(int argc, char* argv[])
             }
             else if (whoami != type::server)
             {
-                os::fail("no vtm server connection");
+                os::fail("No vtm server connection");
                 return 1;
             }
         }
@@ -223,7 +223,7 @@ int main(int argc, char* argv[])
             }
             else 
             {
-                if (!success) os::fail("failed to daemonize");
+                if (!success) os::fail("Failed to daemonize");
                 return !success;
             }
         }
@@ -231,13 +231,13 @@ int main(int argc, char* argv[])
         auto server = os::ipc::socket::open<os::role::server>(prefix);
         if (!server)
         {
-            os::fail("can't start vtm server");
+            os::fail("Can't start vtm server");
             return 1;
         }
         auto logger = os::ipc::socket::open<os::role::server>(prefix + app::shared::logsuffix);
         if (!logger)
         {
-            os::fail("can't start vtm logger");
+            os::fail("Can't start vtm logger");
             return 1;
         }
         using e2 = netxs::ui::e2;
@@ -247,7 +247,7 @@ int main(int argc, char* argv[])
         auto thread = os::process::pool{};
         domain->autorun();
 
-        log("main: listening socket ", server,
+        log(prompt::main, "Listening socket ", server,
           "\n      user: ", userid,
           "\n      pipe: ", prefix);
 
@@ -257,12 +257,12 @@ int main(int argc, char* argv[])
             {
                 thread.run([&, stream](auto session_id)
                 {
-                    log("logs: monitor ", stream, " connected");
+                    log(prompt::logs, "Monitor ", stream, " connected");
                     auto tokens = subs{};
                     domain->LISTEN(tier::general, e2::conio::quit, utf8, tokens) { stream->shut(); };
                     domain->LISTEN(tier::general, e2::conio::logs, utf8, tokens) { stream->send(utf8); };
                     stream->recv();
-                    log("logs: monitor ", stream, " disconnected");
+                    log(prompt::logs, "Monitor ", stream, " disconnected");
                 });
             }
         }};
@@ -274,17 +274,17 @@ int main(int argc, char* argv[])
             {
                 thread.run([&, client, settings](auto session_id)
                 {
-                    log("user: new gate for ", client);
+                    log(prompt::user, "New gate for ", client);
                     auto config = xmls{ settings };
                     auto packet = os::tty::globals().wired.init.recv(client);
                     config.fuse(packet.config);
                     domain->invite(client, packet.user, packet.mode, config, session_id);
-                    log("user: ", client, " logged out");
+                    log(prompt::user, "Client \"", client, "\" logged out");
                 });
             }
         }
         logger->stop(); // Logger must be stopped first to prevent reconnection.
-        domain->SIGNAL(tier::general, e2::conio::quit, "main: server shutdown");
+        domain->SIGNAL(tier::general, e2::conio::quit, msg, (utf::concat(prompt::main, "Server shutdown")));
         events::dequeue();
         domain->shutdown();
         stdlog.join();

--- a/src/vtm.hpp
+++ b/src/vtm.hpp
@@ -9,7 +9,6 @@
 namespace netxs::app::vtm
 {
     static constexpr auto id = "vtm";
-    static constexpr auto desc = " vtm:";
 
     struct link
     {
@@ -730,7 +729,7 @@ namespace netxs::app::vtm
 
         gate(sptr<pipe> uplink, view userid, si32 vtmode, xmls& config, si32 session_id)
             : ui::gate{ uplink, vtmode, config, userid, session_id, true },
-              notes{*this, ansi::add("Gate: ", props.title) }
+              notes{*this, ansi::add(prompt::gate, props.title) }
         {
             //todo local=>nexthop
             local = faux;
@@ -1309,7 +1308,7 @@ namespace netxs::app::vtm
                         auto start = datetime::now();
                         boss.SIGNAL(tier::general, e2::cleanup, counter, ());
                         auto stop = datetime::now() - start;
-                        log("hall: garbage collection",
+                        log(prompt::hall, "Garbage collection",
                         "\n\ttime ", utf::format(stop.count()), "ns",
                         "\n\tobjs ", counter.obj_count,
                         "\n\trefs ", counter.ref_count,
@@ -1337,7 +1336,7 @@ namespace netxs::app::vtm
             if (cfg.winsize && !what.forced) slot->extend({ what.square.coor, cfg.winsize });
             else                             slot->extend(what.square);
             slot->attach(what.applet);
-            log("hall: app type: ", utf::debase(cfg.type), ", menu item id: ", utf::debase(what.menuid));
+            log(prompt::hall, "App type: ", utf::debase(cfg.type), ", menu item id: ", utf::debase(what.menuid));
             this->branch(what.menuid, slot, !cfg.hidden);
             slot->SIGNAL(tier::anycast, e2::form::upon::started, this->This());
             return slot;
@@ -1395,7 +1394,7 @@ namespace netxs::app::vtm
                 }
                 else if (conf_rec.menuid.empty())
                 {
-                    log("hall: attribute '", utf::debase(attr_id), "' is missing, skip item");
+                    log(prompt::hall, "Attribute '", utf::debase(attr_id), "' is missing, skip item");
                     continue;
                 }
                 auto label        = item.take(attr_label, ""s);
@@ -1556,7 +1555,7 @@ namespace netxs::app::vtm
                 auto location = gear.slot;
                 if (gear.meta(hids::anyCtrl))
                 {
-                    log("hall: area copied to clipboard ", location);
+                    log(prompt::hall, "Area copied to clipboard ", location);
                     gate.SIGNAL(tier::release, e2::command::printscreen, gear);
                 }
                 else
@@ -1569,7 +1568,7 @@ namespace netxs::app::vtm
                         window->LISTEN(tier::release, e2::form::upon::vtree::detached, master)
                         {
                             insts_count--;
-                            log("hall: detached: ", insts_count);
+                            log(prompt::hall, "Detached: ", insts_count);
                         };
                         pro::focus::set(window, gear.id, pro::focus::solo::on, pro::focus::flip::off);
                         window->SIGNAL(tier::anycast, e2::form::upon::created, gear); // Tile should change the menu item.
@@ -1582,7 +1581,7 @@ namespace netxs::app::vtm
                 auto slot = window(what);
                 slot->extend(what.square);
                 slot->attach(what.applet);
-                log("hall: attach type=", utf::debase(cfg.type), " menuid=", utf::debase(what.menuid));
+                log(prompt::hall, "Attach type=", utf::debase(cfg.type), " menuid=", utf::debase(what.menuid));
                 this->branch(what.menuid, slot, !cfg.hidden);
                 slot->SIGNAL(tier::anycast, e2::form::upon::started, this->This());
                 what.applet = slot;
@@ -1657,7 +1656,7 @@ namespace netxs::app::vtm
                         auto window_ptr = create(what);
                         if (focused) foci.push_back(window_ptr);
                     }
-                    else log("hall: Unexpected empty app id in autorun configuration");
+                    else log(prompt::hall, "Unexpected empty app id in autorun configuration");
                 }
             }
             auto count = 0;
@@ -1669,7 +1668,7 @@ namespace netxs::app::vtm
             if constexpr (debugmode)
             {
                 SIGNAL(tier::request, e2::form::state::keybd::next, gear_test, (0,0));
-                log("hall: autofocused items count:", gear_test.second);
+                log(prompt::hall, "Autofocused items count:", gear_test.second);
             }
         }
         void redraw(face& canvas) override

--- a/src/vtm.hpp
+++ b/src/vtm.hpp
@@ -1668,7 +1668,7 @@ namespace netxs::app::vtm
             if constexpr (debugmode)
             {
                 SIGNAL(tier::request, e2::form::state::keybd::next, gear_test, (0,0));
-                log(prompt::hall, "Autofocused items count:", gear_test.second);
+                if (gear_test.second) log(prompt::hall, "Autofocused items count", ": ", gear_test.second);
             }
         }
         void redraw(face& canvas) override


### PR DESCRIPTION
Changes
- Fix `ReadConsole` and `ReadConsoleInput` on Windows #390
- Fix regression: Unable to tear window away from tiling manager
- Make log messages more friendly

Closes #390