### PR TITLE
Fix improper OSC 52 output (v2)

### DIFF
--- a/src/netxs/desktopio/application.hpp
+++ b/src/netxs/desktopio/application.hpp
@@ -23,7 +23,7 @@ namespace netxs::app
 
 namespace netxs::app::shared
 {
-    static const auto version = "v0.9.15";
+    static const auto version = "v0.9.16";
     static const auto desktopio = "desktopio";
     static const auto logsuffix = "_log";
     static const auto usr_config = "~/.config/vtm/settings.xml";

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -6231,7 +6231,7 @@ namespace netxs::ui
             auto delimpos = data.find(';');
             if (delimpos != text::npos)
             {
-                clipdata.meta = data.substr(0, ++delimpos);
+                clipdata.meta = data.substr(0, delimpos++);
                 clipdata.utf8.clear();
                 utf::unbase64(data.substr(delimpos), clipdata.utf8);
                 clipdata.form = mime::disabled;


### PR DESCRIPTION
An extra semicolon crept in when sending the clipboard to Linux...
```
      443: stdout: 
      443:      \e]52;c;;MTIz\u0007
```