### PR TITLE
Pull apart mouse hover and keybd focus

### DIFF
--- a/doc/settings.md
+++ b/doc/settings.md
@@ -385,7 +385,6 @@ Note: The full defaut config is at [src/vtm.xml](../src/vtm.xml).
         <viewport coor=0,0 />
         <mouse dblclick=500ms />
         <tooltips timeout=2000ms enabled=true fgc=pureblack bgc=purewhite />
-        <glowfx=true />                      <!-- Show glow effect around selected item. -->
         <debug overlay=off toggle="🐞" />  <!-- Display console debug info. -->
         <regions enabled=0 />             <!-- Highlight UI objects boundaries. -->
     </client>

--- a/doc/vt-input-mode.md
+++ b/doc/vt-input-mode.md
@@ -17,6 +17,7 @@ Anyone who wants to:
 - Distinguish between Left and Right physical keys.
 - Get consistent output regardless of terminal window resize.
 - Track mouse outside the terminal window (getting negative coordinates).
+- Take advantage of high-resolution wheel scrolling.
 - Track scrollback text manipulation.
 - Track application closing and system shutdown.
 - Be independent of operating system and third party libraries.
@@ -24,7 +25,7 @@ Anyone who wants to:
 Existing approaches have the following drawbacks:
 - There is no uniform way to receive keyboard events.
 - Window size tracking requires platform-specific calls with no way to synchronize the output.
-- Mouse tracking modes lack support for negative coordinates and have a limited set of buttons.
+- Mouse tracking modes lack support for negative coordinates, high-resolution wheel scrolling, and have a limited set of buttons.
 - Bracketed paste mode does not support the transfer of binary data and data containing sequences of bracketed paste mode itself.
 
 ## Conventions
@@ -351,7 +352,7 @@ Attribute                 | Description
 `kbmods=<KeyMods>`        | Keyboard modifiers (see Keyboard event).
 `coord=<X>,<Y>`           | Mouse pointer coorinates.
 `buttons=<ButtonState>`   | Mouse button state.
-`wheel=<DeltaY>,<DeltaX>` | Vertical and horizontal wheel delta.
+`wheel=<DeltaY>,<DeltaX>` | Vertical and horizontal wheel high-resolution delta.
 
 In response to the activation of `mouse` tracking, the application receives a vt-sequence containing current mouse state:
 ```

--- a/src/netxs/apps.hpp
+++ b/src/netxs/apps.hpp
@@ -69,6 +69,7 @@ namespace netxs::app::shared
             auto window = ui::cake::ctor();
             auto strob = window->plugin<pro::focus>(pro::focus::mode::focused)
                                ->plugin<pro::notes>(" Left+Right click to close ")
+                               ->active()
                                ->invoke([](auto& boss)
                                 {
                                     //boss.keybd.accept(true);
@@ -96,6 +97,7 @@ namespace netxs::app::shared
                   ->plugin<pro::cache>()
                   ->plugin<pro::notes>(" Left+Right click to close ")
                   ->attach(ui::stem_rate<tier::preview, decltype(e2::config::fps)>::ctor("Set frame rate limit", 1, 200, "fps"))
+                  ->active()
                   ->colors(0xFFFFFFFF, bluedk)
                   ->invoke([&](auto& boss)
                   {
@@ -130,7 +132,7 @@ namespace netxs::app::shared
                       };
                   });
             auto object = window->attach(ui::mock::ctor())
-                                ->colors(0,0); //todo mouse tracking
+                                ->active();
             return window;
         };
         auto build_Region        = [](text cwd, text v,     xmls& config, text patch)
@@ -312,6 +314,7 @@ namespace netxs::app::shared
                 auto test_stat_area = object->attach(slot::_2, ui::fork::ctor(axis::Y));
                     auto layers = test_stat_area->attach(slot::_1, ui::cake::ctor());
                         auto scroll = layers->attach(ui::rail::ctor())
+                                            ->active()
                                             ->colors(whitelt, reddk);
                                     scroll->attach(ui::post::ctor())
                                           ->upload(truecolor);

--- a/src/netxs/apps/calc.hpp
+++ b/src/netxs/apps/calc.hpp
@@ -360,10 +360,12 @@ namespace netxs::app::calc
                             auto func_line = func_body->attach(slot::_1, ui::fork::ctor());
                                 auto fx_sum = func_line->attach(slot::_1, ui::fork::ctor());
                                     auto fx = fx_sum->attach(slot::_1, ui::post::ctor())
+                                                    ->active()
                                                     ->plugin<pro::fader>(c7, c3, fader)
                                                     ->limits({ 3,-1 }, { 4,-1 })
                                                     ->upload(ansi::wrp(wrap::off).add(" Fx "));
                                 auto ellipsis = func_line->attach(slot::_2, ui::post::ctor())
+                                                         ->active()
                                                          ->plugin<pro::fader>(c7, c3, fader)
                                                          ->limits({ -1,1 }, { 3,-1 })
                                                          ->upload(ansi::wrp(wrap::off).add(" … "));
@@ -375,8 +377,10 @@ namespace netxs::app::calc
                                 auto rows_body = body_area->attach(slot::_2, ui::fork::ctor());
                                     auto layers = rows_body->attach(slot::_2, ui::cake::ctor());
                                     auto scroll = layers->attach(ui::rail::ctor())
+                                                        ->active()
                                                         ->limits({ -1,1 }, { -1,-1 });
                                         auto grid = scroll->attach(ui::post::ctor())
+                                                          ->active()
                                                           ->colors(0xFF000000, 0xFFffffff)
                                                           ->plugin<pro::cell_highlight>()
                                                           ->upload(cellatix_text);
@@ -411,6 +415,7 @@ namespace netxs::app::calc
                                                        .bgc(whitelt).fgc(blackdk).add(" Sheet1 "));
                             auto plus_pad = sheet_plus->attach(slot::_2, ui::fork::ctor());
                                 auto plus = plus_pad->attach(slot::_1, ui::post::ctor())
+                                                    ->active()
                                                     ->plugin<pro::fader>(c7, c3, fader)
                                                     ->limits({ 3,-1 }, { 3,-1 })
                                                     ->upload(ansi::wrp(wrap::off).add(" + "));

--- a/src/netxs/apps/calc.xml
+++ b/src/netxs/apps/calc.xml
@@ -77,7 +77,6 @@ R"==(
         <viewport coor=0,0/>
         <mouse dblclick=500ms/>
         <tooltips timeout=2000ms enabled=true fgc=pureblack bgc=purewhite/>
-        <glowfx=true/>                      <!-- Show glow effect around selected item. -->
         <debug overlay=0 toggle="🐞"/>  <!-- Display console debug info. -->
         <regions enabled=0/>             <!-- Highlight UI objects boundaries. -->
     </client>

--- a/src/netxs/apps/desk.hpp
+++ b/src/netxs/apps/desk.hpp
@@ -69,8 +69,6 @@ namespace netxs::app::desk
             auto danger_color    = skin::globals().danger;
             auto highlight_color = skin::globals().highlight;
             auto c1 = danger_color;
-            auto fastfader = skin::globals().fader_fast;
-            auto fader = skin::globals().fader_time;
             auto item_area = ui::fork::ctor()
                 ->active()
                 ->shader(cell::shaders::xlight, e2::form::state::hover)

--- a/src/netxs/apps/desk.hpp
+++ b/src/netxs/apps/desk.hpp
@@ -68,7 +68,7 @@ namespace netxs::app::desk
             auto tall = si32{ skin::globals().menuwide };
             auto danger_color    = skin::globals().danger;
             auto highlight_color = skin::globals().highlight;
-            auto c5 = danger_color;
+            auto c1 = danger_color;
             auto fastfader = skin::globals().fader_fast;
             auto fader = skin::globals().fader_time;
             auto item_area = ui::fork::ctor()
@@ -144,9 +144,9 @@ namespace netxs::app::desk
                 ->drawdots();
             auto app_close = item_area->attach(slot::_2, ui::item::ctor("×"))
                 ->active()
-                ->shader(cell::shaders::color(c5), e2::form::state::mouse)
-                ->template plugin<pro::notes>(" Close application window ")
+                ->shader(cell::shaders::color(c1), e2::form::state::mouse)
                 ->setpad({ 2, 2, tall, tall })
+                ->template plugin<pro::notes>(" Close application window ")
                 ->invoke([&](auto& boss)
                 {
                     auto data_src_shadow = ptr::shadow(data_src);
@@ -177,12 +177,10 @@ namespace netxs::app::desk
             auto highlight_color = skin::globals().highlight;
             auto inactive_color  = skin::globals().inactive;
             auto selected_color  = skin::globals().selected;
-            auto action_color    = skin::globals().action;
             auto danger_color    = skin::globals().danger;
             auto c3 = highlight_color;
             auto c9 = selected_color;
             auto cA = inactive_color;
-            auto c6 = action_color;
             auto c1 = danger_color;
 
             auto apps = ui::list::ctor()
@@ -215,14 +213,13 @@ namespace netxs::app::desk
                     auto item_area = apps->attach(ui::item::ctor(obj_desc))
                         ->flexible()
                         ->accented()
-                        ->shader(cell::shaders::color(cA))
+                        ->colors(cA.fgc(), cA.bgc())
                         ->setpad({ 0, 0, tall, tall }, { 0, 0, -tall, 0 })
                         ->template plugin<pro::notes>(obj_note);
                     continue;
                 }
                 auto head_fork = ui::fork::ctor(axis::X, 0, 1, 0);
                 auto block = apps->attach(ui::list::ctor())
-                    ->active()
                     ->shader(cell::shaders::xlight, e2::form::state::mouse, head_fork)
                     ->setpad({ 0, 0, 0, 0 }, { 0, 0, -tall, 0 });
                 if (!state) block->depend_on_collection(inst_ptr_list); // Remove not pinned apps, like Info/About.
@@ -294,9 +291,9 @@ namespace netxs::app::desk
                     auto fold_bttn = bttn_fork->attach(slot::_1, ui::item::ctor(isfolded ? "…" : "<"))
                         ->setpad({ 2, 2, tall, tall })
                         ->active()
-                        ->shader(cell::shaders::color(c6), e2::form::state::mouse)
+                        ->shader(cell::shaders::xlight, e2::form::state::mouse)
                         ->template plugin<pro::notes>(" Hide active window list.               \n"
-                                                    " Use mouse wheel to switch it to close. ")
+                                                      " Use mouse wheel to switch it to close. ")
                         ->invoke([&](auto& boss)
                         {
                             insts->base::hidden = isfolded;
@@ -429,13 +426,11 @@ namespace netxs::app::desk
         {
             auto tall = si32{ skin::globals().menuwide };
             auto highlight_color = skin::globals().highlight;
-            auto action_color    = skin::globals().action;
             auto inactive_color  = skin::globals().inactive;
             auto warning_color   = skin::globals().warning;
             auto danger_color    = skin::globals().danger;
             auto cA = inactive_color;
             auto c3 = highlight_color;
-            auto c6 = action_color;
             auto c2 = warning_color;
             auto c1 = danger_color;
 
@@ -488,7 +483,6 @@ namespace netxs::app::desk
                 auto tall = si32{ skin::globals().menuwide };
                 auto highlight_color = skin::color(tone::highlight);
                 auto c3 = highlight_color;
-                auto x3 = cell{ c3 }.alpha(0x00);
                 auto user = ui::item::ctor(escx(" &").nil().add(" ")
                         //.link(data_src->id).fgx(data_src->id == my_id ? rgba::vt256[whitelt] : 0x00).add(utf8).nil(), true));
                         .fgx(data_src->id == my_id ? rgba::vt256[whitelt] : 0x00).add(utf8).nil())
@@ -563,14 +557,14 @@ namespace netxs::app::desk
                     };
                 });
             auto taskbar_park = taskbar_viewport->attach(slot::_1, ui::cake::ctor())
-                ->active()
                 ->limits({ menu_min_size, -1 }, { menu_min_size, -1 })
                 ->plugin<pro::notes>(" LeftDrag to adjust the taskbar width                        \n"
                                      " Ctrl+LeftDrag to adjust the folded taskbar width            \n"
                                      " RightDrag or scroll wheel to slide the taskbar menu up/down ")
                 ->plugin<pro::timer>()
-                ->plugin<pro::acryl>(menu_bg_color)
+                ->plugin<pro::acryl>(10)
                 ->plugin<pro::cache>()
+                ->active(menu_bg_color)
                 ->invoke([&](auto& boss)
                 {
                     boss.mouse.template draggable<hids::buttons::left>(true);
@@ -664,13 +658,13 @@ namespace netxs::app::desk
             auto label = label_bttn->attach(slot::_1, ui::item::ctor("users"))
                 ->flexible()
                 ->accented()
-                ->shader(cell::shaders::color(cA))
+                ->colors(cA.fgc(), cA.bgc())
                 ->setpad({ 0, 0, tall, tall })
                 ->limits({ 5, -1 });
             auto userlist_hidden = true;
             auto bttn = label_bttn->attach(slot::_2, ui::item::ctor(userlist_hidden ? "…" : "<"))
                 ->active()
-                ->shader(cell::shaders::color(c6), e2::form::state::mouse)
+                ->shader(cell::shaders::xlight, e2::form::state::mouse)
                 ->plugin<pro::notes>(" Show/hide user list ")
                 ->setpad({ 2, 2, tall, tall });
             auto userlist_area = users_area->attach(ui::cake::ctor())

--- a/src/netxs/apps/desk.hpp
+++ b/src/netxs/apps/desk.hpp
@@ -68,14 +68,12 @@ namespace netxs::app::desk
             auto tall = si32{ skin::globals().menuwide };
             auto danger_color    = skin::globals().danger;
             auto highlight_color = skin::globals().highlight;
-            auto c4 = cell{}.bgc(highlight_color.bgc());
-            auto x4 = cell{ c4 }.bga(0x00);
             auto c5 = danger_color;
-            auto x5 = cell{ c5 }.alpha(0x00);
             auto fastfader = skin::globals().fader_fast;
             auto fader = skin::globals().fader_time;
             auto item_area = ui::fork::ctor()
-                ->plugin<pro::fader>(x4, c4, fastfader)
+                ->active()
+                ->shader(cell::shaders::xlight, e2::form::state::mouse)
                 ->plugin<pro::notes>(" Application window:              \n"
                                      "   Left click to go to the window \n"
                                      "   Right click to pull the window ")
@@ -145,7 +143,8 @@ namespace netxs::app::desk
                 ->flexible()
                 ->drawdots();
             auto app_close = item_area->attach(slot::_2, ui::item::ctor("×"))
-                ->template plugin<pro::fader>(x5, c5, fader)
+                ->active()
+                ->shader(cell::shaders::color(c5), e2::form::state::mouse)
                 ->template plugin<pro::notes>(" Close application window ")
                 ->setpad({ 2, 2, tall, tall })
                 ->invoke([&](auto& boss)
@@ -182,12 +181,9 @@ namespace netxs::app::desk
             auto danger_color    = skin::globals().danger;
             auto c3 = highlight_color;
             auto c9 = selected_color;
-            auto x3 = cell{ c3 }.alpha(0x00);
             auto cA = inactive_color;
             auto c6 = action_color;
-            auto x6 = cell{ c6 }.alpha(0x00);
             auto c1 = danger_color;
-            auto x1 = cell{ c1 }.bga(0x00);
 
             auto apps = ui::list::ctor()
                 ->invoke([&](auto& boss)
@@ -219,14 +215,15 @@ namespace netxs::app::desk
                     auto item_area = apps->attach(ui::item::ctor(obj_desc))
                         ->flexible()
                         ->accented()
-                        ->setpad({ 0, 0, tall, tall },{ 0, 0, -tall, 0 })
-                        ->colors(cA.fgc(), cA.bgc())
+                        ->shader(cell::shaders::color(cA))
+                        ->setpad({ 0, 0, tall, tall }, { 0, 0, -tall, 0 })
                         ->template plugin<pro::notes>(obj_note);
                     continue;
                 }
                 auto head_fork = ui::fork::ctor(axis::X, 0, 1, 0);
                 auto block = apps->attach(ui::list::ctor())
-                    ->template plugin<pro::fader>(x3, c3, skin::globals().fader_fast, head_fork)
+                    ->active()
+                    ->shader(cell::shaders::xlight, e2::form::state::mouse, head_fork)
                     ->setpad({ 0, 0, 0, 0 }, { 0, 0, -tall, 0 });
                 if (!state) block->depend_on_collection(inst_ptr_list); // Remove not pinned apps, like Info/About.
                 block->attach(head_fork)
@@ -296,7 +293,8 @@ namespace netxs::app::desk
                     auto& isfolded = conf.folded;
                     auto fold_bttn = bttn_fork->attach(slot::_1, ui::item::ctor(isfolded ? "…" : "<"))
                         ->setpad({ 2, 2, tall, tall })
-                        ->template plugin<pro::fader>(x6, c6, skin::globals().fader_time)
+                        ->active()
+                        ->shader(cell::shaders::color(c6), e2::form::state::mouse)
                         ->template plugin<pro::notes>(" Hide active window list.               \n"
                                                     " Use mouse wheel to switch it to close. ")
                         ->invoke([&](auto& boss)
@@ -317,7 +315,8 @@ namespace netxs::app::desk
                         });
                     auto drop_bttn = bttn_fork->attach(slot::_2, ui::item::ctor("×"))
                         ->setpad({ 2, 2, tall, tall })
-                        ->template plugin<pro::fader>(x1, c1, skin::globals().fader_time)
+                        ->active()
+                        ->shader(cell::shaders::color(c1), e2::form::state::mouse)
                         ->template plugin<pro::notes>(" Close all open windows in the group ")
                         ->invoke([&](auto& boss)
                         {
@@ -371,9 +370,9 @@ namespace netxs::app::desk
         {
             auto highlight_color = skin::color(tone::highlight);
             auto c8 = cell{}.bgc(0x00).fgc(highlight_color.bgc());
-            auto x8 = cell{ c8 }.alpha(0x00);
             auto ver_label = ui::item::ctor(utf::concat(app::shared::version))
-                ->plugin<pro::fader>(x8, c8, 0ms)
+                ->active()
+                ->shader(cell::shaders::color(c8), e2::form::state::mouse)
                 ->limits({}, { -1, 1 })
                 ->alignment({ snap::tail, snap::tail });
             return ui::cake::ctor()
@@ -436,13 +435,9 @@ namespace netxs::app::desk
             auto danger_color    = skin::globals().danger;
             auto cA = inactive_color;
             auto c3 = highlight_color;
-            auto x3 = cell{ c3 }.alpha(0x00);
             auto c6 = action_color;
-            auto x6 = cell{ c6 }.alpha(0x00);
             auto c2 = warning_color;
-            auto x2 = cell{ c2 }.bga(0x00);
             auto c1 = danger_color;
-            auto x1 = cell{ c1 }.bga(0x00);
 
             auto menu_bg_color = config.take("/config/menu/color", cell{}.fgc(whitedk).bgc(0x60202020));
             auto menu_min_size = config.take("/config/menu/width/folded",   si32{ 4  });
@@ -499,7 +494,8 @@ namespace netxs::app::desk
                         .fgx(data_src->id == my_id ? rgba::vt256[whitelt] : 0x00).add(utf8).nil())
                     ->flexible()
                     ->setpad({ 1, 0, tall, tall }, { 0, 0, -tall, 0 })
-                    ->template plugin<pro::fader>(x3, c3, skin::globals().fader_time)
+                    ->active()
+                    ->shader(cell::shaders::xlight, e2::form::state::mouse)
                     ->template plugin<pro::notes>(" Connected user ");
                 return user;
             };
@@ -567,13 +563,13 @@ namespace netxs::app::desk
                     };
                 });
             auto taskbar_park = taskbar_viewport->attach(slot::_1, ui::cake::ctor())
-                ->colors(menu_bg_color.fgc(), menu_bg_color.bgc())
+                ->active()
                 ->limits({ menu_min_size, -1 }, { menu_min_size, -1 })
                 ->plugin<pro::notes>(" LeftDrag to adjust the taskbar width                        \n"
                                      " Ctrl+LeftDrag to adjust the folded taskbar width            \n"
                                      " RightDrag or scroll wheel to slide the taskbar menu up/down ")
                 ->plugin<pro::timer>()
-                ->plugin<pro::acryl>()
+                ->plugin<pro::acryl>(menu_bg_color)
                 ->plugin<pro::cache>()
                 ->invoke([&](auto& boss)
                 {
@@ -668,12 +664,13 @@ namespace netxs::app::desk
             auto label = label_bttn->attach(slot::_1, ui::item::ctor("users"))
                 ->flexible()
                 ->accented()
+                ->shader(cell::shaders::color(cA))
                 ->setpad({ 0, 0, tall, tall })
-                ->limits({ 5, -1 })
-                ->colors(cA.fgc(), cA.bgc());
+                ->limits({ 5, -1 });
             auto userlist_hidden = true;
             auto bttn = label_bttn->attach(slot::_2, ui::item::ctor(userlist_hidden ? "…" : "<"))
-                ->plugin<pro::fader>(x6, c6, skin::globals().fader_time)
+                ->active()
+                ->shader(cell::shaders::color(c6), e2::form::state::mouse)
                 ->plugin<pro::notes>(" Show/hide user list ")
                 ->setpad({ 2, 2, tall, tall });
             auto userlist_area = users_area->attach(ui::cake::ctor())
@@ -712,7 +709,8 @@ namespace netxs::app::desk
             auto bttns = bttns_area->attach(ui::fork::ctor(axis::X))
                 ->limits(bttn_min_size, bttn_max_size);
             auto disconnect_park = bttns->attach(slot::_1, ui::cake::ctor())
-                ->plugin<pro::fader>(x2, c2, skin::globals().fader_time)
+                ->active()
+                ->shader(cell::shaders::color(c2), e2::form::state::mouse)
                 ->plugin<pro::notes>(" Leave current session ")
                 ->invoke([&, name = text{ username_view }](auto& boss)
                 {
@@ -726,7 +724,8 @@ namespace netxs::app::desk
             auto disconnect_area = disconnect_park->attach(ui::pads::ctor(dent{ 2, 3, tall, tall })->alignment({ snap::head, snap::center }));
             auto disconnect = disconnect_area->attach(ui::item::ctor("× Disconnect"));
             auto shutdown_park = bttns->attach(slot::_2, ui::cake::ctor())
-                ->plugin<pro::fader>(x1, c1, skin::globals().fader_time)
+                ->active()
+                ->shader(cell::shaders::color(c1), e2::form::state::mouse)
                 ->plugin<pro::notes>(" Disconnect all users and shutdown ")
                 ->invoke([&](auto& boss)
                 {

--- a/src/netxs/apps/shop.hpp
+++ b/src/netxs/apps/shop.hpp
@@ -224,8 +224,10 @@ namespace netxs::app::shop
                         for (auto& body : appstore_body) items->attach(ui::post::ctor())
                                                               ->upload(body)
                                                               ->active()
+                                                              ->plugin<pro::focus>()
                                                               ->plugin<pro::grade>()
-                                                              ->plugin<pro::fader>(x3, c3, 250ms);
+                                                              ->shader(cell::shaders::xlight, e2::form::state::hover)
+                                                              ->shader(cell::shaders::color(c3), e2::form::state::keybd::focus::count);
                         items->attach(ui::post::ctor())
                              ->upload(desktopio_body)
                              ->plugin<pro::grade>();

--- a/src/netxs/apps/shop.hpp
+++ b/src/netxs/apps/shop.hpp
@@ -217,11 +217,13 @@ namespace netxs::app::shop
                                ->active();
                 auto layers = object->attach(slot::_2, ui::cake::ctor());
                     auto scroll = layers->attach(ui::rail::ctor())
+                                        ->active()
                                         ->colors(whitedk, 0xFF0f0f0f)
                                         ->limits({ -1,-1 }, { -1,-1 });
                         auto items = scroll->attach(ui::list::ctor());
                         for (auto& body : appstore_body) items->attach(ui::post::ctor())
                                                               ->upload(body)
+                                                              ->active()
                                                               ->plugin<pro::grade>()
                                                               ->plugin<pro::fader>(x3, c3, 250ms);
                         items->attach(ui::post::ctor())

--- a/src/netxs/apps/term.hpp
+++ b/src/netxs/apps/term.hpp
@@ -177,8 +177,6 @@ namespace netxs::app::term
     {
         auto highlight_color = skin::color(tone::highlight);
         auto c3 = highlight_color;
-        auto x3 = cell{ c3 }.alpha(0x00);
-        auto p3 = std::pair{ x3, c3 };
 
         config.cd("/config/term/", "/config/defapp/");
         auto menudata = config.list("menu/item");
@@ -600,7 +598,6 @@ namespace netxs::app::term
                     .notes = label->take(menu::attr::notes, defs.notes),
                     .param = label->take(menu::attr::param, defs.param),
                     .onkey = label->take(menu::attr::onkey, defs.onkey),
-                    .brush = p3,
                 });
             }
             if (item.views.empty()) continue; // Menu item without label.

--- a/src/netxs/apps/term.xml
+++ b/src/netxs/apps/term.xml
@@ -77,7 +77,6 @@ R"==(
         <viewport coor=0,0/>
         <mouse dblclick=500ms/>
         <tooltips timeout=2000ms enabled=true fgc=pureblack bgc=purewhite/>
-        <glowfx=true/>                      <!-- Show glow effect around selected item. -->
         <debug overlay=0 toggle="🐞"/>  <!-- Display console debug info. -->
         <regions enabled=0/>            <!-- Highlight UI objects boundaries. -->
     </client>

--- a/src/netxs/apps/test.hpp
+++ b/src/netxs/apps/test.hpp
@@ -440,6 +440,7 @@ namespace netxs::app::test
                 auto test_stat_area = object0->attach(slot::_2, ui::fork::ctor(axis::Y));
                     auto layers = test_stat_area->attach(slot::_1, ui::cake::ctor());
                         auto scroll = layers->attach(ui::rail::ctor())
+                                            ->active()
                                             ->colors(cyanlt, bluedk);
                             auto object = scroll->attach(ui::post::ctor())
                                                 ->upload(topic)

--- a/src/netxs/apps/text.hpp
+++ b/src/netxs/apps/text.hpp
@@ -105,6 +105,7 @@ displaying the requested definition in a popup window or temporary buffer. Some 
                     auto fields = body_area->attach(slot::_1, ui::pads::ctor(dent{ 1,1 }));
                         auto layers = fields->attach(ui::cake::ctor());
                             auto scroll = layers->attach(ui::rail::ctor())
+                                                ->active()
                                                 ->limits({ 4,3 }, { -1,-1 });
                                 auto edit_box = scroll->attach(ui::post::ctor(true))
                                                       ->plugin<pro::caret>(true, faux, twod{ 25,1 })

--- a/src/netxs/apps/tile.hpp
+++ b/src/netxs/apps/tile.hpp
@@ -91,20 +91,20 @@ namespace netxs::app::tile
                         ->shader(cell::shaders::xlight, e2::form::state::hover)
                         ->invoke([&](auto& boss)
                         {
-                            auto update_focus = [](auto& boss, auto state)
+                            auto update_focus = [](auto& boss, auto count)
                             {
                                 auto highlight_color = skin::color(tone::highlight);
                                 auto c3 = highlight_color;
                                 auto x3 = cell{ c3 }.alpha(0x00);
-                                boss.base::color(state ? 0xFF00ff00 : x3.fgc(), x3.bgc());
+                                boss.base::color(count ? 0xFF00ff00 : x3.fgc(), x3.bgc());
                             };
                             auto data_shadow = ptr::shadow(data_src_sptr);
                             boss.LISTEN(tier::release, e2::form::upon::vtree::attached, parent, boss.tracker, (data_shadow))
                             {
                                 if (auto data_ptr = data_shadow.lock())
                                 {
-                                    data_ptr->RISEUP(tier::request, e2::form::state::keybd::focus::state, state, ());
-                                    update_focus(boss, state);
+                                    data_ptr->RISEUP(tier::request, e2::form::state::keybd::focus::count, count, ());
+                                    update_focus(boss, count);
                                     parent->resize();
                                 }
                             };
@@ -112,9 +112,9 @@ namespace netxs::app::tile
                             {
                                 if (parent) parent->resize(); // Rebuild list.
                             };
-                            data_src_sptr->LISTEN(tier::release, e2::form::state::keybd::focus::state, state, boss.tracker)
+                            data_src_sptr->LISTEN(tier::release, e2::form::state::keybd::focus::count, count, boss.tracker)
                             {
-                                update_focus(boss, state);
+                                update_focus(boss, count);
                             };
                             data_src_sptr->LISTEN(tier::release, events::delist, object, boss.tracker)
                             {

--- a/src/netxs/apps/tile.hpp
+++ b/src/netxs/apps/tile.hpp
@@ -383,17 +383,13 @@ namespace netxs::app::tile
             auto highlight_color = skin::color(tone::highlight);
             auto danger_color    = skin::color(tone::danger);
             auto c3 = highlight_color;
-            auto x3 = cell{ c3 }.alpha(0x00);
             auto c1 = danger_color;
-            auto x1 = cell{ c1 }.alpha(0x00);
-            auto p1 = std::pair{ x1, c1 };
-            auto p3 = std::pair{ x3, c3 };
 
             using namespace app::shared;
             auto [menu_block, cover, menu_data] = menu::mini(true, true, faux, 1,
             menu::list
             {
-                { menu::item{ menu::item::type::Command, true, 0, std::vector<menu::item::look>{{ .label = "+", .notes = " New app ", .brush = p3 }}},
+                { menu::item{ menu::item::type::Command, true, 0, std::vector<menu::item::look>{{ .label = "+", .notes = " New app " }}},
                 [](auto& boss, auto& item)
                 {
                     boss.LISTEN(tier::release, hids::events::mouse::button::click::left, gear)
@@ -402,7 +398,7 @@ namespace netxs::app::tile
                         gear.dismiss(true);
                     };
                 }},
-                { menu::item{ menu::item::type::Command, true, 0, std::vector<menu::item::look>{{ .label = "│", .notes = " Split horizontally ", .brush = p3 }}},
+                { menu::item{ menu::item::type::Command, true, 0, std::vector<menu::item::look>{{ .label = "│", .notes = " Split horizontally " }}},
                 [](auto& boss, auto& item)
                 {
                     boss.LISTEN(tier::release, hids::events::mouse::button::click::left, gear)
@@ -411,7 +407,7 @@ namespace netxs::app::tile
                         gear.dismiss(true);
                     };
                 }},
-                { menu::item{ menu::item::type::Command, true, 0, std::vector<menu::item::look>{{ .label = "──", .notes = " Split vertically ", .brush = p3 }}},
+                { menu::item{ menu::item::type::Command, true, 0, std::vector<menu::item::look>{{ .label = "──", .notes = " Split vertically " }}},
                 [](auto& boss, auto& item)
                 {
                     boss.LISTEN(tier::release, hids::events::mouse::button::click::left, gear)
@@ -420,7 +416,7 @@ namespace netxs::app::tile
                         gear.dismiss(true);
                     };
                 }},
-                { menu::item{ menu::item::type::Command, true, 0, std::vector<menu::item::look>{{ .label = "×", .notes = " Delete pane ", .brush = p1 }}},
+                { menu::item{ menu::item::type::Command, true, 0, std::vector<menu::item::look>{{ .label = "×", .notes = " Delete pane ", .hover = c1 }}},
                 [](auto& boss, auto& item)
                 {
                     boss.LISTEN(tier::release, hids::events::mouse::button::click::left, gear)
@@ -809,20 +805,10 @@ namespace netxs::app::tile
             auto cB = menu_white;
             auto highlight_color = skin::color(tone::highlight);
             auto danger_color    = skin::color(tone::danger);
-            auto action_color    = skin::color(tone::action);
             auto warning_color   = skin::color(tone::warning);
-            auto c6 = action_color;
-            auto x6 = cell{ c6 }.alpha(0x00);
             auto c3 = highlight_color;
-            auto x3 = cell{ c3 }.alpha(0x00);
             auto c2 = warning_color;
-            auto x2 = cell{ c2 }.bga(0x00);
             auto c1 = danger_color;
-            auto x1 = cell{ c1 }.alpha(0x00);
-            auto p1 = std::pair{ x1, c1 };
-            auto p2 = std::pair{ x2, c2 };
-            auto p3 = std::pair{ x3, c3 };
-            auto p6 = std::pair{ x6, c6 };
 
             auto object = ui::fork::ctor(axis::Y)
                 ->plugin<items>()
@@ -855,7 +841,7 @@ namespace netxs::app::tile
                         // ┌────┐  ┌────┐  ┌─┬──┐  ┌────┐  ┌─┬──┐  ┌─┬──┐  ┌────┐  // ┌─┐  ┌─┬─┐  ┌─┬─┐  ┌─┬─┐  
                         // │Exec│  ├─┐  │  │ H  │  ├ V ─┤  │Swap│  │Fair│  │Shut│  // ├─┤  └─┴─┘  └<┴>┘  └>┴<┘  
                         // └────┘  └─┴──┘  └─┴──┘  └────┘  └─┴──┘  └─┴──┘  └────┘  // └─┘                       
-                        //{ menu::item{ menu::item::type::Command, true, 0, std::vector<menu::item::look>{{ .label = " ┐└ ", .notes = " Maximize/restore active pane ", .brush = p3 }}},
+                        //{ menu::item{ menu::item::type::Command, true, 0, std::vector<menu::item::look>{{ .label = " ┐└ ", .notes = " Maximize/restore active pane " }}},
                         //[](auto& boss, auto& item)
                         //{
                         //    boss.LISTEN(tier::release, hids::events::mouse::button::click::left, gear)
@@ -865,7 +851,7 @@ namespace netxs::app::tile
                         //        gear.dismiss(true);
                         //    };
                         //}},
-                        { menu::item{ menu::item::type::Command, true, 0, std::vector<menu::item::look>{{ .label = " + ", .notes = " Create and run a new app in active panes ", .brush = p3 }}},
+                        { menu::item{ menu::item::type::Command, true, 0, std::vector<menu::item::look>{{ .label = " + ", .notes = " Create and run a new app in active panes " }}},
                         [](auto& boss, auto& item)
                         {
                             boss.LISTEN(tier::release, hids::events::mouse::button::click::left, gear)
@@ -874,7 +860,7 @@ namespace netxs::app::tile
                                 gear.dismiss(true);
                             };
                         }},
-                        { menu::item{ menu::item::type::Command, true, 0, std::vector<menu::item::look>{{ .label = ":::", .notes = " Select all panes ", .brush = p3 }}},
+                        { menu::item{ menu::item::type::Command, true, 0, std::vector<menu::item::look>{{ .label = ":::", .notes = " Select all panes " }}},
                         [](auto& boss, auto& item)
                         {
                             boss.LISTEN(tier::release, hids::events::mouse::button::click::left, gear)
@@ -883,7 +869,7 @@ namespace netxs::app::tile
                                 gear.dismiss(true);
                             };
                         }},
-                        { menu::item{ menu::item::type::Command, true, 0, std::vector<menu::item::look>{{ .label = " │ ", .notes = " Split active panes horizontally ", .brush = p3 }}},
+                        { menu::item{ menu::item::type::Command, true, 0, std::vector<menu::item::look>{{ .label = " │ ", .notes = " Split active panes horizontally " }}},
                         [](auto& boss, auto& item)
                         {
                             boss.LISTEN(tier::release, hids::events::mouse::button::click::left, gear)
@@ -892,7 +878,7 @@ namespace netxs::app::tile
                                 gear.dismiss(true);
                             };
                         }},
-                        { menu::item{ menu::item::type::Command, true, 0, std::vector<menu::item::look>{{ .label = "──", .notes = " Split active panes vertically ", .brush = p3 }}},
+                        { menu::item{ menu::item::type::Command, true, 0, std::vector<menu::item::look>{{ .label = "──", .notes = " Split active panes vertically " }}},
                         [](auto& boss, auto& item)
                         {
                             boss.LISTEN(tier::release, hids::events::mouse::button::click::left, gear)
@@ -901,7 +887,7 @@ namespace netxs::app::tile
                                 gear.dismiss(true);
                             };
                         }},
-                        { menu::item{ menu::item::type::Command, true, 0, std::vector<menu::item::look>{{ .label = " ┌┘ ", .notes = " Change split orientation ", .brush = p3 }}},
+                        { menu::item{ menu::item::type::Command, true, 0, std::vector<menu::item::look>{{ .label = " ┌┘ ", .notes = " Change split orientation " }}},
                         [](auto& boss, auto& item)
                         {
                             boss.LISTEN(tier::release, hids::events::mouse::button::click::left, gear)
@@ -910,7 +896,7 @@ namespace netxs::app::tile
                                 gear.dismiss(true);
                             };
                         }},
-                        { menu::item{ menu::item::type::Command, true, 0, std::vector<menu::item::look>{{ .label = "<->", .notes = " Swap two or more panes ", .brush = p3 }}},
+                        { menu::item{ menu::item::type::Command, true, 0, std::vector<menu::item::look>{{ .label = "<->", .notes = " Swap two or more panes " }}},
                         [](auto& boss, auto& item)
                         {
                             boss.LISTEN(tier::release, hids::events::mouse::button::click::left, gear)
@@ -919,7 +905,7 @@ namespace netxs::app::tile
                                 gear.dismiss(true);
                             };
                         }},
-                        { menu::item{ menu::item::type::Command, true, 0, std::vector<menu::item::look>{{ .label = ">|<", .notes = " Equalize split ratio ", .brush = p3 }}},
+                        { menu::item{ menu::item::type::Command, true, 0, std::vector<menu::item::look>{{ .label = ">|<", .notes = " Equalize split ratio " }}},
                         [](auto& boss, auto& item)
                         {
                             boss.LISTEN(tier::release, hids::events::mouse::button::click::left, gear)
@@ -928,7 +914,7 @@ namespace netxs::app::tile
                                 gear.dismiss(true);
                             };
                         }},
-                        { menu::item{ menu::item::type::Command, true, 0, std::vector<menu::item::look>{{ .label = "\"…\"", .notes = " Set tiling manager window title using clipboard data ", .brush = p3 }}},
+                        { menu::item{ menu::item::type::Command, true, 0, std::vector<menu::item::look>{{ .label = "\"…\"", .notes = " Set tiling manager window title using clipboard data " }}},
                         [](auto& boss, auto& item)
                         {
                             boss.LISTEN(tier::release, hids::events::mouse::button::click::left, gear)
@@ -936,7 +922,7 @@ namespace netxs::app::tile
                                 app::shared::set_title(boss, gear);
                             };
                         }},
-                        { menu::item{ menu::item::type::Command, true, 0, std::vector<menu::item::look>{{ .label = " × ", .notes = " Close active app or remove pane if there is no running app ", .brush = p1 }}},
+                        { menu::item{ menu::item::type::Command, true, 0, std::vector<menu::item::look>{{ .label = " × ", .notes = " Close active app or remove pane if there is no running app ", .hover = c1 }}},
                         [](auto& boss, auto& item)
                         {
                             boss.LISTEN(tier::release, hids::events::mouse::button::click::left, gear)

--- a/src/netxs/apps/tile.hpp
+++ b/src/netxs/apps/tile.hpp
@@ -85,10 +85,10 @@ namespace netxs::app::tile
                 {
                     auto highlight_color = skin::color(tone::highlight);
                     auto c3 = highlight_color;
-                    auto x3 = cell{ c3 }.alpha(0x00);
                     return ui::item::ctor(header.empty() ? "- no title -" : header)
                         ->setpad({ 1, 1 })
-                        ->template plugin<pro::fader>(x3, c3, skin::globals().fader_time)
+                        ->active()
+                        ->shader(cell::shaders::xlight, e2::form::state::hover)
                         ->invoke([&](auto& boss)
                         {
                             auto update_focus = [](auto& boss, auto state)
@@ -96,7 +96,7 @@ namespace netxs::app::tile
                                 auto highlight_color = skin::color(tone::highlight);
                                 auto c3 = highlight_color;
                                 auto x3 = cell{ c3 }.alpha(0x00);
-                                boss.color(state ? 0xFF00ff00 : x3.fgc(), x3.bgc());
+                                boss.base::color(state ? 0xFF00ff00 : x3.fgc(), x3.bgc());
                             };
                             auto data_shadow = ptr::shadow(data_src_sptr);
                             boss.LISTEN(tier::release, e2::form::upon::vtree::attached, parent, boss.tracker, (data_shadow))
@@ -440,6 +440,7 @@ namespace netxs::app::tile
 
             return ui::cake::ctor()
                 ->isroot(true, base::placeholder)
+                ->active()
                 ->colors(cC.fgc(), cC.bgc())
                 ->limits(dot_00, -dot_11)
                 ->plugin<pro::focus>(pro::focus::mode::focusable)
@@ -469,6 +470,7 @@ namespace netxs::app::tile
         {
             return ui::veer::ctor()
                 ->plugin<pro::focus>(pro::focus::mode::hub/*default*/, true/*default*/, true)
+                ->active()
                 ->invoke([&](auto& boss)
                 {
                     auto highlight = [](auto& boss, auto state)
@@ -887,7 +889,7 @@ namespace netxs::app::tile
                                 gear.dismiss(true);
                             };
                         }},
-                        { menu::item{ menu::item::type::Command, true, 0, std::vector<menu::item::look>{{ .label = " ┌┘ ", .notes = " Change split orientation " }}},
+                        { menu::item{ menu::item::type::Command, true, 0, std::vector<menu::item::look>{{ .label = "┌┘", .notes = " Change split orientation " }}},
                         [](auto& boss, auto& item)
                         {
                             boss.LISTEN(tier::release, hids::events::mouse::button::click::left, gear)
@@ -922,7 +924,7 @@ namespace netxs::app::tile
                                 app::shared::set_title(boss, gear);
                             };
                         }},
-                        { menu::item{ menu::item::type::Command, true, 0, std::vector<menu::item::look>{{ .label = " × ", .notes = " Close active app or remove pane if there is no running app ", .hover = c1 }}},
+                        { menu::item{ menu::item::type::Command, true, 0, std::vector<menu::item::look>{{ .label = "×", .notes = " Close active app ", .hover = c1 }}},
                         [](auto& boss, auto& item)
                         {
                             boss.LISTEN(tier::release, hids::events::mouse::button::click::left, gear)

--- a/src/netxs/desktopio/application.hpp
+++ b/src/netxs/desktopio/application.hpp
@@ -161,13 +161,11 @@ namespace netxs::app::shared
 
             struct look
             {
-                using pair = std::pair<cell, cell>; // Accented/idle.
                 text label{};
                 text notes{};
                 text param{};
                 text onkey{};
                 si32 value{};
-                pair brush{};
                 cell hover{};
                 cell focus{};
             };
@@ -209,18 +207,10 @@ namespace netxs::app::shared
             auto action_color    = skin::color(tone::action);
             auto warning_color   = skin::color(tone::warning);
             auto c6 = action_color;
-            auto x6 = cell{ c6 }.alpha(0x00);
             auto c3 = highlight_color;
             auto x3 = cell{ c3 }.alpha(0x00);
             auto c2 = warning_color;
-            auto x2 = cell{ c2 }.bga(0x00);
             auto c1 = danger_color;
-            auto x1 = cell{ c1 }.alpha(0x00);
-            auto p1 = std::pair{ x1, c1 };
-            auto p2 = std::pair{ x2, c2 };
-            auto p3 = std::pair{ x3, c3 };
-            auto p6 = std::pair{ x6, c6 };
-            auto turntime = skin::globals().fader_time;
             auto macstyle = skin::globals().macstyle;
 
             auto menuveer = ui::veer::ctor();
@@ -232,24 +222,16 @@ namespace netxs::app::shared
             {
                 auto& props = std::get<0>(config);
                 auto& setup = std::get<1>(config);
-                auto& hover = props.alive;
+                auto& alive = props.alive;
                 auto& label = props.views.front().label;
                 auto& notes = props.views.front().notes;
-                auto& brush = props.views.front().brush;
+                auto& hover = props.views.front().hover;
                 auto button = ui::item::ctor(label)->drawdots();
-                //if (hover) button->template plugin<pro::fader>(brush.first, brush.second, turntime); //todo template: GCC complains
-                //else       button->colors(0,0); //todo for mouse tracking
-                button->active();
-                if (hover)
+                button->active(); // Always active for tooltips.
+                if (alive)
                 {
-                    //if (brush.first.set())
-                    {
-                        button->shader(cell::shaders::xlight, e2::form::state::mouse);
-                    }
-                    //else
-                    {
-
-                    }
+                    if (hover.set()) button->shader(cell::shaders::color(hover), e2::form::state::hover);
+                    else             button->shader(cell::shaders::xlight,       e2::form::state::hover);
                 }
                 button->template plugin<pro::notes>(notes)
                     ->setpad({ 2,2,!slimsize,!slimsize })
@@ -280,7 +262,7 @@ namespace netxs::app::shared
             {
                 auto control = std::vector<link>
                 {
-                    { menu::item{ menu::item::type::Command, true, 0, std::vector<menu::item::look>{{ .label = "—", .notes = " Minimize ", .brush = p2 }}},
+                    { menu::item{ menu::item::type::Command, true, 0, std::vector<menu::item::look>{{ .label = "—", .notes = " Minimize ", .hover = c2 }}},
                     [](auto& boss, auto& item)
                     {
                         boss.LISTEN(tier::release, hids::events::mouse::button::click::left, gear)
@@ -289,7 +271,7 @@ namespace netxs::app::shared
                             gear.dismiss();
                         };
                     }},
-                    { menu::item{ menu::item::type::Command, true, 0, std::vector<menu::item::look>{{ .label = "□", .notes = " Maximize ", .brush = p6 }}},
+                    { menu::item{ menu::item::type::Command, true, 0, std::vector<menu::item::look>{{ .label = "□", .notes = " Maximize ", .hover = c6 }}},
                     [](auto& boss, auto& item)
                     {
                         boss.LISTEN(tier::release, hids::events::mouse::button::click::left, gear)
@@ -298,7 +280,7 @@ namespace netxs::app::shared
                             gear.dismiss();
                         };
                     }},
-                    { menu::item{ menu::item::type::Command, true, 0, std::vector<menu::item::look>{{ .label = "×", .notes = " Close ", .brush = p1 }}},
+                    { menu::item{ menu::item::type::Command, true, 0, std::vector<menu::item::look>{{ .label = "×", .notes = " Close ", .hover = c1 }}},
                     [](auto& boss, auto& item)
                     {
                         boss.LISTEN(tier::release, hids::events::mouse::button::click::left, gear)
@@ -406,15 +388,13 @@ namespace netxs::app::shared
         {
             auto highlight_color = skin::color(tone::highlight);
             auto c3 = highlight_color;
-            auto x3 = cell{ c3 }.alpha(0x00);
-            auto p3 = std::pair{ x3, c3 };
             auto items = list
             {
-                { item{ item::type::Command, true, 0, std::vector<item::look>{{ .label = ansi::und(true).add("F").nil().add("ile"), .notes = " File menu item ", .brush = p3 }}}, [&](auto& boss, auto& item){ }},
-                { item{ item::type::Command, true, 0, std::vector<item::look>{{ .label = ansi::und(true).add("E").nil().add("dit"), .notes = " Edit menu item ", .brush = p3 }}}, [&](auto& boss, auto& item){ }},
-                { item{ item::type::Command, true, 0, std::vector<item::look>{{ .label = ansi::und(true).add("V").nil().add("iew"), .notes = " View menu item ", .brush = p3 }}}, [&](auto& boss, auto& item){ }},
-                { item{ item::type::Command, true, 0, std::vector<item::look>{{ .label = ansi::und(true).add("D").nil().add("ata"), .notes = " Data menu item ", .brush = p3 }}}, [&](auto& boss, auto& item){ }},
-                { item{ item::type::Command, true, 0, std::vector<item::look>{{ .label = ansi::und(true).add("H").nil().add("elp"), .notes = " Help menu item ", .brush = p3 }}}, [&](auto& boss, auto& item){ }},
+                { item{ item::type::Command, true, 0, std::vector<item::look>{{ .label = ansi::und(true).add("F").nil().add("ile"), .notes = " File menu item " }}}, [&](auto& boss, auto& item){ }},
+                { item{ item::type::Command, true, 0, std::vector<item::look>{{ .label = ansi::und(true).add("E").nil().add("dit"), .notes = " Edit menu item " }}}, [&](auto& boss, auto& item){ }},
+                { item{ item::type::Command, true, 0, std::vector<item::look>{{ .label = ansi::und(true).add("V").nil().add("iew"), .notes = " View menu item " }}}, [&](auto& boss, auto& item){ }},
+                { item{ item::type::Command, true, 0, std::vector<item::look>{{ .label = ansi::und(true).add("D").nil().add("ata"), .notes = " Data menu item " }}}, [&](auto& boss, auto& item){ }},
+                { item{ item::type::Command, true, 0, std::vector<item::look>{{ .label = ansi::und(true).add("H").nil().add("elp"), .notes = " Help menu item " }}}, [&](auto& boss, auto& item){ }},
             };
             config.cd("/config/defapp/");
             auto [menu, cover, menu_data] = create(config, items);

--- a/src/netxs/desktopio/application.hpp
+++ b/src/netxs/desktopio/application.hpp
@@ -168,6 +168,8 @@ namespace netxs::app::shared
                 text onkey{};
                 si32 value{};
                 pair brush{};
+                cell hover{};
+                cell focus{};
             };
 
             using imap = std::unordered_map<si32, si32>;
@@ -235,8 +237,20 @@ namespace netxs::app::shared
                 auto& notes = props.views.front().notes;
                 auto& brush = props.views.front().brush;
                 auto button = ui::item::ctor(label)->drawdots();
-                if (hover) button->template plugin<pro::fader>(brush.first, brush.second, turntime); //todo template: GCC complains
-                else       button->colors(0,0); //todo for mouse tracking
+                //if (hover) button->template plugin<pro::fader>(brush.first, brush.second, turntime); //todo template: GCC complains
+                //else       button->colors(0,0); //todo for mouse tracking
+                button->active();
+                if (hover)
+                {
+                    //if (brush.first.set())
+                    {
+                        button->shader(cell::shaders::xlight, e2::form::state::mouse);
+                    }
+                    //else
+                    {
+
+                    }
+                }
                 button->template plugin<pro::notes>(notes)
                     ->setpad({ 2,2,!slimsize,!slimsize })
                     ->invoke([&](auto& boss) // Store shared ptr to the menu item config.

--- a/src/netxs/desktopio/application.hpp
+++ b/src/netxs/desktopio/application.hpp
@@ -208,11 +208,9 @@ namespace netxs::app::shared
             auto warning_color   = skin::color(tone::warning);
             auto c6 = action_color;
             auto c3 = highlight_color;
-            auto x3 = cell{ c3 }.alpha(0x00);
             auto c2 = warning_color;
             auto c1 = danger_color;
             auto macstyle = skin::globals().macstyle;
-
             auto menuveer = ui::veer::ctor();
             auto menufork = ui::fork::ctor()
                 //todo
@@ -234,7 +232,7 @@ namespace netxs::app::shared
                     else             button->shader(cell::shaders::xlight,       e2::form::state::hover);
                 }
                 button->template plugin<pro::notes>(notes)
-                    ->setpad({ 2,2,!slimsize,!slimsize })
+                    ->setpad({ 2, 2, !slimsize, !slimsize })
                     ->invoke([&](auto& boss) // Store shared ptr to the menu item config.
                     {
                         auto props_shadow = ptr::shared(std::move(props));
@@ -262,7 +260,7 @@ namespace netxs::app::shared
             {
                 auto control = std::vector<link>
                 {
-                    { menu::item{ menu::item::type::Command, true, 0, std::vector<menu::item::look>{{ .label = "—", .notes = " Minimize ", .hover = c2 }}},
+                    { menu::item{ menu::item::type::Command, true, 0, std::vector<menu::item::look>{{ .label = "—", .notes = " Minimize " }}},//, .hover = c2 }}}, //toto too funky
                     [](auto& boss, auto& item)
                     {
                         boss.LISTEN(tier::release, hids::events::mouse::button::click::left, gear)
@@ -271,7 +269,7 @@ namespace netxs::app::shared
                             gear.dismiss();
                         };
                     }},
-                    { menu::item{ menu::item::type::Command, true, 0, std::vector<menu::item::look>{{ .label = "□", .notes = " Maximize ", .hover = c6 }}},
+                    { menu::item{ menu::item::type::Command, true, 0, std::vector<menu::item::look>{{ .label = "□", .notes = " Maximize " }}},//, .hover = c6 }}},
                     [](auto& boss, auto& item)
                     {
                         boss.LISTEN(tier::release, hids::events::mouse::button::click::left, gear)

--- a/src/netxs/desktopio/application.hpp
+++ b/src/netxs/desktopio/application.hpp
@@ -23,7 +23,7 @@ namespace netxs::app
 
 namespace netxs::app::shared
 {
-    static const auto version = "v0.9.9w";
+    static const auto version = "v0.9.10";
     static const auto desktopio = "desktopio";
     static const auto logsuffix = "_log";
     static const auto usr_config = "~/.config/vtm/settings.xml";

--- a/src/netxs/desktopio/baseui.hpp
+++ b/src/netxs/desktopio/baseui.hpp
@@ -471,7 +471,7 @@ namespace netxs::events::userland
                         {
                             EVENT_XS( on    , const id_t ),
                             EVENT_XS( off   , const id_t ),
-                            EVENT_XS( state , bool       ),
+                            EVENT_XS( count , si32       ),
                         };
                     };
                 };

--- a/src/netxs/desktopio/baseui.hpp
+++ b/src/netxs/desktopio/baseui.hpp
@@ -999,13 +999,13 @@ namespace netxs::ui
                 if (parent_ptr) parent_ptr->base::reflow(); //todo too expensive. ? accumulate deferred reflow? or make it when stated?
             };
             //todo deprecated
-            LISTEN(tier::release, e2::render::any, parent_canvas)
-            {
-                if (base::filler.wdt() && !base::hidden)
-                {
-                    parent_canvas.fill([&](cell& c) { c.fusefull(base::filler); });
-                }
-            };
+            //LISTEN(tier::release, e2::render::any, parent_canvas)
+            //{
+            //    if (base::filler.wdt() && !base::hidden)
+            //    {
+            //        parent_canvas.fill([&](cell& c) { c.fusefull(base::filler); });
+            //    }
+            //};
         }
     };
 }

--- a/src/netxs/desktopio/baseui.hpp
+++ b/src/netxs/desktopio/baseui.hpp
@@ -590,10 +590,7 @@ namespace netxs::ui
         subs relyon; // base: Subscription on parent events.
         rect region; // base: The region occupied by the object.
         rect socket; // base: The region provided for the object.
-
-        //todo deprecated
         cell filler; // base: Object color.
-
         twod min_sz; // base: Minimal size.
         twod max_sz; // base: Maximal size.
         twod anchor; // base: Object balance point. Center point for any transform (on preview).
@@ -628,23 +625,19 @@ namespace netxs::ui
             if constexpr (Absolute) area.coor += region.coor;
             return area;
         }
-        auto color() const { return filler; }
+        auto color() const { return base::filler; }
         void color(rgba fg_color, rgba bg_color)
         {
-            // To make an object transparent to mouse events,
-            // no id (cell::id = 0) is used by default in the filler.
-            // The bell::id is configurable only with pro::mouse.
             base::filler.bgc(bg_color)
                         .fgc(fg_color)
                         .txt(whitespace);
             SIGNAL(tier::release, e2::form::prop::filler, filler);
         }
-        void color(cell const& new_filler)
+        void color(cell const& new_filler) // Set id=0 to make the object transparent to mouse events.
         {
             base::filler = new_filler;
             SIGNAL(tier::release, e2::form::prop::filler, filler);
         }
-
         // base: Align object.
         void xform(snap atcrop, snap atgrow, si32& coor, si32& size, si32& width)
         {
@@ -998,14 +991,17 @@ namespace netxs::ui
                 }
                 if (parent_ptr) parent_ptr->base::reflow(); //todo too expensive. ? accumulate deferred reflow? or make it when stated?
             };
-            //todo deprecated
-            //LISTEN(tier::release, e2::render::any, parent_canvas)
-            //{
-            //    if (base::filler.wdt() && !base::hidden)
-            //    {
-            //        parent_canvas.fill([&](cell& c) { c.fusefull(base::filler); });
-            //    }
-            //};
+            LISTEN(tier::release, e2::render::any, parent_canvas)
+            {
+                if (base::filler.wdt())
+                {
+                    parent_canvas.fill([&](cell& c) { c.fusefull(base::filler); });
+                }
+                else if (base::filler.link())
+                {
+                    parent_canvas.fill([&](cell& c) { c.link(bell::id); });
+                }
+            };
         }
     };
 }

--- a/src/netxs/desktopio/baseui.hpp
+++ b/src/netxs/desktopio/baseui.hpp
@@ -451,7 +451,8 @@ namespace netxs::events::userland
                 };
                 SUBSET_XS( state )
                 {
-                    EVENT_XS( mouse    , si32     ), // notify the object if mouse is active or not. The form is active when the number of clients (form::eventa::mouse::enter - mouse::leave) is not zero, only release, si32 - number of clients.
+                    EVENT_XS( mouse    , si32     ), // notify the object if mouse is active or not. The form is active when the number of clients (form::eventa::mouse::enter - mouse::leave) is not zero, only release.
+                    EVENT_XS( hover    , si32     ), // notify the object how many mouse cursors are hovering, si32 - number of cursors.
                     //EVENT_XS( params   , ui::para ), // notify the object has changed title params.
                     EVENT_XS( color    , ui::tone ), // notify the object has changed tone, preview to set.
                     EVENT_XS( highlight, bool     ),

--- a/src/netxs/desktopio/canvas.hpp
+++ b/src/netxs/desktopio/canvas.hpp
@@ -1652,7 +1652,7 @@ namespace netxs
             };
             struct xlight_t
             {
-                si32 factor = 1;
+                si32 factor; // Uninitialized.
                 template<class T>
                 inline auto operator [] (T param) const
                 {
@@ -1762,7 +1762,7 @@ namespace netxs
             static constexpr auto skipnuls = skipnuls_t{};
             static constexpr auto     text =     text_t{};
             static constexpr auto     meta =     meta_t{};
-            static constexpr auto   xlight =   xlight_t{};
+            static constexpr auto   xlight =   xlight_t{ 1 };
             static constexpr auto   invert =   invert_t{};
             static constexpr auto  reverse =  reverse_t{};
             static constexpr auto   invbit =   invbit_t{};

--- a/src/netxs/desktopio/canvas.hpp
+++ b/src/netxs/desktopio/canvas.hpp
@@ -1721,7 +1721,8 @@ namespace netxs
                 template<class D, class S>
                 inline void operator () (D& dst, S& src) const
                 {
-                    dst.fuse(src);
+                    auto i = factor;
+                    while(i-- > 0) dst.fuse(src);
                     operator()(dst);
                 }
             };

--- a/src/netxs/desktopio/canvas.hpp
+++ b/src/netxs/desktopio/canvas.hpp
@@ -1702,8 +1702,9 @@ namespace netxs
                     : colors{ colors },
                       factor{ factor }
                 { }
-                constexpr color_t(cell const& brush)
-                    : colors{ brush.uv }
+                constexpr color_t(cell const& brush, si32 factor = 1)
+                    : colors{ brush.uv },
+                      factor{ factor }
                 { }
                 template<class T>
                 inline auto operator [] (T param) const

--- a/src/netxs/desktopio/canvas.hpp
+++ b/src/netxs/desktopio/canvas.hpp
@@ -305,7 +305,20 @@ namespace netxs
         // rgba: Shift color.
         void xlight()
         {
-            if (luma() > 140)
+            //todo unify
+            if (chan.a == 0)
+            {
+                chan.a = 42;
+                chan.r = 0xFF;
+                chan.g = 0xFF;
+                chan.b = 0xFF;
+            }
+            else if (chan.a != 0xFF)
+            {
+                auto k = 42;
+                chan.a = chan.a > 0xFF - k ? 0xFF : chan.a + k;
+            }
+            else if (luma() > 140)
             {
                 auto k = 64;
                 chan.r = chan.r < k ? 0x00 : chan.r - k;
@@ -1486,6 +1499,7 @@ namespace netxs
         auto  txt() const  { return gc.get();      } // cell: Return Grapheme cluster.
         auto& egc()        { return gc;            } // cell: Get Grapheme cluster token.
         auto& egc() const  { return gc;            } // cell: Get Grapheme cluster token.
+        auto  set() const  { return uv.bg || uv.fg;} // cell: Return true if color set.
         auto  bga() const  { return uv.bg.chan.a;  } // cell: Return Background alpha/transparency.
         auto  fga() const  { return uv.fg.chan.a;  } // cell: Return Foreground alpha/transparency.
         auto& bgc()        { return uv.bg;         } // cell: Return Background color.

--- a/src/netxs/desktopio/console.hpp
+++ b/src/netxs/desktopio/console.hpp
@@ -398,7 +398,6 @@ namespace netxs::ui
             span tooltip_timeout; // conf: Timeout for tooltip.
             cell tooltip_colors; // conf: Tooltip rendering colors.
             bool tooltip_enabled; // conf: Enable tooltips.
-            bool glow_fx; // conf: Enable glow effect in main menu.
             bool debug_overlay; // conf: Enable to show debug overlay.
             text debug_toggle; // conf: Debug toggle shortcut.
             bool show_regions; // conf: Highlight region ownership.
@@ -443,13 +442,11 @@ namespace netxs::ui
                         background_image.size(block.limits());
                         background_image.output(block);
                     }
-                    glow_fx           = config.take("glowfx", true);
                     simple            = faux;
                 }
                 else
                 {
                     simple            = !(legacy_mode & ui::console::direct);
-                    glow_fx           = faux;
                     title             = "";
                 }
                 vtmode = legacy_mode & ui::console::nt16   ? svga::nt16

--- a/src/netxs/desktopio/controls.hpp
+++ b/src/netxs/desktopio/controls.hpp
@@ -2297,7 +2297,6 @@ namespace netxs::ui
         {
             auto backup = This();
             depo[std::type_index(typeid(S))] = std::make_unique<S>(*backup, std::forward<Args>(args)...);
-            base::reflow();
             return backup;
         }
         // form: Detach feature and return itself.
@@ -2306,7 +2305,6 @@ namespace netxs::ui
         {
             auto backup = This();
             depo.erase(std::type_index(typeid(S)));
-            base::reflow();
             return backup;
         }
         // form: deprecated in favor of pro::brush. Set colors and return itself.

--- a/src/netxs/desktopio/controls.hpp
+++ b/src/netxs/desktopio/controls.hpp
@@ -1832,6 +1832,10 @@ namespace netxs::ui
                 {
                     state = rent;
                 };
+                boss.LISTEN(tier::request, e2::form::state::hover, state, memo)
+                {
+                    state = rent;
+                };
                 boss.LISTEN(tier::release, e2::form::draggable::any, enabled, memo)
                 {
                     switch (auto deed = boss.bell::protos<tier::release>())

--- a/src/netxs/desktopio/controls.hpp
+++ b/src/netxs/desktopio/controls.hpp
@@ -1806,6 +1806,7 @@ namespace netxs::ui
                         {
                             boss.SIGNAL(tier::release, e2::form::state::mouse, rent);
                         }
+                        boss.SIGNAL(tier::release, e2::form::state::hover, rent);
                     }
                     //if constexpr (debugmode) log("Enter boss:", boss.id, " full:", full);
                 };
@@ -1818,6 +1819,7 @@ namespace netxs::ui
                         {
                             boss.SIGNAL(tier::release, e2::form::state::mouse, rent);
                         }
+                        boss.SIGNAL(tier::release, e2::form::state::hover, rent);
                     }
                     //if constexpr (debugmode) log("Leave boss:", boss.id, " full:", full - 1);
                     if (!--full)
@@ -2327,7 +2329,7 @@ namespace netxs::ui
                 };
                 LISTEN(tier::release, RenderOrder, parent_canvas, -, (fx))
                 {
-                    if (param) parent_canvas.fill(fx);
+                    if (param) parent_canvas.fill(fx[param]);
                 };
             }
             return This();

--- a/src/netxs/desktopio/controls.hpp
+++ b/src/netxs/desktopio/controls.hpp
@@ -2147,7 +2147,7 @@ namespace netxs::ui
                 boss.LISTEN(tier::release, e2::render::prerender, parent_canvas, memo)
                 {
                     if (!alive || boss.base::filler.bga() == 0xFF) return;
-                    parent_canvas.blur(width);
+                    parent_canvas.blur(width, [&](cell& c) { c.alpha(0xFF); });
                 };
             }
         };

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -384,11 +384,12 @@ namespace netxs::ui
                 : owner{ owner },
                   encod{ prot::w32 }
             {
-                owner.LISTEN(tier::release, e2::form::state::keybd::focus::state, s, token)
+                owner.LISTEN(tier::release, e2::form::state::keybd::focus::count, count, token)
                 {
-                    if (state(s))
+                    auto focused = !!count;
+                    if (state(focused))
                     {
-                        owner.ipccon.focus(s, encod);
+                        owner.ipccon.focus(focused, encod);
                     }
                 };
                 owner.SIGNAL(tier::request, e2::form::state::keybd::check, state.last);

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -7841,7 +7841,7 @@ namespace netxs::ui
                 if (auto parent = base::parent()) parent_id = parent->id;
                 if (canvas.size())
                 {
-                    splash.zoom(canvas, cell::shaders::fullid(parent_id));
+                    splash.zoom(canvas, cell::shaders::onlyid(parent_id));
                     splash.output(errmsg);
                     splash.blur(2, [](cell& c) { c.fgc(rgba::transit(c.bgc(), c.fgc(), 127)); });
                     splash.output(errmsg);

--- a/src/vtm.hpp
+++ b/src/vtm.hpp
@@ -908,9 +908,7 @@ namespace netxs::app::vtm
                     if (applet) // Render main menu/application.
                     if (auto context = canvas.change_basis(base::area()))
                     {
-                        //todo too hacky, unify
-                        if (props.glow_fx) applet->render(canvas); // Render the taskbar menu twice to achieve the glow effect.
-                                           applet->render(canvas);
+                        applet->render(canvas);
                     }
                 }
             }

--- a/src/vtm.xml
+++ b/src/vtm.xml
@@ -146,7 +146,7 @@ R"==(
             <folded=4/>
             <expanded=31/>
         </width>
-        <color fgc=whitedk bgc=0x60202020 />
+        <color fgc=whitedk bgc=0xC0202020 /> <!-- Set the bgc alpha to FF to disable acrylics in taskbar. -->
     </menu>
     <panel> <!-- Desktop info panel. -->
         <cmd = ""/> <!-- Command-line to activate. -->

--- a/src/vtm.xml
+++ b/src/vtm.xml
@@ -242,7 +242,6 @@ R"==(
         </clipboard>
         <mouse dblclick=500ms/>
         <tooltips timeout=2000ms enabled=true fgc=pureblack bgc=purewhite/>
-        <glowfx=true/>                      <!-- Show glow effect around selected item. -->
         <debug overlay=off toggle="🐞"/>  <!-- Display console debug info. -->
         <regions enabled=0/>             <!-- Highlight UI objects boundaries. -->
         <keyboard>


### PR DESCRIPTION
Changes
- Pull apart mouse hover and keybd focus
  - hover: pale backlight
  - focus: bright highlight (can be tested in Gems `vtm -r gems`)
- Remove taskbar glow option

xlink #400