### PR TITLE
Fix anyplex crashes

### DIFF
--- a/doc/anyplex.md
+++ b/doc/anyplex.md
@@ -49,7 +49,7 @@ Field             | Description
 Attribute     | Values                                 | Default                  | Description
 --------------|----------------------------------------|--------------------------|------------
 **id**        | `<id>[/sub-id]`                        | empty string (`""`)      | Object reference ID.
-**gc**        | `string`                               | empty string (`""`)      | Grapheme cluster to write to cells (will be scaled to a 1x1 cell size).
+**gc**        | `string`                               | ASCII Space (0x20) `" "` | Grapheme cluster to write to cells (will be scaled to a 1x1 cell size).
 **ontop**     | `0`\|`1`                               | `0`                      | 0 = under text, 1 = over text.
 **width**     | `float (0..65535]`                     | Terminal viewport width  | Raster scale width (cells).
 **height**    | `float (0..65535]`                     | Terminal viewport height | Raster scale height (cells).

--- a/src/netxs/desktopio/application.hpp
+++ b/src/netxs/desktopio/application.hpp
@@ -22,7 +22,7 @@ namespace netxs::app
 
 namespace netxs::app::shared
 {
-    static const auto version = "v2026.04.09";
+    static const auto version = "v2026.04.10";
     static const auto repository = "https://github.com/directvt/vtm";
     static const auto usr_config = "~/.config/vtm/settings.xml"s;
     static const auto sys_config = "/etc/vtm/settings.xml"s;

--- a/src/netxs/desktopio/canvas.hpp
+++ b/src/netxs/desktopio/canvas.hpp
@@ -1342,6 +1342,7 @@ namespace netxs
             sprite        fragment{ *std::pmr::new_delete_resource() }; // Rasterized fragment within the document area. Using default resource allocator.
             rect          document_area; // All transformations and alignments must be performed for this area.
             imagens::docs dom;
+            byte          stamp{}; // Increment on image update.
         };
 
         template<class T>
@@ -1920,6 +1921,7 @@ namespace netxs
         //  1    | ontop=0 | 1
         //  3    | transform=0..7 ([FlipY][FlipX][SwapXY])
         //  2    | scale=[inside|outside|stretch|none]
+        //  8    | stamp 0..255
 
         static constexpr auto px_objX_16_mask = (ui64)0b00000000'00000000'00000000'00000000'00000000'00000000'11111111'11111111;
         static constexpr auto px_objY_16_mask = (ui64)0b00000000'00000000'00000000'00000000'11111111'11111111'00000000'00000000;
@@ -1927,7 +1929,7 @@ namespace netxs
         static constexpr auto px_align_4_mask = (ui64)0b00000000'00001111'00000000'00000000'00000000'00000000'00000000'00000000;
         static constexpr auto px_xform_3_mask = (ui64)0b00000000'01110000'00000000'00000000'00000000'00000000'00000000'00000000;
         static constexpr auto px_ontop_1_mask = (ui64)0b00000000'10000000'00000000'00000000'00000000'00000000'00000000'00000000;
-      //static constexpr auto px_rsrvd_8_mask = (ui64)0b11111111'00000000'00000000'00000000'00000000'00000000'00000000'00000000;
+        static constexpr auto px_stamp_8_mask = (ui64)0b11111111'00000000'00000000'00000000'00000000'00000000'00000000'00000000;
 
         auto get_image_xy() const
         {
@@ -1944,10 +1946,12 @@ namespace netxs
         auto get_image_align() const { return       netxs::get_field<px_align_4_mask>(px); }
         auto get_image_xform() const { return       netxs::get_field<px_xform_3_mask>(px); }
         auto get_image_ontop() const { return       netxs::get_field<px_ontop_1_mask>(px); }
+        auto get_image_stamp() const { return       netxs::get_field<px_stamp_8_mask>(px); }
         auto set_image_index(si32 n) { netxs::set_field<px_index16_mask>(n, px); }
         auto set_image_align(si32 n) { netxs::set_field<px_align_4_mask>(n, px); }
         auto set_image_xform(si32 n) { netxs::set_field<px_xform_3_mask>(n, px); }
         auto set_image_ontop(si32 n) { netxs::set_field<px_ontop_1_mask>(n, px); }
+        auto set_image_stamp(si32 n) { netxs::set_field<px_stamp_8_mask>(n, px); }
         auto set_image_attrs(imagens::image& image, imagens::image::attrs_t& new_attrs)
         {
             auto attrs = std::array<si32, imagens::attr_count>{};
@@ -1961,6 +1965,7 @@ namespace netxs
             set_image_align(attrs[imagens::align    ]);
             set_image_xform(attrs[imagens::transform]);
             set_image_ontop(attrs[imagens::ontop    ]);
+            set_image_stamp(image.stamp++);
             return *this;
         }
 

--- a/src/netxs/desktopio/geometry.hpp
+++ b/src/netxs/desktopio/geometry.hpp
@@ -795,6 +795,12 @@ namespace netxs
               type{ undef }
         { }
 
+        void reset()
+        {
+            bits.clear();
+            area = {};
+            type = sprite::undef;
+        }
         template<class Elem>
         auto raster()
         {
@@ -813,7 +819,7 @@ namespace netxs
             }
             else
             {
-                bits.resize(0);
+                bits.clear();
             }
         }
         // sprite: Returns the minimum opaque area within the PMA fp32 sprite.

--- a/src/netxs/desktopio/geometry.hpp
+++ b/src/netxs/desktopio/geometry.hpp
@@ -831,7 +831,7 @@ namespace netxs
             auto h = area.size.y;
             auto image_raster = raster<irgb>();
             auto data = image_raster._data;
-            assert(area.length() <= data.size()); // Invalid sprite element type.
+            assert((size_t)area.length() <= data.size()); // Invalid sprite element type.
             auto get_row = [&](si32 y){ return data.subspan(y * w, w); };
             auto y0 = 0;
             auto is_visible = [](irgb p){ return p.a != 0; };

--- a/src/netxs/desktopio/geometry.hpp
+++ b/src/netxs/desktopio/geometry.hpp
@@ -811,6 +811,10 @@ namespace netxs
             {
                 bits.resize(netxs::udivupper(new_length, sizeof(ui32)));
             }
+            else
+            {
+                bits.resize(0);
+            }
         }
         // sprite: Returns the minimum opaque area within the PMA fp32 sprite.
         template<class irgb>

--- a/src/netxs/desktopio/gui.hpp
+++ b/src/netxs/desktopio/gui.hpp
@@ -1952,11 +1952,11 @@ namespace netxs::gui
             //svg_data = test_cc;
             auto change_currentColor = [](std::span<char> data, view colorString) -> auto& // Workaround for currentColor.
             {
-                static thread_local auto matches = std::vector<ui64>{}; // List of currentColors positions within the document.
+                static thread_local auto matches = std::vector<arch>{}; // List of currentColors positions within the document.
                 matches.clear();
                 if (colorString.size() <= "currentColor"sv.size())
                 {
-                    auto pos = ui64{};
+                    auto pos = arch{};
                     auto crop = view{ data.data(), data.size() };
                     while((pos = crop.find("currentColor", pos)) != text::npos)
                     {

--- a/src/netxs/desktopio/gui.hpp
+++ b/src/netxs/desktopio/gui.hpp
@@ -2425,6 +2425,11 @@ namespace netxs::gui
             {
                 auto& image_dom = *image.dom[0];
                 auto original_doc_size_fpx = fp2d{ image_dom.width(), image_dom.height() }; // Original doc size (float).
+                if (!std::isnormal(original_doc_size_fpx.x) || !std::isnormal(original_doc_size_fpx.y))
+                {
+                    image.fragment.set_area<irgb>(rect{});
+                    return;
+                }
                 auto final_doc_size_fpx = original_doc_size_fpx; // Rendered doc size (float).
 
                 auto attrs = std::array<fp32, imagens::attr_count>{};

--- a/src/netxs/desktopio/system.hpp
+++ b/src/netxs/desktopio/system.hpp
@@ -2055,7 +2055,7 @@ namespace netxs::os
             auto file = std::ifstream{ path, std::ios::binary | std::ios::ate }; // std::ios::ate: Seek to the end to get file size.
             if (file.is_open())
             {
-                buffer.resize(file.tellg());
+                buffer.resize((size_t)file.tellg());
                 done = !!file.seekg(0, std::ios::beg).read((char*)buffer.data(), buffer.size());
             }
             return done;

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -7527,7 +7527,7 @@ namespace netxs::ui
                     return ret;
                 };
                 // Register image.
-                if (iter == image_cache.end() && (doc_str || different_image_size()))
+                if ((iter == image_cache.end() || different_image_size()) && doc_str)
                 {
                     //todo group by id
                     auto image_ptr = ptr::shared(imagens::image{ .id       = id_str,

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -7361,7 +7361,6 @@ namespace netxs::ui
             auto& console = *target;
             console.flush();
             utf::trim(attrs_str, netxs::whitespaces);
-            if (!attrs_str) return;
             auto id_str     = qiew{};
             auto sub_id_str = qiew{};
             auto gc_opt     = std::optional<qiew>{};

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -7364,7 +7364,7 @@ namespace netxs::ui
             if (!attrs_str) return;
             auto id_str     = qiew{};
             auto sub_id_str = qiew{};
-            auto gc_str     = qiew{};
+            auto gc_opt     = std::optional{ qiew{} };
             auto doc_str    = qiew{};
             auto unregister = faux;
             auto new_attrs = imagens::image::attrs_t{};
@@ -7412,7 +7412,7 @@ namespace netxs::ui
                     }
                     else if (attr_str == "gc") // gc="string". Grapheme cluster used to fill image area.
                     {
-                        gc_str = value_str;
+                        gc_opt = value_str;
                     }
                     else // Regular attributes (si32 or dict).
                     {
@@ -7510,6 +7510,7 @@ namespace netxs::ui
                 auto h = (si32)std::ceil(_h.value());
                 auto x = (si32)_x.value();
                 auto y = (si32)_y.value();
+                auto gc_str = gc_opt ? gc_opt.value() : " ";
                 auto c = cell{ target->brush }.txt(gc_str, 1, 1, 1, 1);
                 auto print_image_buffer = [&]
                 {
@@ -7527,7 +7528,19 @@ namespace netxs::ui
                     return ret;
                 };
                 // Register image.
-                if ((iter == image_cache.end() || different_image_size()) && doc_str)
+                if (iter != image_cache.end() && iter->second->document != doc_str) // Update doc for existing image.
+                {
+                    auto& image = *iter->second;
+                    image.document = doc_str;
+                    image.fragment.reset();
+                    image.document_area = {};
+                    image.dom = {};
+                    if (new_attrs[imagens::width ]) image.attrs[imagens::width ] = new_attrs[imagens::width];
+                    if (new_attrs[imagens::height]) image.attrs[imagens::height] = new_attrs[imagens::height];
+                    if (new_attrs[imagens::scale ]) image.attrs[imagens::scale ] = new_attrs[imagens::scale];
+                    //todo signal FE
+                }
+                else if ((iter == image_cache.end() || different_image_size()) && doc_str)
                 {
                     //todo group by id
                     auto image_ptr = ptr::shared(imagens::image{ .id       = id_str,

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -7517,29 +7517,49 @@ namespace netxs::ui
                            : draw_block(image_buffer, cell::shaders::image);
                 };
                 //todo revise cache logic (it is just a test)
-                auto different_image_size = [&]
+                auto different_image_attrs = [&]
                 {
                     auto& image = *iter->second;
-                    auto ret = image.attrs[imagens::width ] != new_attrs[imagens::width ]
-                            || image.attrs[imagens::height] != new_attrs[imagens::height]
-                            || image.attrs[imagens::scale ] != new_attrs[imagens::scale ];
-                    if (ret) doc_str = image.document;
+                    auto ret = new_attrs[imagens::width ] && image.attrs[imagens::width ] != new_attrs[imagens::width ]
+                            || new_attrs[imagens::height] && image.attrs[imagens::height] != new_attrs[imagens::height]
+                            || new_attrs[imagens::dx    ] && image.attrs[imagens::dx    ] != new_attrs[imagens::dx    ]
+                            || new_attrs[imagens::dy    ] && image.attrs[imagens::dy    ] != new_attrs[imagens::dy    ]
+                            || new_attrs[imagens::scale ] && image.attrs[imagens::scale ] != new_attrs[imagens::scale ]
+                            || doc_str && image.document != doc_str;
+                    return ret;
+                };
+                auto same_doc = [&]
+                {
+                    auto& image = *iter->second;
+                    auto ret = (!new_attrs[imagens::width ] || image.attrs[imagens::width ] == new_attrs[imagens::width ])
+                            && (!new_attrs[imagens::height] || image.attrs[imagens::height] == new_attrs[imagens::height])
+                            && (!new_attrs[imagens::scale ] || image.attrs[imagens::scale ] == new_attrs[imagens::scale ])
+                            && (!doc_str || image.document == doc_str);
                     return ret;
                 };
                 // Register image.
-                if (iter != image_cache.end() && iter->second->document != doc_str) // Update doc for existing image.
+                if (iter != image_cache.end() && same_doc()) // Move existing image.
                 {
                     auto& image = *iter->second;
-                    image.document = doc_str;
+                    if (new_attrs[imagens::dx]) image.attrs[imagens::dx] = new_attrs[imagens::dx];
+                    if (new_attrs[imagens::dy]) image.attrs[imagens::dy] = new_attrs[imagens::dy];
+                    //todo signal FE
+                }
+                else if (iter != image_cache.end() && different_image_attrs()) // Update existing image.
+                {
+                    auto& image = *iter->second;
                     image.fragment.reset();
                     image.document_area = {};
                     image.dom = {};
-                    if (new_attrs[imagens::width ]) image.attrs[imagens::width ] = new_attrs[imagens::width];
+                    if (doc_str && image.document != doc_str) image.document = doc_str;
+                    if (new_attrs[imagens::width ]) image.attrs[imagens::width ] = new_attrs[imagens::width ];
                     if (new_attrs[imagens::height]) image.attrs[imagens::height] = new_attrs[imagens::height];
-                    if (new_attrs[imagens::scale ]) image.attrs[imagens::scale ] = new_attrs[imagens::scale];
+                    if (new_attrs[imagens::scale ]) image.attrs[imagens::scale ] = new_attrs[imagens::scale ];
+                    if (new_attrs[imagens::dx    ]) image.attrs[imagens::dx    ] = new_attrs[imagens::dx    ];
+                    if (new_attrs[imagens::dy    ]) image.attrs[imagens::dy    ] = new_attrs[imagens::dy    ];
                     //todo signal FE
                 }
-                else if ((iter == image_cache.end() || different_image_size()) && doc_str)
+                else if (iter == image_cache.end() && doc_str)
                 {
                     //todo group by id
                     auto image_ptr = ptr::shared(imagens::image{ .id       = id_str,

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -7559,7 +7559,7 @@ namespace netxs::ui
                     if (new_attrs[imagens::dy    ]) image.attrs[imagens::dy    ] = new_attrs[imagens::dy    ];
                     //todo signal FE
                 }
-                else if (iter == image_cache.end() && doc_str)
+                else if (iter == image_cache.end() && (id_str || doc_str)) // If there is no id and svg then just clear viewport.
                 {
                     //todo group by id
                     auto image_ptr = ptr::shared(imagens::image{ .id       = id_str,
@@ -7576,21 +7576,21 @@ namespace netxs::ui
                         log("%%The limit on the number of embedded objects has been reached", prompt::term);
                     }
                 }
-                else if (doc_str) // Replace existing image.
-                {
-                    //log("%%Object with id='%%' updated", prompt::term, id_str ? id_str : "<empty string>");
-                    auto& image = *iter->second;
-                    if (image.document != doc_str)
-                    {
-                        image.document = doc_str;
-                        image.attrs[imagens::width] = new_attrs[imagens::width];
-                        image.attrs[imagens::height] = new_attrs[imagens::height];
-                        image.attrs[imagens::scale] = new_attrs[imagens::scale];
-                        //todo notify all gates
-                        //signal(release, ..., gate)
-                        //       scan all gate rasters and looking for the image_index reference in their cells and submit a forward notification if something found
-                    }
-                }
+                //else if (doc_str) // Replace existing image.
+                //{
+                //    //log("%%Object with id='%%' updated", prompt::term, id_str ? id_str : "<empty string>");
+                //    auto& image = *iter->second;
+                //    if (image.document != doc_str)
+                //    {
+                //        image.document = doc_str;
+                //        image.attrs[imagens::width] = new_attrs[imagens::width];
+                //        image.attrs[imagens::height] = new_attrs[imagens::height];
+                //        image.attrs[imagens::scale] = new_attrs[imagens::scale];
+                //        //todo notify all gates
+                //        //signal(release, ..., gate)
+                //        //       scan all gate rasters and looking for the image_index reference in their cells and submit a forward notification if something found
+                //    }
+                //}
                 if (iter != image_cache.end())
                 {
                     auto& image = *iter->second;

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -7520,12 +7520,12 @@ namespace netxs::ui
                 auto different_image_attrs = [&]
                 {
                     auto& image = *iter->second;
-                    auto ret = new_attrs[imagens::width ] && image.attrs[imagens::width ] != new_attrs[imagens::width ]
-                            || new_attrs[imagens::height] && image.attrs[imagens::height] != new_attrs[imagens::height]
-                            || new_attrs[imagens::dx    ] && image.attrs[imagens::dx    ] != new_attrs[imagens::dx    ]
-                            || new_attrs[imagens::dy    ] && image.attrs[imagens::dy    ] != new_attrs[imagens::dy    ]
-                            || new_attrs[imagens::scale ] && image.attrs[imagens::scale ] != new_attrs[imagens::scale ]
-                            || doc_str && image.document != doc_str;
+                    auto ret = (new_attrs[imagens::width ] && image.attrs[imagens::width ] != new_attrs[imagens::width ])
+                            || (new_attrs[imagens::height] && image.attrs[imagens::height] != new_attrs[imagens::height])
+                            || (new_attrs[imagens::dx    ] && image.attrs[imagens::dx    ] != new_attrs[imagens::dx    ])
+                            || (new_attrs[imagens::dy    ] && image.attrs[imagens::dy    ] != new_attrs[imagens::dy    ])
+                            || (new_attrs[imagens::scale ] && image.attrs[imagens::scale ] != new_attrs[imagens::scale ])
+                            || (doc_str && image.document != doc_str);
                     return ret;
                 };
                 auto same_doc = [&]

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -7364,7 +7364,7 @@ namespace netxs::ui
             if (!attrs_str) return;
             auto id_str     = qiew{};
             auto sub_id_str = qiew{};
-            auto gc_opt     = std::optional{ qiew{} };
+            auto gc_opt     = std::optional<qiew>{};
             auto doc_str    = qiew{};
             auto unregister = faux;
             auto new_attrs = imagens::image::attrs_t{};


### PR DESCRIPTION
#### Changes

- AnyPlex:
  - Fix crash on empty svg canvas.
  - Make `gc=' '` (whitespace) by default.
  - Fix updating SVG document for the same id.
  - Allow viewport clearing by printing `\e[H\e]app\a`.
    ```pwsh
    "`e[H`e]app`a"
    ```

##### Animation Example

- `anyplex_test.ps1`:
  ```pwsh
  "`e[H`e]app; gc='' id=tiger width=40.1 height=20 $(cat Ghostscript_Tiger.svg) flip=h`a"
  while ($true) {
      for ($i = 0; $i -lt 40; $i++)
      {
          "`e[H`e]app;gc='' id=tiger flip=h dx={0:N3}`a" -f ($i / 20)
          Start-Sleep -Milliseconds 25
      }
      for ($i = 39; $i -gt 0; $i--)
      {
          "`e[H`e]app;gc='' id=tiger dx={0:N3}`a" -f ($i / 20)
          Start-Sleep -Milliseconds 25
      }
  }
  ```
