### PR TITLE
Implement DOSKEY functionality

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,6 +93,14 @@ jobs:
     - name: Build
       run: cmake --build ${{ steps.strings.outputs.bin }} --config Release
 
+    - name: Test (POSIX)
+      if: matrix.os != 'windows-latest'
+      run: ${{ steps.strings.outputs.bin }}/vtm -v
+
+    - name: Test (Windows)
+      if: matrix.os == 'windows-latest'
+      run: ${{ steps.strings.outputs.bin }}/Release/vtm.exe -v
+
     - name: Pack (POSIX)
       if: matrix.os != 'windows-latest'
       run: 7z a -ttar vtm_${{ matrix.platform }}_${{ matrix.arch }}.tar ${{ steps.strings.outputs.bin }}/vtm

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,11 +94,11 @@ jobs:
       run: cmake --build ${{ steps.strings.outputs.bin }} --config Release
 
     - name: Test (POSIX)
-      if: matrix.os != 'windows-latest'
+      if: matrix.os != 'windows-latest' && matrix.cpu != 'arm' && matrix.cpu != 'arm64'
       run: ${{ steps.strings.outputs.bin }}/vtm -v
 
     - name: Test (Windows)
-      if: matrix.os == 'windows-latest'
+      if: matrix.os == 'windows-latest' && matrix.cpu != 'arm' && matrix.cpu != 'arm64'
       run: ${{ steps.strings.outputs.bin }}/Release/vtm.exe -v
 
     - name: Pack (POSIX)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Windows/Linux/macOS Intel/ARM x32/x64 binaries
+name: Build binaries
 
 on:
   push:
@@ -8,6 +8,7 @@ on:
 
 jobs:
   build:
+    name: Build for ${{ matrix.platform }}/${{ matrix.cpu }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -99,7 +99,9 @@ jobs:
 
     - name: Test (Windows)
       if: matrix.os == 'windows-latest' && matrix.cpu != 'arm' && matrix.cpu != 'arm64'
-      run: ${{ steps.strings.outputs.bin }}/Release/vtm.exe -v
+      run: |
+        ${{ steps.strings.outputs.bin }}/Release/vtm.exe -v
+      shell: cmd
 
     - name: Pack (POSIX)
       if: matrix.os != 'windows-latest'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,109 @@
+name: Windows/Linux/macOS Intel/ARM x32/x64 binaries
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ windows-latest, ubuntu-latest ]
+        cpu: [ x64, x86, arm64, arm ]
+        exclude:
+          - os: windows-latest
+            cpu: x86
+        include:
+          - os: macos-13
+            platform: macos
+            cpu: universal
+            arch: any
+            cxx: c++
+            flags: '-DCMAKE_OSX_ARCHITECTURES="arm64;x86_64" -DCMAKE_OSX_DEPLOYMENT_TARGET=11.0 -DCMAKE_CXX_FLAGS_RELEASE="-DNDEBUG"'
+          - os: windows-latest
+            platform: windows
+            cpu: Win32
+            arch: x86
+          - os: windows-latest
+            cxx: cl
+          - os: ubuntu-latest
+            cpu: x64
+            cxx: g++
+          - os: ubuntu-latest
+            cpu: x86
+            apt: g++-i686-linux-gnu
+            cxx: /bin/i686-linux-gnu-g++
+          - os: ubuntu-latest
+            cpu: arm
+            apt: g++-arm-linux-gnueabihf
+            cxx: /bin/arm-linux-gnueabihf-g++
+          - os: ubuntu-latest
+            cpu: arm64
+            apt: g++-aarch64-linux-gnu
+            cxx: /bin/aarch64-linux-gnu-g++
+
+          - os: ubuntu-latest
+            flags: '-DCMAKE_CXX_FLAGS_RELEASE="-static -s -DNDEBUG"'
+          - os: windows-latest
+            flags: '-DCMAKE_CXX_FLAGS_RELEASE="/MT /DNDEBUG" -A '
+
+          - os: ubuntu-latest
+            platform: linux
+          - os: windows-latest
+            platform: windows
+
+          - cpu: x64
+            arch: x86_64
+          - cpu: x86
+            arch: x86
+          - cpu: arm64
+            arch: arm64
+          - cpu: arm
+            arch: arm32
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set reusable strings
+      id: strings
+      shell: bash
+      run: |
+        echo "bin=${{ github.workspace }}/bin" >> "$GITHUB_OUTPUT"
+
+    - name: Install compiler
+      if: ${{ matrix.apt }}
+      run: >
+        sudo apt -y install ${{ matrix.apt }}
+
+    - name: Configure CMake
+      run: >
+        cmake -B ${{ steps.strings.outputs.bin }}
+        -DCMAKE_CXX_COMPILER=${{ matrix.cxx }}
+        ${{ matrix.flags }} ${{ matrix.os == 'windows-latest' && matrix.cpu || '' }}
+        -DCMAKE_BUILD_TYPE=Release
+        -S ${{ github.workspace }}
+
+    - name: Build
+      run: cmake --build ${{ steps.strings.outputs.bin }} --config Release
+
+    - name: Pack (POSIX)
+      if: matrix.os != 'windows-latest'
+      run: 7z a -ttar vtm_${{ matrix.platform }}_${{ matrix.arch }}.tar ${{ steps.strings.outputs.bin }}/vtm
+
+    - name: Upload Artifact (POSIX)
+      if: matrix.os != 'windows-latest'
+      uses: actions/upload-artifact@v3
+      with:
+        name: vtm_${{ matrix.platform }}_${{ matrix.arch }}
+        path: vtm_${{ matrix.platform }}_${{ matrix.arch }}.tar
+
+    - name: Upload Artifact (Windows)
+      if: matrix.os == 'windows-latest'
+      uses: actions/upload-artifact@v3
+      with:
+        name: vtm_${{ matrix.platform }}_${{ matrix.arch }}
+        path: ${{ steps.strings.outputs.bin }}/Release/vtm.exe

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,6 +29,8 @@ jobs:
             platform: windows
             cpu: Win32
             arch: x86
+            cxx: cl
+            flags: '-DCMAKE_CXX_FLAGS_RELEASE="/MT /DNDEBUG" -A '
           - os: windows-latest
             cxx: cl
           - os: ubuntu-latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    name: Build for ${{ matrix.platform }}/${{ matrix.cpu }}
+    name: ${{ matrix.platform }} / ${{ matrix.cpu }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -1,6 +1,92 @@
 ﻿{
   "configurations": [
     {
+      "name": "1.Win-x64-Debug",
+      "generator": "Ninja",
+      "configurationType": "Debug",
+      "buildRoot": "${workspaceRoot}\\.vs\\build\\${name}",
+      "installRoot": "${workspaceRoot}\\.vs\\build\\install\\${name}",
+      "cmakeCommandArgs": "",
+      "buildCommandArgs": "",
+      "ctestCommandArgs": "",
+      "inheritEnvironments": [ "msvc_x64_x64" ],
+      "variables": [
+        {
+          "name": "CMAKE_CXX_FLAGS_DEBUG",
+          "value": "-DDEBUG /MTd /Zi /Ob0 /Od /RTC1 /bigobj /utf-8",
+          "type": "STRING"
+        }
+      ],
+      "intelliSenseMode": "windows-msvc-x64"
+    },
+    {
+      "name": "2.WSL-x64-Debug",
+      "generator": "Ninja",
+      "configurationType": "Debug",
+      "buildRoot": "${workspaceRoot}\\.vs\\build\\${name}",
+      "installRoot": "${workspaceRoot}\\.vs\\build\\install\\${name}",
+      "cmakeExecutable": "/usr/bin/cmake",
+      "cmakeCommandArgs": "-S ../../",
+      "buildCommandArgs": "",
+      "ctestCommandArgs": "",
+      "inheritEnvironments": [ "linux_x64" ],
+      "wslPath": "${defaultWSLPath}",
+      "addressSanitizerRuntimeFlags": "detect_leaks=0",
+      "variables": [
+        {
+          "name": "CMAKE_CXX_FLAGS",
+          "value": "-DDEBUG -g -O0 -pthread",
+          "type": "STRING"
+        }
+      ],
+      "intelliSenseMode": "linux-gcc-x64"
+    },
+    {
+      "name": "3.Win-x32-Debug",
+      "generator": "Ninja",
+      "configurationType": "Debug",
+      "buildRoot": "${workspaceRoot}\\.vs\\build\\${name}",
+      "installRoot": "${workspaceRoot}\\.vs\\build\\install\\${name}",
+      "cmakeCommandArgs": "",
+      "buildCommandArgs": "",
+      "ctestCommandArgs": "",
+      "inheritEnvironments": [ "msvc_x86_x64" ],
+      "variables": [
+        {
+          "name": "CMAKE_CXX_FLAGS_DEBUG",
+          "value": "-DDEBUG /MTd /Zi /Ob0 /Od /RTC1 /bigobj /utf-8",
+          "type": "STRING"
+        }
+      ]
+    },
+    {
+      "name": "4.WSL-x32-Debug",
+      "generator": "Ninja",
+      "configurationType": "MinSizeRel",
+      "buildRoot": "${workspaceRoot}\\.vs\\build\\${name}",
+      "installRoot": "${workspaceRoot}\\.vs\\build\\install\\${name}",
+      "cmakeExecutable": "/usr/bin/cmake",
+      "cmakeCommandArgs": "-S ../../",
+      "buildCommandArgs": "",
+      "ctestCommandArgs": "",
+      "inheritEnvironments": [ "linux_x86" ],
+      "variables": [
+        {
+          "name": "CMAKE_CXX_FLAGS",
+          "value": "-pthread -static -s",
+          "type": "STRING"
+        },
+        {
+          "name": "CMAKE_CXX_COMPILER",
+          "value": "/bin/i686-linux-gnu-g++",
+          "type": "STRING"
+        }
+      ],
+      "intelliSenseMode": "linux-gcc-x86",
+      "wslPath": "${defaultWSLPath}",
+      "addressSanitizerRuntimeFlags": "detect_leaks=0"
+    },
+    {
       "name": "PROD-Win-ARM32",
       "generator": "Ninja",
       "configurationType": "MinSizeRel",
@@ -179,107 +265,6 @@
       "wslPath": "${defaultWSLPath}",
       "addressSanitizerRuntimeFlags": "detect_leaks=0",
       "remoteCopyUseCompilerDefaults": true
-    },
-    {
-      "name": "Win-x32-Debug",
-      "generator": "Ninja",
-      "configurationType": "Debug",
-      "buildRoot": "${workspaceRoot}\\.vs\\build\\${name}",
-      "installRoot": "${workspaceRoot}\\.vs\\build\\install\\${name}",
-      "cmakeCommandArgs": "",
-      "buildCommandArgs": "",
-      "ctestCommandArgs": "",
-      "inheritEnvironments": [ "msvc_x86_x64" ],
-      "variables": [
-        {
-          "name": "CMAKE_CXX_FLAGS_DEBUG",
-          "value": "-DDEBUG /MTd /Zi /Ob0 /Od /RTC1 /bigobj /utf-8",
-          "type": "STRING"
-        }
-      ]
-    },
-    {
-      "name": "Win-x64-Debug",
-      "generator": "Ninja",
-      "configurationType": "Debug",
-      "buildRoot": "${workspaceRoot}\\.vs\\build\\${name}",
-      "installRoot": "${workspaceRoot}\\.vs\\build\\install\\${name}",
-      "cmakeCommandArgs": "",
-      "buildCommandArgs": "",
-      "ctestCommandArgs": "",
-      "inheritEnvironments": [ "msvc_x64_x64" ],
-      "variables": [
-        {
-          "name": "CMAKE_CXX_FLAGS_DEBUG",
-          "value": "-DDEBUG /MTd /Zi /Ob0 /Od /RTC1 /bigobj /utf-8",
-          "type": "STRING"
-        }
-      ],
-      "intelliSenseMode": "windows-msvc-x64"
-    },
-    {
-      "name": "Win-x64-Release",
-      "generator": "Ninja",
-      "configurationType": "MinSizeRel",
-      "buildRoot": "${workspaceRoot}\\.vs\\build\\${name}",
-      "installRoot": "${workspaceRoot}\\.vs\\build\\install\\${name}",
-      "cmakeCommandArgs": "",
-      "buildCommandArgs": "",
-      "ctestCommandArgs": "",
-      "inheritEnvironments": [ "msvc_x64_x64" ],
-      "variables": [
-        {
-          "name": "CMAKE_CXX_FLAGS_MINSIZEREL",
-          "value": "/EHsc /bigobj /utf-8",
-          "type": "STRING"
-        }
-      ],
-      "intelliSenseMode": "windows-msvc-x64"
-    },
-    {
-      "name": "WSL-x64-Debug",
-      "generator": "Ninja",
-      "configurationType": "Debug",
-      "buildRoot": "${workspaceRoot}\\.vs\\build\\${name}",
-      "installRoot": "${workspaceRoot}\\.vs\\build\\install\\${name}",
-      "cmakeExecutable": "/usr/bin/cmake",
-      "cmakeCommandArgs": "-S ../../",
-      "buildCommandArgs": "",
-      "ctestCommandArgs": "",
-      "inheritEnvironments": [ "linux_x64" ],
-      "wslPath": "${defaultWSLPath}",
-      "addressSanitizerRuntimeFlags": "detect_leaks=0",
-      "variables": [
-        {
-          "name": "CMAKE_CXX_FLAGS",
-          "value": "-DDEBUG -g -O0 -pthread",
-          "type": "STRING"
-        }
-      ],
-      "intelliSenseMode": "linux-gcc-x64"
-    },
-    {
-      "name": "WSL-x64-Release",
-      "generator": "Ninja",
-      "configurationType": "MinSizeRel",
-      "buildRoot": "${workspaceRoot}\\.vs\\build\\${name}",
-      "installRoot": "${workspaceRoot}\\.vs\\build\\install\\${name}",
-      "cmakeExecutable": "/usr/bin/cmake",
-      "cmakeCommandArgs": "-S ../../",
-      "buildCommandArgs": "",
-      "ctestCommandArgs": "",
-      "inheritEnvironments": [ "linux_x64" ],
-      "wslPath": "${defaultWSLPath}",
-      "addressSanitizerRuntimeFlags": "detect_leaks=0",
-      "remoteCopyUseCompilerDefaults": true,
-      "intelliSenseMode": "linux-gcc-x64",
-      "variables": [
-        {
-          "name": "CMAKE_CXX_FLAGS",
-          "value": "-Ofast -pthread -s",
-          "type": "STRING"
-        }
-      ]
     }
   ]
 }

--- a/readme.md
+++ b/readme.md
@@ -22,11 +22,13 @@ Text-baased desktop inside your console.
 
 # Building from Source
 
+You can use [Github Actions](../../actions) to build statically linked binaries for the big three OS platforms: Linux, Windows, and macOS.
+
 ### Unix
 
 Build-time dependencies
  - 64-bit system host
- - `git`, `cmake`,  `C++20 compiler` ([GCC 11](https://gcc.gnu.org/projects/cxx-status.html), [Clang 14](https://clang.llvm.org/cxx_status.html), [MSVC](https://visualstudio.microsoft.com/downloads/))
+ - `git`, `cmake`,  `C++20 compiler` ([GCC 11](https://gcc.gnu.org/projects/cxx-status.html), [Clang 14](https://clang.llvm.org/cxx_status.html))
  - RAM requirements for compilation:
    - Compiling with GCC — 4GB of RAM
    - Compiling with Clang — 9GB of RAM
@@ -41,19 +43,7 @@ sudo cmake --install bin
 vtm
 ```
 
-Note: A 32-bit binary executable can only be built using cross-compilation on a 64-bit system. In order to do so make sure you have additional cross-compilation libraries installed, e.g. on Linux `sudo apt install gcc-i686-linux-gnu g++-i686-linux-gnu` (x86) or `sudo apt install gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf` (ARM32).
-
-Example of cross-compilation for x86 Linux
-```
-cmake . -B bin -DCMAKE_CXX_COMPILER="/bin/i686-linux-gnu-g++" -DCMAKE_CXX_FLAGS="-static -pthread -s"
-cmake --build bin
-```
-
-Example of cross-compilation for ARM32 Linux
-```
-cmake . -B bin -DCMAKE_CXX_COMPILER="/bin/arm-linux-gnueabihf-g++" -DCMAKE_CXX_FLAGS="-static -pthread -s -Wno-psabi"
-cmake --build bin
-```
+Note: A 32-bit binary executable can only be built using cross-compilation on a 64-bit system.
 
 ### Windows
 

--- a/src/netxs/apps/desk.hpp
+++ b/src/netxs/apps/desk.hpp
@@ -30,6 +30,7 @@ namespace netxs::app::desk
         text    param{};
         text    patch{};
         bool   folded{};
+        bool notfound{};
     };
 
     using menu = std::unordered_map<text, spec>;

--- a/src/netxs/apps/desk.hpp
+++ b/src/netxs/apps/desk.hpp
@@ -506,7 +506,7 @@ namespace netxs::app::desk
 
             window->invoke([menu_max_size, menu_min_size, menu_selected](auto& boss) mutable
             {
-                auto ground = background("gems;About;"); // It can't be a child - it has exclusive rendering (first of all).
+                auto ground = background("gems;Demo;"); // It can't be a child - it has exclusive rendering (first of all).
                 boss.LISTEN(tier::release, e2::form::upon::vtree::attached, parent, -, (ground, current_default = text{}, previous_default = text{}, selected = text{ menu_selected }))
                 {
                     current_default  = selected;

--- a/src/netxs/apps/shop.hpp
+++ b/src/netxs/apps/shop.hpp
@@ -29,7 +29,7 @@ namespace netxs::events::userland
 namespace netxs::app::shop
 {
     static constexpr auto id = "gems";
-    static constexpr auto desc = "Desktopio App Manager (DEMO)";
+    static constexpr auto desc = "Application Distribution Hub (DEMO)";
 
     using events = netxs::events::userland::shop;
 
@@ -80,7 +80,7 @@ namespace netxs::app::shop
                 appstore_head =
                 ansi::nil().eol().mgl(2).mgr(2)
                 .bld(true).fgc(whitelt).jet(bias::left).wrp(wrap::on)
-                .add("Desktopio Application Distribution Hub").bld(faux).add("\n\n");
+                .add("Application Distribution Hub").bld(faux).add("\n\n");
 
                 auto textancy_text = ansi::nil().add(
                 "Hello World!😎\n"

--- a/src/netxs/apps/shop.hpp
+++ b/src/netxs/apps/shop.hpp
@@ -216,7 +216,6 @@ namespace netxs::app::shop
                     auto [menu_block, cover, menu_data] = app::shared::menu::create(config, {});
                     menu_object->attach(slot::_1, menu_block);
                     menu_object->attach(slot::_2, ui::post::ctor())
-                               ->limits({ 42,-1 }, { -1,-1 })
                                ->upload(appstore_head)
                                ->active();
                 auto layers = object->attach(slot::_2, ui::cake::ctor());

--- a/src/netxs/apps/shop.hpp
+++ b/src/netxs/apps/shop.hpp
@@ -94,35 +94,32 @@ namespace netxs::app::shop
                     "Virtual Terminal."),
 
                     item("Tile", bluedk, "3", "Free ", "Get",
-                    "Meta object. Tiling window manager."),
+                    "Tiling window manager."),
 
                     item("Text", cyandk, "102", "Free ", "Get",
-                    "A simple text editor for Desktopio environment "
-                    "and a basic editing tool which enables "
-                    "desktop users to create documents that "
-                    "contain ANSI-formatted text."),
+                    "Text editor for Desktopio environment. "
+                    "Basic editing tool which allows "
+                    "desktop users to create documents containing rich text."),
 
                     item("Calc", greendk, "30", "Free ", "Get",
-                    "A simple spreadsheet calculator application."),
+                    "Spreadsheet calculator."),
 
                     item("Task", magentadk, "311", "Free ", "Get",
-                    "A task manager program that displays "
+                    "Task manager that displays "
                     "information about CPU, memory utilization, "
                     "and current I/O usage."),
 
                     item("Draw", reddk, "64", "Free ", "Get",
-                    "A simple program which enables desktop "
-                    "users to create sophisticated ANSI-artworks."),
+                    "ANSI-artwork Studio."),
 
                     item("Char", yellowdk, "161", "Free ", "Get",
-                    "An utility that allows browsing all Unicode "
-                    "codepoints and inspecting their metadata."),
+                    "Unicode codepoints browser."),
 
                     item(ansi::fgc(0xFFff0000).add("File"), cyanlt, "4", "Free ", "Get",
-                    "An orthodox file manager for Desktopio environment."),
+                    "File manager."),
 
                     item("Time", bluedk, "4", "Free ", "Get",
-                    "A calendar application for Desktopio environment."),
+                    "Calendar."),
 
                     item("Goto", bluedk, "4", "Free ", "Get",
                     "Internet/SSH browser."),
@@ -140,7 +137,7 @@ namespace netxs::app::shop
                     "Workspace settings configurator."),
 
                     item("View", cyandk, "1", "Free ", "Get",
-                    "Meta object. Workspace location marker."),
+                    "Workspace location marker."),
                 };
 
                 auto qr = escx(

--- a/src/netxs/apps/term.hpp
+++ b/src/netxs/apps/term.hpp
@@ -670,9 +670,9 @@ namespace netxs::app::term
                                 });
                             }
                         }
-                        else
+                        else if (boss.base::size() != new_size)
                         {
-                            auto panel = boss.size();
+                            auto panel = boss.base::size();
                             new_size = new_size.less(dot_11, panel, std::max(dot_11, new_size));
                             auto warp = rect{ dot_00, new_size } - rect{ dot_00, panel };
                             boss.base::locked = faux; // Unlock resizing.

--- a/src/netxs/apps/text.hpp
+++ b/src/netxs/apps/text.hpp
@@ -38,150 +38,40 @@ namespace netxs::app::textancy
         text topic3 = R"( 
 Plain text vs. rich text
 
-There are important differences between plain text (created and edited by 
-text editors) and rich text (such as that created by word processors or 
-desktop publishing software).
+There are important differences between plain text (created and edited by text editors) and rich text (such as that created by word processors or desktop publishing software).
 
-Plain text exclusively consists of character representation. Each character 
-is represented by a fixed-length sequence of one, two, or four bytes, or as a 
-variable-length sequence of one to four bytes, in accordance to specific 
-character encoding conventions, such as ASCII, ISO/IEC 2022, UTF-8, or 
-Unicode. These conventions define many printable characters, but also 
-non-printing characters that control the flow of the text, such as space, 
-line break, and page break. Plain text contains no other information about 
-the text itself, not even the character encoding convention employed. Plain 
-text is stored in text files, although text files do not exclusively store 
-plain text. In the early days of computers, plain text was displayed using a 
-monospace font, such that horizontal alignment and columnar formatting were 
-sometimes done using whitespace characters. For compatibility reasons, this 
-tradition has not changed.
+Plain text exclusively consists of character representation. Each character is represented by a fixed-length sequence of one, two, or four bytes, or as a variable-length sequence of one to four bytes, in accordance to specific character encoding conventions, such as ASCII, ISO/IEC 2022, UTF-8, or Unicode. These conventions define many printable characters, but also non-printing characters that control the flow of the text, such as space, line break, and page break. Plain text contains no other information about the text itself, not even the character encoding convention employed. Plain text is stored in text files, although text files do not exclusively store plain text. In the early days of computers, plain text was displayed using a monospace font, such that horizontal alignment and columnar formatting were sometimes done using hitespace characters. For compatibility reasons, this tradition has not changed.
 
-Rich text, on the other hand, may contain metadata, character formatting data 
-(e.g. typeface, size, weight and style), paragraph formatting data (e.g. 
-indentation, alignment, letter and word distribution, and space between lines 
-or other paragraphs), and page specification data (e.g. size, margin and 
-reading direction). Rich text can be very complex. Rich text can be saved in 
-binary format (e.g. DOC), text files adhering to a markup language (e.g. RTF 
-or HTML), or in a hybrid form of both (e.g. Office Open XML).
+Rich text, on the other hand, may contain metadata, character formatting data (e.g. typeface, size, weight and style), paragraph formatting data (e.g. indentation, alignment, letter and word distribution, and space between lines or other paragraphs), and page specification data (e.g. size, margin and reading direction). Rich text can be very complex. Rich text can be saved in binary format (e.g. DOC), text files adhering to a markup language (e.g. RTF or HTML), or in a hybrid form of both (e.g. Office Open XML).
 
-Text editors are intended to open and save text files containing either plain 
-text or anything that can be interpreted as plain text, including the markup 
-for rich text or the markup for something else (e.g. SVG).
+Text editors are intended to open and save text files containing either plain text or anything that can be interpreted as plain text, including the markup for rich text or the markup for something else (e.g. SVG).
 
 History
 
-Before text editors existed, computer text was punched into cards with 
-keypunch machines. Physical boxes of these thin cardboard cards were then 
-inserted into a card-reader. Magnetic tape and disk "card-image" files 
-created from such card decks often had no line-separation characters at all, 
-and assumed fixed-length 80-character records. An alternative to cards was 
-punched paper tape. It could be created by some teleprinters (such as the 
-Teletype), which used special characters to indicate ends of records.
+Before text editors existed, computer text was punched into cards with keypunch machines. Physical boxes of these thin cardboard cards were then inserted into a card-reader. Magnetic tape and disk "card-image" files created from such card decks often had no line-separation characters at all, and assumed fixed-length 80-character records. An alternative to cards was punched paper tape. It could be created by some teleprinters (such as the Teletype), which used special characters to indicate ends of records.
 
-The first text editors were "line editors" oriented to teleprinter- or 
-typewriter-style terminals without displays. Commands (often a single 
-keystroke) effected edits to a file at an imaginary insertion point called 
-the "cursor". Edits were verified by typing a command to print a small 
-section of the file, and periodically by printing the entire file. In some 
-line editors, the cursor could be moved by commands that specified the line 
-number in the file, text strings (context) for which to search, and 
-eventually regular expressions. Line editors were major improvements over 
-keypunching. Some line editors could be used by keypunch; editing commands 
-could be taken from a deck of cards and applied to a specified file. Some 
-common line editors supported a "verify" mode in which change commands 
-displayed the altered lines.
+The first text editors were "line editors" oriented to teleprinter- or typewriter-style terminals without displays. Commands (often a single keystroke) effected edits to a file at an imaginary insertion point called the "cursor". Edits were verified by typing a command to print a small section of the file, and periodically by printing the entire file. In some line editors, the cursor could be moved by commands that specified the line number in the file, text strings (context) for which to search, and eventually regular expressions. Line editors were major improvements over keypunching. Some line editors could be used by keypunch; editing commands could be taken from a deck of cards and applied to a specified file. Some common line editors supported a "verify" mode in which change commands displayed the altered lines.
 
-When computer terminals with video screens became available, screen-based 
-text editors (sometimes called just "screen editors") became common. One of 
-the earliest full-screen editors was O26, which was written for the operator 
-console of the CDC 6000 series computers in 1967. Another early full-screen 
-editor was vi. Written in the 1970s, it is still a standard editor on Unix 
-and Linux operating systems. Also written in the 1970s was the UCSD Pascal 
-Screen Oriented Editor, which was optimized both for indented source code as 
-well as general text. Emacs, one of the first free and open source software 
-projects, is another early full-screen or real-time editor, one that was 
-ported to many systems. A full-screen editor's ease-of-use and speed 
-(compared to the line-based editors) motivated many early purchases of video 
-terminals.
+When computer terminals with video screens became available, screen-based text editors (sometimes called just "screen editors") became common. One of the earliest full-screen editors was O26, which was written for the operator console of the CDC 6000 series computers in 1967. Another early full-screen editor was vi. Written in the 1970s, it is still a standard editor on Unix and Linux operating systems. Also written in the 1970s was the UCSD Pascal Screen Oriented Editor, which was optimized both for indented source code as well as general text. Emacs, one of the first free and open source software projects, is another early full-screen or real-time editor, one that was ported to many systems. A full-screen editor's ease-of-use and speed (compared to the line-based editors) motivated many early purchases of video terminals.
 
-The core data structure in a text editor is the one that manages the string 
-(sequence of characters) or list of records that represents the current state 
-of the file being edited. While the former could be stored in a single long 
-consecutive array of characters, the desire for text editors that could more 
-quickly insert text, delete text, and undo/redo previous edits led to the 
-development of more complicated sequence data structures. A typical text 
-editor uses a gap buffer, a linked list of lines (as in PaperClip), a piece 
-table, or a rope, as its sequence data structure.
+The core data structure in a text editor is the one that manages the string (sequence of characters) or list of records that represents the current state of the file being edited. While the former could be stored in a single long consecutive array of characters, the desire for text editors that could more quickly insert text, delete text, and undo/redo previous edits led to the development of more complicated sequence data structures. A typical text editor uses a gap buffer, a linked list of lines (as in PaperClip), a piece table, or a rope, as its sequence data structure.
 
 Types of text editors
 
-Some text editors are small and simple, while others offer broad and complex 
-functions. For example, Unix and Unix-like operating systems have the pico 
-editor (or a variant), but many also include the vi and Emacs editors. 
-Microsoft Windows systems come with the simple Notepad, though many 
-people—especially programmers—prefer other editors with more features. Under 
-Apple Macintosh's classic Mac OS there was the native SimpleText, which was 
-replaced in Mac OS X by TextEdit, which combines features of a text editor 
-with those typical of a word processor such as rulers, margins and multiple 
-font selection. These features are not available simultaneously, but must be 
-switched by user command, or through the program automatically determining 
-the file type.
+Some text editors are small and simple, while others offer broad and complex functions. For example, Unix and Unix-like operating systems have the pico editor (or a variant), but many also include the vi and Emacs editors. Microsoft Windows systems come with the simple Notepad, though many people—especially programmers—prefer other editors with more features. Under Apple Macintosh's classic Mac OS there was the native SimpleText, which was replaced in Mac OS X by TextEdit, which combines features of a text editor with those typical of a word processor such as rulers, margins and multiple font selection. These features are not available simultaneously, but must be switched by user command, or through the program automatically determining the file type.
 
-Most word processors can read and write files in plain text format, allowing 
-them to open files saved from text editors. Saving these files from a word 
-processor, however, requires ensuring the file is written in plain text 
-format, and that any text encoding or BOM settings won't obscure the file for 
-its intended use. Non-WYSIWYG word processors, such as WordStar, are more 
-easily pressed into service as text editors, and in fact were commonly used 
-as such during the 1980s. The default file format of these word processors 
-often resembles a markup language, with the basic format being plain text and 
-visual formatting achieved using non-printing control characters or escape 
-sequences. Later word processors like Microsoft Word store their files in a 
-binary format and are almost never used to edit plain text files.
+Most word processors can read and write files in plain text format, allowing them to open files saved from text editors. Saving these files from a word processor, however, requires ensuring the file is written in plain text format, and that any text encoding or BOM settings won't obscure the file for its intended use. Non-WYSIWYG word processors, such as WordStar, are more easily pressed into service as text editors, and in fact were commonly used as such during the 1980s. The default file format of these word processors often resembles a markup language, with the basic format being plain text and visual formatting achieved using non-printing control characters or escape 
+sequences. Later word processors like Microsoft Word store their files in a binary format and are almost never used to edit plain text files.
 
-Some text editors can edit unusually large files such as log files or an 
-entire database placed in a single file. Simpler text editors may just read 
-files into the computer's main memory. With larger files, this may be a slow 
-process, and the entire file may not fit. Some text editors do not let the 
-user start editing until this read-in is complete. Editing performance also 
-often suffers in nonspecialized editors, with the editor taking seconds or 
-even minutes to respond to keystrokes or navigation commands. Specialized 
-editors have optimizations such as only storing the visible portion of large 
-files in memory, improving editing performance.
+Some text editors can edit unusually large files such as log files or an entire database placed in a single file. Simpler text editors may just read files into the computer's main memory. With larger files, this may be a slow process, and the entire file may not fit. Some text editors do not let the user start editing until this read-in is complete. Editing performance also often suffers in nonspecialized editors, with the editor taking seconds or even minutes to respond to keystrokes or navigation commands. Specialized 
+editors have optimizations such as only storing the visible portion of large files in emory, improving editing performance.
 
-Some editors are programmable, meaning, e.g., they can be customized for 
-specific uses. With a programmable editor it is easy to automate repetitive 
-tasks or, add new functionality or even implement a new application within 
-the framework of the editor. One common motive for customizing is to make a 
-text editor use the commands of another text editor with which the user is 
-more familiar, or to duplicate missing functionality the user has come to 
-depend on. Software developers often use editor customizations tailored to 
-the programming language or development environment they are working in. The 
-programmability of some text editors is limited to enhancing the core editing 
-functionality of the program, but Emacs can be extended far beyond editing 
-text files—for web browsing, reading email, online chat, managing files or 
-playing games and is often thought of as a Lisp execution environment with a 
-Text User Interface. Emacs can even be programmed to emulate Vi, its rival in 
-the traditional editor wars of Unix culture.
+Some editors are programmable, meaning, e.g., they can be customized for specific uses. With a programmable editor it is easy to automate repetitive tasks or, add new functionality or even implement a new application within the framework of the editor. One common motive for customizing is to make a text editor use the commands of another text editor with which the user is more familiar, or to duplicate missing functionality the user has come to depend on. Software developers often use editor customizations tailored to the programming language or development environment they are working in. The programmability of some text editors is limited to enhancing the core editing functionality of the program, but Emacs can be extended far beyond editing text files—for web browsing, reading email, online chat, managing files or playing games and is often thought of as a Lisp execution environment with a Text User Interface. Emacs can even be programmed to emulate Vi, its rival in the traditional editor wars of Unix culture.
 
-An important group of programmable editors uses REXX as a scripting language. 
-These "orthodox editors" contain a "command line" into which commands and 
-macros can be typed and text lines into which line commands and macros can be 
-typed. Most such editors are derivatives of ISPF/PDF EDIT or of XEDIT, IBM's 
-flagship editor for VM/SP through z/VM. Among them are THE, KEDIT, X2, 
-Uni-edit, and SEDIT.
+An important group of programmable editors uses REXX as a scripting language. These "orthodox editors" contain a "command line" into which commands and macros can be typed and text lines into which line commands and macros can be typed. Most such editors are derivatives of ISPF/PDF EDIT or of XEDIT, IBM's flagship editor for VM/SP through z/VM. Among them are THE, KEDIT, X2, Uni-edit, and SEDIT.
 
-A text editor written or customized for a specific use can determine what the 
-user is editing and assist the user, often by completing programming terms 
-and showing tooltips with relevant documentation. Many text editors for 
-software developers include source code syntax highlighting and automatic 
-indentation to make programs easier to read and write. Programming editors 
-often let the user select the name of an include file, function or variable, 
-then jump to its definition. Some also allow for easy navigation back to the 
-original section of code by storing the initial cursor location or by 
-displaying the requested definition in a popup window or temporary buffer. 
-Some editors implement this ability themselves, but often an auxiliary 
-utility like ctags is used to locate the definitions.
+A text editor written or customized for a specific use can determine what the user is editing and assist the user, often by completing programming terms and showing tooltips with relevant documentation. Many text editors for software developers include source code syntax highlighting and automatic indentation to make programs easier to read and write. Programming editors often let the user select the name of an include file, function or variable, then jump to its definition. Some also allow for easy navigation back to the original section of code by storing the initial cursor location or by 
+displaying the requested definition in a popup window or temporary buffer. Some editors implement this ability themselves, but often an auxiliary utility like ctags is used to locate the definitions.
 
 )";
 
@@ -219,10 +109,10 @@ utility like ctags is used to locate the definitions.
                                 auto edit_box = scroll->attach(ui::post::ctor(true))
                                                       ->plugin<pro::caret>(true, faux, twod{ 25,1 })
                                                       ->colors(blackdk, whitelt)
-                                                      ->upload(ansi::wrp(wrap::off).mgl(1)
+                                                      ->upload(ansi::wrp(wrap::on).mgl(1).mgr(1)
                                                       .add(topic3)
                                                       .fgc(highlight_color.bgc())
-                                                      .add("From Wikipedia, the free encyclopedia"));
+                                                      .wrp(wrap::off).add("From Wikipedia, the free encyclopedia"));
                     auto status_line = body_area->attach(slot::_2, ui::post::ctor())
                                                 ->limits({ 1,1 }, { -1,1 })
                                                 ->upload(ansi::wrp(wrap::off).mgl(1).mgr(1).jet(bias::right).fgc(whitedk)

--- a/src/netxs/desktopio/application.hpp
+++ b/src/netxs/desktopio/application.hpp
@@ -23,7 +23,7 @@ namespace netxs::app
 
 namespace netxs::app::shared
 {
-    static const auto version = "v0.9.9v";
+    static const auto version = "v0.9.9w";
     static const auto desktopio = "desktopio";
     static const auto logsuffix = "_log";
     static const auto usr_config = "~/.config/vtm/settings.xml";

--- a/src/netxs/desktopio/baseui.hpp
+++ b/src/netxs/desktopio/baseui.hpp
@@ -998,7 +998,7 @@ namespace netxs::ui
                 if (parent_ptr) parent_ptr->base::reflow(); //todo too expensive. ? accumulate deferred reflow? or make it when stated?
             };
             //todo deprecated
-            LISTEN(tier::release, /*!*/e2::render::any, parent_canvas)
+            LISTEN(tier::release, e2::render::any, parent_canvas)
             {
                 if (base::filler.wdt() && !base::hidden)
                 {

--- a/src/netxs/desktopio/canvas.hpp
+++ b/src/netxs/desktopio/canvas.hpp
@@ -2011,7 +2011,7 @@ namespace netxs
             return c;
         }
         template<class P>
-        void /*!*/fill(rect block, P fuse) // core: Process the specified region by the specified proc.
+        void fill(rect block, P fuse) // core: Process the specified region by the specified proc.
         {
             block.normalize_itself();
             netxs::onrect(*this, block, fuse);
@@ -2166,7 +2166,7 @@ namespace netxs
             return word<Direction>(twod{ offset, 0 });
         }
         template<class P>
-        void /*!*/cage(rect area, dent border, P fuse) // core: Draw the cage around specified area.
+        void cage(rect area, dent border, P fuse) // core: Draw the cage around specified area.
         {
             auto temp = area;
             temp.size.y = std::max(0, border.t); // Top
@@ -2183,7 +2183,7 @@ namespace netxs
             fill(temp.clip(area), fuse);
         }
         template<class P>
-        void /*!*/cage(rect area, twod border_width, P fuse) // core: Draw the cage around specified area.
+        void cage(rect area, twod border_width, P fuse) // core: Draw the cage around specified area.
         {
             cage(area, dent{ border_width.x, border_width.x, border_width.y, border_width.y }, fuse);
         }

--- a/src/netxs/desktopio/console.hpp
+++ b/src/netxs/desktopio/console.hpp
@@ -787,7 +787,7 @@ namespace netxs::ui
         wptr       nexthop; // gate: .
         hook       oneoff_focus; // gate: .
 
-        void /*!*/draw_foreign_names(face& parent_canvas)
+        void draw_foreign_names(face& parent_canvas)
         {
             auto& header = *uname.lyric;
             auto  half_x = header.size().x / 2;
@@ -802,7 +802,7 @@ namespace netxs::ui
                 parent_canvas.fill(header, cell::shaders::fuse);
             }
         }
-        void /*!*/draw_mouse_pointer(face& canvas)
+        void draw_mouse_pointer(face& canvas)
         {
             static const auto idle = cell{}.txt("\xE2\x96\x88"/*\u2588 █ */).bgc(0x00).fgc(0xFF00ff00);
             static const auto busy = cell{}.bgc(reddk).fgc(0xFFffffff);
@@ -817,7 +817,7 @@ namespace netxs::ui
                 canvas.fill(area, cell::shaders::fuse(brush));
             }
         }
-        void /*!*/draw_clipboard_preview(face& canvas, time const& stamp)
+        void draw_clipboard_preview(face& canvas, time const& stamp)
         {
             for (auto& [id, gear_ptr] : input.gears)
             {
@@ -834,7 +834,7 @@ namespace netxs::ui
                 }
             }
         }
-        void /*!*/draw_tooltips(face& canvas, time const& stamp)
+        void draw_tooltips(face& canvas, time const& stamp)
         {
             auto full = canvas.full();
             auto area = canvas.area();

--- a/src/netxs/desktopio/consrv.hpp
+++ b/src/netxs/desktopio/consrv.hpp
@@ -639,6 +639,15 @@ struct impl : consrv
             result += tail;
             line = result;
         }
+        auto off_aliases(text& exe)
+        {
+            auto lock = std::lock_guard{ locker };
+            utf::to_low(exe);
+            if (auto exe_iter = macros.find(exe); exe_iter != macros.end())
+            {
+                macros.erase(exe_iter);
+            }
+        }
         void reset()
         {
             auto lock = std::lock_guard{ locker };
@@ -1135,7 +1144,12 @@ struct impl : consrv
                             case VK_F4:  //todo menu
                             case VK_F7:  //todo menu
                             case VK_F9:  //todo menu
-                            case VK_F10: //todo clear exes aliases
+                            case VK_F10:
+                            if (cooked.ctrl & (LEFT_ALT_PRESSED | RIGHT_ALT_PRESSED))
+                            {
+                                off_aliases(nameview);
+                                break;
+                            }
                             case VK_F11:
                             case VK_F12:
                                 break;

--- a/src/netxs/desktopio/consrv.hpp
+++ b/src/netxs/desktopio/consrv.hpp
@@ -4768,7 +4768,25 @@ struct impl : consrv
             input;
         };
         auto& packet = payload::cast(upload);
+        //todo depuplicate code
+        auto exe = text{};
+        if (packet.input.utf16)
+        {
+            auto data = take_buffer<wchr, feed::fwd>(packet);
+            auto shadow = wiew{ data.data(), data.size() };
+            utf::to_utf(shadow, exe);
+        }
+        else
+        {
+            auto data = take_buffer<char, feed::fwd>(packet);
+            auto shadow = view{ data.data(), data.size() };
+            if (inpenc->codepage == CP_UTF8) exe = shadow;
+            else                             inpenc->decode_run(shadow, exe);
+        }
+        auto input_exe = exe;
+        utf::to_low(exe);
         log("\t", show_page(packet.input.utf16, inpenc->codepage),
+          "\n\tinput.exe: ", ansi::hi(utf::debase<faux, faux>(input_exe)),
           "\n\tlimit: ", packet.input.count);
     }
     auto api_input_history_get_volume        ()

--- a/src/netxs/desktopio/consrv.hpp
+++ b/src/netxs/desktopio/consrv.hpp
@@ -4440,7 +4440,7 @@ struct impl : consrv
     }
     auto api_input_history_clear             ()
     {
-        log(prompt, "ClearConsoleCommandHistory");
+        log(prompt, "ExpungeConsoleCommandHistory");
         struct payload : drvpacket<payload>
         {
             struct
@@ -4509,7 +4509,7 @@ struct impl : consrv
     }
     auto api_input_history_info_get          ()
     {
-        log(prompt, "GetConsoleHistory");
+        log(prompt, "GetConsoleHistoryInfo");
         struct payload : drvpacket<payload>
         {
             struct
@@ -4528,7 +4528,7 @@ struct impl : consrv
     }
     auto api_input_history_info_set          ()
     {
-        log(prompt, "SetConsoleHistory");
+        log(prompt, "SetConsoleHistoryInfo");
         struct payload : drvpacket<payload>
         {
             struct

--- a/src/netxs/desktopio/consrv.hpp
+++ b/src/netxs/desktopio/consrv.hpp
@@ -1142,7 +1142,12 @@ struct impl : consrv
                             case VK_CLEAR:/*NUMPAD 5*/
                             case VK_F2:  //todo menu
                             case VK_F4:  //todo menu
-                            case VK_F7:  //todo menu
+                            case VK_F7:
+                            if (cooked.ctrl & (LEFT_ALT_PRESSED | RIGHT_ALT_PRESSED))
+                            {
+                                hist = {};
+                                break;
+                            }
                             case VK_F9:  //todo menu
                             case VK_F10:
                             if (cooked.ctrl & (LEFT_ALT_PRESSED | RIGHT_ALT_PRESSED))

--- a/src/netxs/desktopio/consrv.hpp
+++ b/src/netxs/desktopio/consrv.hpp
@@ -4322,16 +4322,16 @@ struct impl : consrv
             {
                 struct
                 {
-                    ui16 srccb; // Length in bytes.
+                    ui16 srccb;
                     ui16 pad_1;
-                    ui16 execb; // Length in bytes.
+                    ui16 execb;
                     byte utf16;
                 }
                 input;
                 struct
                 {
                     ui16 pad_1;
-                    ui16 dstcb; // Length in bytes.
+                    ui16 dstcb;
                     ui16 pad_2;
                     byte pad_3;
                 }
@@ -4384,9 +4384,9 @@ struct impl : consrv
         {
             struct
             {
-                ui16 srccb; // Length in bytes.
-                ui16 dstcb; // Length in bytes.
-                ui16 execb; // Length in bytes.
+                ui16 srccb;
+                ui16 dstcb;
+                ui16 execb;
                 byte utf16;
             }
             input;

--- a/src/netxs/desktopio/consrv.hpp
+++ b/src/netxs/desktopio/consrv.hpp
@@ -1173,6 +1173,7 @@ struct impl : consrv
                             if (cooked.ctrl & (LEFT_ALT_PRESSED | RIGHT_ALT_PRESSED))
                             {
                                 hist = {};
+                                if (server.io_log) log("%%Cleared command history for process '%procname%'", prompt::cin, nameview);
                                 break;
                             }
                             case VK_F9:  //todo menu
@@ -1180,6 +1181,7 @@ struct impl : consrv
                             if (cooked.ctrl & (LEFT_ALT_PRESSED | RIGHT_ALT_PRESSED))
                             {
                                 off_aliases(nameview);
+                                if (server.io_log) log("%%Removed DOSKEY aliases for process '%procname%'", prompt::cin, nameview);
                                 break;
                             }
                             case VK_F11:

--- a/src/netxs/desktopio/consrv.hpp
+++ b/src/netxs/desktopio/consrv.hpp
@@ -4339,8 +4339,8 @@ struct impl : consrv
             };
         };
         auto& packet = payload::cast(upload);
-        auto src = text{};
         auto exe = text{};
+        auto src = text{};
         auto dst = text{};
         if (packet.input.utf16)
         {
@@ -4348,8 +4348,8 @@ struct impl : consrv
             if (data.size() * sizeof(wchr) == packet.input.srccb + packet.input.execb)
             {
                 auto shadow = wiew{ data.data(), data.size() };
-                utf::to_utf(utf::pop_front(shadow, packet.input.srccb / sizeof(wchr)), src);
                 utf::to_utf(utf::pop_front(shadow, packet.input.execb / sizeof(wchr)), exe);
+                utf::to_utf(utf::pop_front(shadow, packet.input.srccb / sizeof(wchr)), src);
             }
         }
         else
@@ -4360,22 +4360,22 @@ struct impl : consrv
                 auto shadow = view{ data.data(), data.size() };
                 if (inpenc->codepage == CP_UTF8)
                 {
-                    src = utf::pop_front(shadow, packet.input.srccb);
                     exe = utf::pop_front(shadow, packet.input.execb);
+                    src = utf::pop_front(shadow, packet.input.srccb);
                 }
                 else
                 {
-                    inpenc->decode_run(utf::pop_front(shadow, packet.input.srccb), src);
                     inpenc->decode_run(utf::pop_front(shadow, packet.input.execb), exe);
+                    inpenc->decode_run(utf::pop_front(shadow, packet.input.srccb), src);
                 }
             }
         }
         packet.reply.dstcb = 0; // Far crashed if it is not set.
 
         log("\t", show_page(packet.input.utf16, inpenc->codepage),
-          "\n\tsrc: ", src,
-          "\n\texe: ", exe,
-          "\n\treply.dst: ", dst);
+          "\n\texe: ",       ansi::hi(utf::debase<faux, faux>(exe)),
+          "\n\tsrc: ",       ansi::hi(utf::debase<faux, faux>(src)),
+          "\n\treply.dst: ", ansi::hi(utf::debase<faux, faux>(dst)));
     }
     auto api_alias_add                       ()
     {
@@ -4392,8 +4392,8 @@ struct impl : consrv
             input;
         };
         auto& packet = payload::cast(upload);
-        auto src = text{};
         auto exe = text{};
+        auto src = text{};
         auto dst = text{};
         if (packet.input.utf16)
         {
@@ -4401,9 +4401,9 @@ struct impl : consrv
             if (data.size() * sizeof(wchr) == packet.input.srccb + packet.input.dstcb + packet.input.execb)
             {
                 auto shadow = wiew{ data.data(), data.size() };
+                utf::to_utf(utf::pop_front(shadow, packet.input.execb / sizeof(wchr)), exe);
                 utf::to_utf(utf::pop_front(shadow, packet.input.srccb / sizeof(wchr)), src);
                 utf::to_utf(utf::pop_front(shadow, packet.input.dstcb / sizeof(wchr)), dst);
-                utf::to_utf(utf::pop_front(shadow, packet.input.execb / sizeof(wchr)), exe);
             }
         }
         else
@@ -4414,22 +4414,22 @@ struct impl : consrv
                 auto shadow = view{ data.data(), data.size() };
                 if (inpenc->codepage == CP_UTF8)
                 {
+                    exe = utf::pop_front(shadow, packet.input.execb);
                     src = utf::pop_front(shadow, packet.input.srccb);
                     dst = utf::pop_front(shadow, packet.input.dstcb);
-                    exe = utf::pop_front(shadow, packet.input.execb);
                 }
                 else
                 {
+                    inpenc->decode_run(utf::pop_front(shadow, packet.input.execb), exe);
                     inpenc->decode_run(utf::pop_front(shadow, packet.input.srccb), src);
                     inpenc->decode_run(utf::pop_front(shadow, packet.input.dstcb), dst);
-                    inpenc->decode_run(utf::pop_front(shadow, packet.input.execb), exe);
                 }
             }
         }
         log("\t", show_page(packet.input.utf16, inpenc->codepage),
-          "\n\tsrc: ", src,
-          "\n\tdst: ", dst,
-          "\n\texe: ", exe);
+          "\n\texecb: ", packet.input.execb, "\texe: ", ansi::hi(utf::debase<faux, faux>(exe)),
+          "\n\tsrccb: ", packet.input.srccb, "\tsrc: ", ansi::hi(utf::debase<faux, faux>(src)),
+          "\n\tdstcb: ", packet.input.dstcb, "\tdst: ", ansi::hi(utf::debase<faux, faux>(dst)));
     }
     auto api_alias_exes_get_volume           ()
     {

--- a/src/netxs/desktopio/consrv.hpp
+++ b/src/netxs/desktopio/consrv.hpp
@@ -4611,6 +4611,7 @@ struct impl : consrv
             if (inpenc->codepage == CP_UTF8) exe = shadow;
             else                             inpenc->decode_run(shadow, exe);
         }
+        auto input_exe = exe;
         utf::to_low(exe);
         auto exe_iter = macros.find(exe);
         if (exe_iter == macros.end())
@@ -4644,6 +4645,7 @@ struct impl : consrv
             packet.reply.bytes = static_cast<ui16>(toANSI.size());
         }
         log("\t", show_page(packet.input.utf16, inpenc->codepage),
+          "\n\tinput.exe:   ", ansi::hi(utf::debase<faux, faux>(input_exe)),
           "\n\treply.yield: ", ansi::hi(utf::debase<faux, faux>(crop)),
           "\n\treply.bytes: ", packet.reply.bytes);
     }
@@ -4679,6 +4681,7 @@ struct impl : consrv
             if (inpenc->codepage == CP_UTF8) exe = shadow;
             else                             inpenc->decode_run(shadow, exe);
         }
+        auto input_exe = exe;
         utf::to_low(exe);
         auto exe_iter = macros.find(exe);
         if (exe_iter == macros.end())
@@ -4715,6 +4718,7 @@ struct impl : consrv
             answer.send_data(condrv, toANSI, true);
         }
         log("\t", show_page(packet.input.utf16, inpenc->codepage),
+          "\n\tinput.exe:   ", ansi::hi(utf::debase<faux, faux>(input_exe)),
           "\n\treply.yield: ", ansi::hi(utf::debase<faux, faux>(crop)),
           "\n\treply.bytes: ", packet.reply.bytes);
     }
@@ -4730,7 +4734,26 @@ struct impl : consrv
             input;
         };
         auto& packet = payload::cast(upload);
-        log("\t", show_page(packet.input.utf16, inpenc->codepage));
+        //todo depuplicate code
+        auto exe = text{};
+        if (packet.input.utf16)
+        {
+            auto data = take_buffer<wchr, feed::fwd>(packet);
+            auto shadow = wiew{ data.data(), data.size() };
+            utf::to_utf(shadow, exe);
+        }
+        else
+        {
+            auto data = take_buffer<char, feed::fwd>(packet);
+            auto shadow = view{ data.data(), data.size() };
+            if (inpenc->codepage == CP_UTF8) exe = shadow;
+            else                             inpenc->decode_run(shadow, exe);
+        }
+        auto input_exe = exe;
+        utf::to_low(exe);
+        //todo implement
+        log("\t", show_page(packet.input.utf16, inpenc->codepage),
+          "\n\tinput.exe: ", ansi::hi(utf::debase<faux, faux>(input_exe)));
     }
     auto api_input_history_limit_set         ()
     {
@@ -4765,10 +4788,27 @@ struct impl : consrv
             input;
         };
         auto& packet = payload::cast(upload);
-        //todo
+        //todo depuplicate code
+        auto exe = text{};
+        if (packet.input.utf16)
+        {
+            auto data = take_buffer<wchr, feed::fwd>(packet);
+            auto shadow = wiew{ data.data(), data.size() };
+            utf::to_utf(shadow, exe);
+        }
+        else
+        {
+            auto data = take_buffer<char, feed::fwd>(packet);
+            auto shadow = view{ data.data(), data.size() };
+            if (inpenc->codepage == CP_UTF8) exe = shadow;
+            else                             inpenc->decode_run(shadow, exe);
+        }
+        auto input_exe = exe;
+        utf::to_low(exe);
         packet.reply.count = 0; // Requires by the "doskey /history".
-
+        //todo implement
         log("\t", show_page(packet.input.utf16, inpenc->codepage),
+          "\n\tinput.exe: ", ansi::hi(utf::debase<faux, faux>(input_exe)),
           "\n\treply.count: ", packet.reply.count);
     }
     auto api_input_history_get               ()
@@ -4788,10 +4828,27 @@ struct impl : consrv
             input;
         };
         auto& packet = payload::cast(upload);
-        //todo
+        //todo depuplicate code
+        auto exe = text{};
+        if (packet.input.utf16)
+        {
+            auto data = take_buffer<wchr, feed::fwd>(packet);
+            auto shadow = wiew{ data.data(), data.size() };
+            utf::to_utf(shadow, exe);
+        }
+        else
+        {
+            auto data = take_buffer<char, feed::fwd>(packet);
+            auto shadow = view{ data.data(), data.size() };
+            if (inpenc->codepage == CP_UTF8) exe = shadow;
+            else                             inpenc->decode_run(shadow, exe);
+        }
+        auto input_exe = exe;
+        utf::to_low(exe);
         packet.reply.bytes = 0;
-
+        //todo implement
         log("\t", show_page(packet.input.utf16, inpenc->codepage),
+          "\n\tinput.exe: ", ansi::hi(utf::debase<faux, faux>(input_exe)),
           "\n\treply.bytes: ", packet.reply.bytes);
     }
     auto api_input_history_info_get          ()

--- a/src/netxs/desktopio/consrv.hpp
+++ b/src/netxs/desktopio/consrv.hpp
@@ -647,7 +647,7 @@ struct impl : consrv
                     auto c = utf::to_low(s.back());
                     if (c >= '1' && c <= '9')
                     {
-                        auto n = c - '1';
+                        auto n = static_cast<ui32>(c - '1');
                         if (args.size() > n) result += args[n];
                     }
                     else switch (c)

--- a/src/netxs/desktopio/controls.hpp
+++ b/src/netxs/desktopio/controls.hpp
@@ -4026,7 +4026,12 @@ namespace netxs::ui
         // item: .
         auto accented(bool b = true) { unln = b; return This(); }
         // item: .
-        void set(view utf8) { data = utf8; base::reflow(); }
+        void set(view utf8)
+        {
+            data.parser::style.wrp(wrap::off);
+            data = utf8;
+            base::reflow();
+        }
     };
 
     // controls: Textedit box.

--- a/src/netxs/desktopio/controls.hpp
+++ b/src/netxs/desktopio/controls.hpp
@@ -871,7 +871,7 @@ namespace netxs::ui
                             }
                         };
                     }
-                    boss.LISTEN(tier::release, /*!*/e2::postrender, canvas, memo)
+                    boss.LISTEN(tier::release, e2::postrender, canvas, memo)
                     {
                         done = live;
                         auto state = down ? (step == span::zero() ? faux : true)

--- a/src/netxs/desktopio/controls.hpp
+++ b/src/netxs/desktopio/controls.hpp
@@ -3015,7 +3015,7 @@ namespace netxs::ui
                               0 };
             auto height = cover.width() ? cover.height() + 1
                                         : 0;
-            if (beyond) square.y += height;
+            if (beyond) square.y += height - 1;
             else        square.y  = height;
             new_area.size.y = square.y;
         }

--- a/src/netxs/desktopio/directvt.hpp
+++ b/src/netxs/desktopio/directvt.hpp
@@ -1108,6 +1108,7 @@ namespace netxs::directvt
                         right_half(next);
                     }
                 };
+                block.basevt::inv(state.inv()); //todo Windows Server 2019 loses the reverse video SGR attribute.
                 if (image.hash() != cache.hash())
                 {
                     block.basevt::scroll_wipe();

--- a/src/netxs/desktopio/directvt.hpp
+++ b/src/netxs/desktopio/directvt.hpp
@@ -1108,7 +1108,6 @@ namespace netxs::directvt
                         right_half(next);
                     }
                 };
-                block.basevt::inv(state.inv()); //todo Windows Server 2019 loses the reverse video SGR attribute.
                 if (image.hash() != cache.hash())
                 {
                     block.basevt::scroll_wipe();

--- a/src/netxs/desktopio/richtext.hpp
+++ b/src/netxs/desktopio/richtext.hpp
@@ -2370,7 +2370,7 @@ namespace netxs::ui
             flow::size(new_size);
         }
         template<class P = noop>
-        void /*!*/blur(si32 r, P shade = {}) // face: .
+        void blur(si32 r, P shade = {}) // face: .
         {
             using irgb = vrgb::value_type;
 

--- a/src/netxs/desktopio/richtext.hpp
+++ b/src/netxs/desktopio/richtext.hpp
@@ -125,12 +125,28 @@ namespace netxs::ui
                 outwidth = printout.coor.x + printout.size.x - textline.coor.x;
 
                 if constexpr (!Split)
-                if (printout.size.x > 1)
+                if (printout.size.x > 1 && textline.size.x > printout.size.x)
                 {
-                    auto p = curpoint + printout.size.x - 1;
-                    if (block.at(p).wdt() == 2)
+                    auto n = printout.size.x - 1;
+                    auto p = curpoint + n;
+                    while (n)
                     {
-                        --printout.size.x;
+                        auto& c = block.at(p);
+                        if (c.isspc() || c.wdt() == 3) break;
+                        n--;
+                        p--;
+                    }
+                    if (n > 0) // Cut by whitespace.
+                    {
+                        printout.size.x = n + 1;
+                    }
+                    else // Cut on a widechar boundary (CJK/Emoji).
+                    {
+                        auto p = curpoint + printout.size.x - 1;
+                        if (block.at(p).wdt() == 2)
+                        {
+                            --printout.size.x;
+                        }
                     }
                 }
             }

--- a/src/netxs/desktopio/system.hpp
+++ b/src/netxs/desktopio/system.hpp
@@ -2974,7 +2974,7 @@ namespace netxs::os
                     }
                     auto size = DWORD{ os::pipebuf };
                     auto wstr = wide(size, 0);
-                    ok(::GetConsoleTitleW(wstr.data(), size), "::GetConsoleTitleW()", os::unexpected);
+                    ok(::GetConsoleTitleW(wstr.data(), size), "::GetConsoleTitleW(vtmode)", os::unexpected);
                     dtvt::backup.title = wstr.data();
                     ok(::GetConsoleCursorInfo(os::stdout_fd, &dtvt::backup.caret), "::GetConsoleCursorInfo()", os::unexpected);
 
@@ -3879,10 +3879,13 @@ namespace netxs::os
         {
             auto utf8 = text{};
             #if defined(_WIN32)
+            if (!os::dtvt::active)
+            {
                 auto size = DWORD{ os::pipebuf };
                 auto wstr = wide(size, 0);
-                ok(::GetConsoleTitleW(wstr.data(), size), "::GetConsoleTitleW()", os::unexpected);
+                ok(::GetConsoleTitleW(wstr.data(), size), "::GetConsoleTitleW(tty)", os::unexpected);
                 utf8 = utf::to_utf(wstr);
+            }
             #else
             #endif
             return utf8;

--- a/src/netxs/desktopio/system.hpp
+++ b/src/netxs/desktopio/system.hpp
@@ -2984,7 +2984,7 @@ namespace netxs::os
                         ok(::SetConsoleMode(os::stdin_fd,         dtvt::backup.imode), "::SetConsoleMode(imode)", os::unexpected);
                         ok(::SetConsoleOutputCP(                  dtvt::backup.opage), "::SetConsoleOutputCP(opage)", os::unexpected);
                         ok(::SetConsoleCP(                        dtvt::backup.ipage), "::SetConsoleCP(ipage)", os::unexpected);
-                        ok(::SetConsoleTitleW(                    dtvt::backup.title.c_str()), "::GetConsoleTitleW()", os::unexpected);
+                        ok(::SetConsoleTitleW(                    dtvt::backup.title.c_str()), "::SetConsoleTitleW()", os::unexpected);
                         ok(::SetConsoleCursorInfo(os::stdout_fd, &dtvt::backup.caret), "::SetConsoleCursorInfo()", os::unexpected);
                     #else
                         ::tcsetattr(os::stdin_fd, TCSANOW, &dtvt::backup);
@@ -3860,6 +3860,18 @@ namespace netxs::os
             #endif
             if constexpr (debugmode) log(prompt::tty, "Console title changed to ", ansi::hi(utf::debase<faux, faux>(utf8)));
         }
+        auto title()
+        {
+            auto utf8 = text{};
+            #if defined(_WIN32)
+                auto size = DWORD{ os::pipebuf };
+                auto wstr = wide(size, 0);
+                ok(::GetConsoleTitleW(wstr.data(), size), "::GetConsoleTitleW()", os::unexpected);
+                utf8 = utf::to_utf(wstr);
+            #else
+            #endif
+            return utf8;
+        }
         static auto clipboard = text{};
         struct proxy : s11n
         {
@@ -3936,7 +3948,7 @@ namespace netxs::os
             proxy()
                 : s11n{ *this }
             {
-                s11n::header.set(id_t{}, ""s);
+                s11n::header.set(id_t{}, tty::title());
                 s11n::footer.set(id_t{}, ""s);
             }
         };

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -338,9 +338,7 @@ namespace netxs::ui
                     owner.LISTEN(tier::release, hids::events::device::mouse::any, gear, token)
                     {
                         check_focus(gear);
-                        auto buttons_only = !(state & mode::drag);
-                        if (owner.selmod == mime::disabled
-                         || buttons_only) // Allow mouse button reporting along with scrollback selection (mouse shell integration with DECSET 1000).
+                        if (owner.selmod == mime::disabled)
                         {
                             if (gear.captured(owner.id))
                             {
@@ -356,15 +354,12 @@ namespace netxs::ui
                             {
                                 owner.ipccon.mouse(gear, moved, coord, encod, state);
                             }
-                            if (!buttons_only) gear.dismiss();
+                            gear.dismiss();
                         }
                     };
                     smode = owner.selmod;
                 }
-                if (state & mode::drag) // Prevent scrollback selection along with mouse drag reporting.
-                {
-                    owner.selection_selmod(mime::disabled);
-                }
+                owner.selection_selmod(mime::disabled);
             }
             void disable(mode m)
             {

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -4415,7 +4415,7 @@ namespace netxs::ui
                                 assert(test_futures());
                             } // case 2 done.
                         }
-                        batch.current().splice(start, count, proto, fuse);
+                        batch.current().splice<Copy>(start, count, proto, fuse);
                     }
                     assert(coord.y >= 0 && coord.y < arena);
                     coord.y += y_top;
@@ -4429,7 +4429,7 @@ namespace netxs::ui
                     if (coord.x <= panel.x)//todo styles! || ! curln.wrapped())
                     {
                         auto n = std::min(count, panel.x - std::max(0, saved.x));
-                        dnbox.splice(saved, n, proto, fuse);
+                        dnbox.splice<Copy>(saved, n, proto, fuse);
                     }
                     else
                     {
@@ -4440,7 +4440,7 @@ namespace netxs::ui
                         auto dest = dnbox.iter() + seek;
                         auto tail = dnbox.iend();
                         auto back = panel.x;
-                        rich::unlimit_fill_proc(data, size, dest, tail, back, cell::shaders::full);
+                        rich::unlimit_fill_proc<Copy>(data, size, dest, tail, back, cell::shaders::full);
                     }
                     coord.y = std::min(coord.y + y_end + 1, panel.y - 1);
                     // Note: coord can be unsync due to scroll regions.

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -1107,6 +1107,11 @@ namespace netxs::ui
                     auto get_mode() const { return !selection_active() ? term_state::type::empty:
                                                     selection_selbox() ? term_state::type::block:
                                                                          term_state::type::lines; }
+            // bufferbase: Get viewport position.
+    virtual si32 get_origin(bool follow)
+            {
+                return 0;
+            }
             // bufferbase: Get viewport basis.
     virtual si32 get_basis()
             {
@@ -2599,6 +2604,7 @@ namespace netxs::ui
                 id_t ancid{}; // buff: The nearest line id to the slide.
                 si32 ancdy{}; // buff: Slide's top line offset.
                 bool round{}; // buff: Is the slide position approximate.
+                bool rolls{}; // buff: The scrollback buffer ring was scrolled.
 
                 // buff: Decrease height.
                 void dec_height(si32& vsize, type kind, si32 size)
@@ -2722,6 +2728,7 @@ namespace netxs::ui
                         ancdy = 0;
                         slide = 0;
                     }
+                    rolls = true;
                 }
                 // buff: Remove information about the specified line from accounting.
                 void undock_base_back(line& l) override { undock(l._kind, l._size); }
@@ -2953,6 +2960,14 @@ namespace netxs::ui
                 assert(result);
                 return result;
             }
+            // scroll_buf: Get viewport position.
+            si32 get_origin(bool follow) override
+            {
+                auto coor_y = follow ? batch.basis
+                                     : batch.slide;
+                scroll_buf::set_slide(coor_y); // Update slide id anchoring.
+                return -coor_y;
+            }
             // scroll_buf: Get viewport basis.
             si32 get_basis() override
             {
@@ -2977,9 +2992,11 @@ namespace netxs::ui
             // scroll_buf: Set viewport position and return whether the viewport is reset.
             bool set_slide(si32& fresh_slide) override
             {
-                if (batch.slide == -fresh_slide) return batch.slide == batch.basis;
-
-                fresh_slide = -fresh_slide;
+                if (batch.slide == fresh_slide && !batch.rolls)
+                {
+                    return batch.slide == batch.basis;
+                }
+                batch.rolls = faux;
 
                 if (batch.basis == fresh_slide)
                 {
@@ -3176,7 +3193,6 @@ namespace netxs::ui
                     }
                 }
 
-                fresh_slide = -fresh_slide;
                 return batch.slide == batch.basis;
             }
             // scroll_buf: Recalc batch.slide using anchoring by para_id + para_offset.
@@ -6497,12 +6513,8 @@ namespace netxs::ui
                     auto pos = console.get_coord(dot_00).x;
                     origin.x = bufferbase::reset_viewport(origin.x, pos, console.panel.x);
                 }
-                origin.y = -console.get_basis();
             }
-            else
-            {
-                origin.y = -console.get_slide();
-            }
+            origin.y = console.get_origin(follow[axis::Y]);
         }
         // term: Proceed terminal changes.
         template<class P>
@@ -7229,7 +7241,9 @@ namespace netxs::ui
                 if (new_area.coor != base::coor())
                 {
                     auto& console = *target;
-                    follow[axis::Y] = console.set_slide(new_area.coor.y);
+                    auto fresh_coor = -new_area.coor.y;
+                    follow[axis::Y] = console.set_slide(fresh_coor);
+                    new_area.coor.y = -fresh_coor;
                     origin = new_area.coor;
                 }
             };

--- a/src/netxs/desktopio/utf.hpp
+++ b/src/netxs/desktopio/utf.hpp
@@ -1515,6 +1515,13 @@ namespace netxs::utf
         if (stop == tail) utf8 = view{};
         else              utf8.remove_prefix(std::distance(head, stop));
     }
+    template<class View>
+    auto pop_front(View&& line, auto size)
+    {
+        auto crop = line.substr(0, size);
+        line.remove_prefix(size);
+        return crop;
+    }
     template<class TextOrView>
     auto is_plain(TextOrView&& utf8)
     {

--- a/src/netxs/desktopio/utf.hpp
+++ b/src/netxs/desktopio/utf.hpp
@@ -431,6 +431,11 @@ namespace netxs::utf
                  operator text () const { return text{ data(), size() }; }
         explicit operator bool () const { return view::length(); }
 
+        // qiew: Return substring.
+        constexpr auto substr(size_t offset = 0, size_t count = npos) const
+        {
+            return qiew{ view::substr(offset, count) };
+        }
         // qiew: Convert to text.
         auto str() const { return operator text(); }
         // qiew: Peek front char.
@@ -773,7 +778,7 @@ namespace netxs::utf
     }
     auto substr(qiew utf8, size_t start, size_t length = text::npos)
     {
-        if (length == 0) return view{};
+        if (length == 0) return qiew{};
         auto head = utf8.data();
         auto stop = head + utf8.size();
         auto calc = [](auto& it, auto& count, auto limit)

--- a/src/netxs/desktopio/utf.hpp
+++ b/src/netxs/desktopio/utf.hpp
@@ -1538,6 +1538,13 @@ namespace netxs::utf
         line.remove_prefix(size);
         return crop;
     }
+    template<class View>
+    auto pop_back(View&& line, auto size)
+    {
+        auto crop = line.substr(line.size() - size);
+        line.remove_suffix(size);
+        return crop;
+    }
     template<class TextOrView>
     auto is_plain(TextOrView&& utf8)
     {

--- a/src/vtm.hpp
+++ b/src/vtm.hpp
@@ -542,7 +542,7 @@ namespace netxs::app::vtm
                     handle_drop(gear);
                 };
 
-                boss.LISTEN(tier::release, /*!*/e2::postrender, canvas, memo)
+                boss.LISTEN(tier::release, e2::postrender, canvas, memo)
                 {
                     //todo Highlighted area drawn twice
                     for (auto const& [key, data] : slots)
@@ -820,7 +820,7 @@ namespace netxs::app::vtm
                 this->SIGNAL(tier::request, e2::form::prop::viewport, viewport, ());
                 move_viewport(newpos, viewport);
             };
-            LISTEN(tier::release, /*!*/e2::render::any, canvas, tokens, (fullscreen_banner = page{ "Fullscreen Mode\n\n" }))
+            LISTEN(tier::release, e2::render::any, canvas, tokens, (fullscreen_banner = page{ "Fullscreen Mode\n\n" }))
             {
                 if (&canvas != &input.xmap) // Draw a shadow of user's terminal window for other users (spectators).
                 {
@@ -845,7 +845,7 @@ namespace netxs::app::vtm
                     canvas.bump(saved_context);
                 }
             };
-            LISTEN(tier::release, /*!*/e2::postrender, parent_canvas, tokens)
+            LISTEN(tier::release, e2::postrender, parent_canvas, tokens)
             {
                 if (&parent_canvas != &input.xmap)
                 {


### PR DESCRIPTION
Changes:
- Implemented the following APIs ([DOSKEY.EXE](https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/doskey)) support:
  - `AddConsoleAlias`
  - `GetConsoleAlias`
  - `GetConsoleAliasExesLength`
  - `GetConsoleAliasExes`
  - `GetConsoleAliasesLength`
  - `GetConsoleAliases`
  - `ExpungeConsoleCommandHistory`
  - `SetConsoleNumberOfCommands` - not used
  - `GetConsoleCommandHistoryLength`
  - `GetConsoleCommandHistory`
  - `GetConsoleHistoryInfo` - not used
  - `SetConsoleHistoryInfo` - not used
- Alt+F10 to wipe DOSKEY aliases for current process (by process module name).
- Alt+F7 to clear command history (by process module name).
- Processes with the same module name share a common command history.
- Force 16-color mode on MS Windows prior Windows 10.
- Implement word-based text wrapping. #396
- Add GitHub Action workflow to generate binaries for the big three OS platforms.
- Disable mouse event processing when any reporting mode enabled. #438
- Add the ability to change default menu item settings. #439

Closes #396
Closes #428
Closes #438