### PR TITLE
Fix interference with copy/move/del

### DIFF
--- a/src/netxs/desktopio/application.hpp
+++ b/src/netxs/desktopio/application.hpp
@@ -23,7 +23,7 @@ namespace netxs::app
 
 namespace netxs::app::shared
 {
-    static const auto version = "v0.9.13";
+    static const auto version = "v0.9.14";
     static const auto desktopio = "desktopio";
     static const auto logsuffix = "_log";
     static const auto usr_config = "~/.config/vtm/settings.xml";

--- a/src/netxs/desktopio/consrv.hpp
+++ b/src/netxs/desktopio/consrv.hpp
@@ -1116,7 +1116,7 @@ struct impl : consrv
                     server.uiterm.update([&]
                     {
                         auto& term = server.uiterm;
-                        term.ondata("(Ctrl+C to Yes) ");
+                        term.ondata("(Ctrl+C = Y) ");
                     });
                 }
                 lock.lock();


### PR DESCRIPTION
xlink https://github.com/microsoft/terminal/issues/217

Fix interference with copy/move/del:
```
D:\sources\test\cmd>copy iii ooo 
Overwrite ooo? (Yes/No/All): ^C 

        0 file(s) copied.

D:\sources\test\cmd>move iii ooo 
Overwrite D:\sources\test\cmd\ooo? (Yes/No/All): ^C 

        0 file(s) moved.

D:\sources\test\cmd>del ppp 
D:\sources\test\cmd\ppp\*, Are you sure (Y/N)? ^C 

D:\sources\test\cmd>test 
About to do it.
Press any key to continue . . . 
Terminate batch job (Y/N)? (Ctrl+C = Y) y 
^C
D:\sources\test\cmd> 
```