### PR TITLE
Fix rendering issue when scrollback buffer is full

### DIFF
--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -4463,7 +4463,7 @@ namespace netxs::ui
                 auto view = dest.view();
                 auto full = dest.full();
                 auto coor = twod{ 0, batch.slide - batch.ancdy + y_top };
-                auto stop = batch.slide + panel.y;
+                auto stop = view.coor.y + view.size.y;
                 auto head = batch.iter_by_id(batch.ancid);
                 auto tail = batch.end();
                 auto find = selection_active() && match.length() && owner.selmod == mime::textonly;


### PR DESCRIPTION
Fixes issue with built-in terminal: The new text stops rendering when the scrollback buffer is filled to the top and begins to behave like a ring.