### PR TITLE
Distinguish between sessions running with elevated privileges

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -83,9 +83,9 @@ Note: You can use [Github Actions](../../actions) to build statically linked bin
 - [Built-in Applications](doc/apps.md)
 - Draft: [VT Input Mode](doc/vt-input-mode.md)
 
-# Feedback
+# Feedback and Questions
 
-If you encounter unexpected behavior, inconsistent wording/grammar/spelling, or find an option that doesn't work, please consider [filing an issue](https://github.com/netxs-group/vtm/issues/new/choose).
+If you have questions, encounter unexpected behavior, inconsistent wording/grammar/spelling, or find an option that doesn't work, consider [filing an issue](https://github.com/netxs-group/vtm/issues/new/choose).
 
 Any feedback in any language is welcome.
 

--- a/src/netxs/apps/desk.hpp
+++ b/src/netxs/apps/desk.hpp
@@ -630,8 +630,8 @@ namespace netxs::app::desk
                 });
             auto users_area = apps_users->attach(slot::_2, ui::list::ctor());
             auto label_bttn = users_area->attach(ui::fork::ctor(axis::X))
-                                        ->plugin<pro::notes>(" List of connected users ");
-            auto label = label_bttn->attach(slot::_1, ui::item::ctor("users"))
+                                        ->plugin<pro::notes>(" List of active connections ");
+            auto label = label_bttn->attach(slot::_1, ui::item::ctor(os::process::elevated ? "admins" : "users"))
                 ->flexible()
                 ->accented()
                 ->colors(cA.fgc(), cA.bgc())

--- a/src/netxs/desktopio/application.hpp
+++ b/src/netxs/desktopio/application.hpp
@@ -23,7 +23,7 @@ namespace netxs::app
 
 namespace netxs::app::shared
 {
-    static const auto version = "v0.9.17";
+    static const auto version = "v0.9.18";
     static const auto desktopio = "desktopio";
     static const auto logsuffix = "_log";
     static const auto usr_config = "~/.config/vtm/settings.xml";

--- a/src/netxs/desktopio/system.hpp
+++ b/src/netxs/desktopio/system.hpp
@@ -2309,7 +2309,7 @@ namespace netxs::os
                             auto stop = datetime::now() + retry_timeout;
                             do
                             {
-                                std::this_thread::sleep_for(100ms);
+                                os::sleep(100ms);
                                 done = play();
                             }
                             while (!done && stop > datetime::now());
@@ -4126,7 +4126,7 @@ namespace netxs::os
             //extio.shut();
             //while (true)
             //{
-            //    std::this_thread::sleep_for(1s);
+            //    os::sleep(1s);
             //}
 
             intio.shut();

--- a/src/netxs/desktopio/system.hpp
+++ b/src/netxs/desktopio/system.hpp
@@ -2517,7 +2517,6 @@ namespace netxs::os
         static const auto elevated = []
         {
             #if defined(_WIN32)
-
                 auto issuer = SID_IDENTIFIER_AUTHORITY{ SECURITY_NT_AUTHORITY };
                 auto admins = PSID{};
                 auto member = BOOL{};
@@ -2525,12 +2524,8 @@ namespace netxs::os
                            && ::CheckTokenMembership(nullptr, admins, &member)
                            && member;
                 ::FreeSid(admins);
-
             #else
-
-                //todo implement
-                auto result = faux;
-
+                auto result = !::getuid(); // If getuid() == 0 - we are running under sudo/root.
             #endif
             return result;
         }();
@@ -3122,6 +3117,10 @@ namespace netxs::os
         }();
         static auto vtmode = []       // tty: VT mode bit set.
         {
+            if (os::process::elevated)
+            {
+                log(prompt::os, ansi::clr(yellowlt, "Running with elevated privileges"));
+            }
             if (os::dtvt::active)
             {
                 log(prompt::os, "DirectVT mode");

--- a/src/netxs/desktopio/system.hpp
+++ b/src/netxs/desktopio/system.hpp
@@ -2514,6 +2514,26 @@ namespace netxs::os
 
     namespace process
     {
+        static const auto elevated = []
+        {
+            #if defined(_WIN32)
+
+                auto issuer = SID_IDENTIFIER_AUTHORITY{ SECURITY_NT_AUTHORITY };
+                auto admins = PSID{};
+                auto member = BOOL{};
+                auto result = ::AllocateAndInitializeSid(&issuer, 2, SECURITY_BUILTIN_DOMAIN_RID, DOMAIN_ALIAS_RID_ADMINS, 0, 0, 0, 0, 0, 0, &admins)
+                           && ::CheckTokenMembership(nullptr, admins, &member)
+                           && member;
+                ::FreeSid(admins);
+
+            #else
+
+                //todo implement
+                auto result = faux;
+
+            #endif
+            return result;
+        }();
         auto getid()
         {
             #if defined(_WIN32)
@@ -2526,7 +2546,6 @@ namespace netxs::os
         }
         static auto id = process::getid();
         static auto arg0 = text{};
-
         struct args
         {
         private:


### PR DESCRIPTION
Changes
- Make elevated and non-elevated users different independent users
- Rename connection list on taskbar to "admins" or "users" as an indication of whether the vtm is running with elevated privileges or not

Closes #463
Closes #466