### PR TITLE
Open descriptors leakage workaround

### DIFF
--- a/.resources/status/freebsd.svg
+++ b/.resources/status/freebsd.svg
@@ -18,8 +18,8 @@
     <text x="1000" y="140" transform="scale(.1)" text-anchor="end"
     >FreeBSD amd64</text>
     <text x="1230" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" text-anchor="start"
-    >v0.9.9n</text>
+    >v0.9.9o</text>
     <text x="1230" y="140" transform="scale(.1)" text-anchor="start"
-    >v0.9.9n</text>
+    >v0.9.9o</text>
   </g>
 </svg>

--- a/.resources/status/linux.svg
+++ b/.resources/status/linux.svg
@@ -18,8 +18,8 @@
     <text x="1000" y="140" transform="scale(.1)" text-anchor="end"
     >Linux amd64</text>
     <text x="1230" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" text-anchor="start"
-    >v0.9.9n</text>
+    >v0.9.9o</text>
     <text x="1230" y="140" transform="scale(.1)" text-anchor="start"
-    >v0.9.9n</text>
+    >v0.9.9o</text>
   </g>
 </svg>

--- a/.resources/status/macos.svg
+++ b/.resources/status/macos.svg
@@ -18,8 +18,8 @@
     <text x="1000" y="140" transform="scale(.1)" text-anchor="end"
     >macOS any</text>
     <text x="1230" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" text-anchor="start"
-    >v0.9.9n</text>
+    >v0.9.9o</text>
     <text x="1230" y="140" transform="scale(.1)" text-anchor="start"
-    >v0.9.9n</text>
+    >v0.9.9o</text>
   </g>
 </svg>

--- a/.resources/status/netbsd.svg
+++ b/.resources/status/netbsd.svg
@@ -18,8 +18,8 @@
     <text x="1000" y="140" transform="scale(.1)" text-anchor="end"
     >NetBSD amd64</text>
     <text x="1230" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" text-anchor="start"
-    >v0.9.9n</text>
+    >v0.9.9o</text>
     <text x="1230" y="140" transform="scale(.1)" text-anchor="start"
-    >v0.9.9n</text>
+    >v0.9.9o</text>
   </g>
 </svg>

--- a/.resources/status/openbsd.svg
+++ b/.resources/status/openbsd.svg
@@ -18,8 +18,8 @@
     <text x="1000" y="140" transform="scale(.1)" text-anchor="end"
     >OpenBSD amd64</text>
     <text x="1230" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" text-anchor="start"
-    >v0.9.9n</text>
+    >v0.9.9o</text>
     <text x="1230" y="140" transform="scale(.1)" text-anchor="start"
-    >v0.9.9n</text>
+    >v0.9.9o</text>
   </g>
 </svg>

--- a/.resources/status/windows.svg
+++ b/.resources/status/windows.svg
@@ -18,8 +18,8 @@
     <text x="1000" y="140" transform="scale(.1)" text-anchor="end"
     >Windows amd64</text>
     <text x="1230" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" text-anchor="start"
-    >v0.9.9n</text>
+    >v0.9.9o</text>
     <text x="1230" y="140" transform="scale(.1)" text-anchor="start"
-    >v0.9.9n</text>
+    >v0.9.9o</text>
   </g>
 </svg>

--- a/src/netxs/desktopio/application.hpp
+++ b/src/netxs/desktopio/application.hpp
@@ -21,7 +21,7 @@ namespace netxs::app
 
 namespace netxs::app::shared
 {
-    static const auto version = "v0.9.9n";
+    static const auto version = "v0.9.9o";
     static const auto desktopio = "desktopio";
     static const auto logsuffix = "_log";
     static const auto usr_config = "~/.config/vtm/settings.xml";


### PR DESCRIPTION
An external process that provides a transport tunnel for the vtm allows its open handles to leak into our process. There are duplicate stdin/stdout handles among the open descriptors, preventing them from being closed.

Affected:
- ssh
- nc
- ncat
- socat

xlink: https://github.com/netxs-group/vtm/issues/401#issuecomment-1603240008

Closes #409