### PR TITLE
Implement layering

### DIFF
--- a/doc/anyplex.md
+++ b/doc/anyplex.md
@@ -78,8 +78,8 @@ Attribute  | Scope  | Value/Range                      | Default                
 **f**      | Shared | `n\|v\|h\|vh\|hv`                | `n`                      | **F**lip: `n` = none, `v` = vertical, `h` = horizontal.
 **a**      | Shared | `[l\|c\|r][t\|m\|b]`             | `cm`                     | **A**lign: 2D alignment within the Clipping Box and the `W x H` area. (`l` = left, `c` = center, `r` = right, `t` = top, `m` = middle, `b` = bottom).
 **o**      | Shared | `0\|1`                           | `0`                      | **O**ntop: 0 = under text, 1 = over text.
-**gc**     | Unique | `string`                         | ASCII Space (0x20) `" "` | Grapheme cluster to write to cells (will be scaled to a 1x1 cell size).
-**W, H**   | Unique | `0..65535`                       | `0`                      | **Grid Container**: Physical footprint in cells. If `0`, nothing is rendered (registration only).
+**gc**     | Unique | `string`                         | ASCII Space (0x20) `" "` | **G**rapheme **c**luster to write to cells (will be scaled to a 1x1 cell size).
+**W, H**   | Unique | `0..65535`                       | `0`                      | Grid Container: Physical footprint in cells. If `0`, nothing is rendered (registration only).
 **r, c**   | Unique | `0..65535`                       | `0`                      | **R**ow, **c**olumn 1-based slicing index for target cell slice. (0 = full height/width, 1..n = specific cell/slice).
 
 > Notes:

--- a/doc/anyplex.md
+++ b/doc/anyplex.md
@@ -13,24 +13,28 @@ Scope                           | Role
 
 #### Rendering & Interaction
 
-- **Normalized Source Viewport**: The source document is first projected onto a virtual canvas of size `1.0` by `1.0`. A rectangular fragment (crop) is then extracted from this canvas using normalized coordinates `u`, `v` (top-left) and `uw`, `vh` (size), where `1.0` equals the full canvas dimension. Negative values for `uw` or `vh` cause the extracted fragment to be flipped along the respective axis.
-- **Target Rectangular Area**: The grid footprint is explicitly defined by the unique attributes **W** and **H**. The range of affected cell indices starts at the current cursor position and spans `[0 .. W-1]` horizontally and `[0 .. H-1]` vertically. If `W` or `H` is `0`, no cells are modified, and the object is only registered in the cache.
+- **Normalized Source Viewport**: The source document is first projected onto a virtual canvas of size `1.0` by `1.0`. A rectangular fragment (crop) is then extracted from this canvas using normalized coordinates `u`, `v` (top-left) and `uw`, `vh` (size). Negative values for `uw` or `vh` cause the extracted fragment to be flipped along the respective axis.
+- **Target Rectangular Area**: The grid footprint is explicitly defined by the unique attributes **W** and **H**. The range of affected cells starts at the current cursor position and spans `[0 .. W-1]` horizontally and `[0 .. H-1]` vertically. If `W` or `H` is `0`, no cells are modified (registration only).
 - **Pixel-wise Precision**:
   - **Content Positioning**: The image fragment is scaled according to `fit` and aligned within the **Clipping Box** (`w x h`) using the `a` attribute.
   - **Box Positioning**: This Clipping Box is then aligned within the **Grid Container** (`W x H`) using the same `a` attribute.
   - **Offsets**: Shared `x` and `y` values are applied as final pixel offsets from the resulting position.
   - **Final Cut**: The Grid Container acts as a strict physical mask; any pixels falling outside the `W x H` cell area are not rendered.
-- **Persistence**: Metadata (Object Reference + Unique attributes) is stored per-cell to survive scrollback and ensure logical linking for rectangular reflow, using only an implementation-defined minimum of data to minimize memory overhead.
+- **Persistence**: Metadata is stored per-cell to survive scrollback and ensure logical linking.
 - **Cursor Position**: Anchored at the top-left; moves to the cell immediately following the bottom-right corner of the **Grid Container** (`W x H`) after output.
 - **Destructivity**:
-  - If the `gc` attribute is not empty, the provided grapheme cluster is written to **every cell** in the target area, replacing existing text and SGR attributes.
+  - If the `gc` attribute is not empty, the provided grapheme cluster is written to every cell in the target area, replacing existing text and SGR attributes.
   - If `gc` is empty, the output is non-destructive; existing text and SGR attributes remain visually intact.
   - Subsequent text written over the area does not destroy the underlying object. Metadata remains in the cell until explicitly replaced.
-- **Selection & Highlighting**: When a cell is selected (e.g., mouse selection or **SGR 7**), the frontend **applies a 0.5 opacity mask** to the object's pixels within that specific cell to ensure the selection remains visible.
+- **Selection & Highlighting**: When a cell is selected by mouse or highlighted using **SGR 7**, the frontend **applies a 0.5 opacity mask** to the object's pixels within that specific cell to ensure the selection remains visible.
 - **Searchability**: Any text contained within the document (e.g., `<text>` in SVG) is rendered as part of the graphic and is not indexed for terminal text search.
-- **Layering & Transparency**: Supports per-pixel alpha. The `o`(ontop) attribute determines Z-order:
-  - `0`: `[Cell BG] -> [Object] -> [Text]`
-  - `1`: `[Cell BG] -> [Text] -> [Object]`
+- **Layering & Composition**:
+  - Supports per-pixel alpha blending in linear color space.
+  - **Recursive Rendering**: If a layer (`l`) references an object that itself has layers, the entire tree is rendered. Circular references are silently ignored.
+  - **Z-Order**: Layers are rendered in the order they are defined (first is bottom). The "main" document of the current `id` is rendered as the final layer on top.
+  - **Ontop (`o`)**: Determines if the *entire composite* is drawn under (`0`) or over (`1`) the cell text:
+    - `0`: `[Cell BG] -> [Object] -> [Text]`
+    - `1`: `[Cell BG] -> [Text] -> [Object]`
   - The cell's background color always remains at the bottom. The terminal cursor is always drawn on top. Alpha blending should be performed in **linear color space**.
 - **Foreground Color & Security**: The underlying cell **SGR foreground color** maps to `currentColor` (for SVG). All external references (e.g., `http://...`) are ignored for security purposes.
 
@@ -53,24 +57,18 @@ Field           | Description
 
 #### Attribute Scoping
 
-Attributes are divided into **Shared** (object-wide) and **Unique** (per-instance/cell).
+Attributes are divided into **Shared** (object-wide), **Layer** (layer specific) and **Unique** (per-instance/cell).
 
-- **Shared Attributes**: `l`, `u`, `v`, `uw`, `vh`, `x`, `y`, `w`, `h`, `fit`, `rt`, `a`, `f`, `o`.
-  - These define the global geometry, orientation, and content mapping.
-  - Updating a shared attribute for an existing `id` immediately affects **all cells** currently linked to that object.
-- **Layer Attributes**: `u`, `v`, `uw`, `vh`, `x`, `y`, `w`, `h`, `fit`, `rt`, `a`, `f`, `o`.
-  - These define the global geometry, orientation, and content mapping for the specified layer.
-- **Unique Attributes**: `W`, `H`, `r`, `c`, `gc`.
-  - These define the physical footprint on the terminal grid and the specific slice being rendered.
-  - **W** and **H** define the **Grid Container** (the parcel of cells).
-  - If a unique attribute is omitted in a sequence, it reverts to its **Default Value**.
+- **Shared Attributes**: `l`, `u`, `v`, `uw`, `vh`, `x`, `y`, `w`, `h`, `fit`, `rt`, `a`, `f`, `o`. Global to all instances of the `id`.
+- **Layer Attributes**: All Shared attributes can be overridden per layer inside `l=id(key=val)`.
+- **Unique Attributes**: `W`, `H`, `r`, `c`, `gc`. Specific to the instance and the grid slice.
 
 #### Attributes
 
 Attribute  | Scope  | Value/Range                      | Default                  | Description
 -----------|--------|----------------------------------|--------------------------|------------
 **id**     | -      | `<id>[/sub-id]`                  | empty string (`""`)      | Object reference ID.
-**l**      | Shared | `<id>[/sub-id][(<layer attributes>)]`  | empty string (`""`)      | Adds a layer by referencing registered object. Can be specified multiple times; layers are rendered in the order they appear (first is bottom).
+**l**      | Shared | `<id>[/sub-id][(<layer attrs>)]` | empty string (`""`)      | Adds a layer. Can be specified multiple times.
 **u, v**   | Shared | `float`                          | `0.0`                    | Top-left of the source crop (0.0-1.0).
 **uw, vh** | Shared | `float`                          | `1.0`                    | Size of the source crop (0.0-1.0). Negative flips.
 **x, y**   | Shared | `float`                          | `0.0`                    | Offset of the Clipping Box **inside** the `W x H` area (cells).
@@ -94,13 +92,14 @@ Attribute  | Scope  | Value/Range                      | Default                
 
 #### Lifecycle & Cache Management
 
-Input State            | Action
------------------------|-------
-**id** + **doc**       | Store or update the object document in the cache and output it.
-**id** + **empty-doc** | Unregister the `id` and free the cache index.
-**id** + **no-doc**    | Output the existing cached object.
-**id/sub-id**          | If a `sub-id` is specified, the FE renders only that specific element at its original coordinates (as it would appear in the full document), inheriting all parent styles (CSS, `<g>` groups).
-**Errors**             | If a document is invalid, the `id` is unknown, the `sub-id` is missing, or the cache is full, the FE **clears the object metadata** in the target area (rendering nothing) and logs the error.
+Input State                | Action
+---------------------------|-------
+**id** + **doc**           | Register/update.
+**id** + **doc** + **W,H** | Register/update and output to the specified area.
+**id** + **W,H**           | Output to the specified area.
+**id** + **empty-doc**     | Unregister.
+**id/sub-id**              | If a `sub-id` is specified, the FE renders only that specific element at its original coordinates (as it would appear in the full document), inheriting all parent styles (CSS, `<g>` groups).
+**Errors**                 | If a document is invalid, the `id` is unknown, the `sub-id` is missing, or the cache is full, the FE **clears the object metadata** in the target area (rendering nothing) and logs the error.
 
 > Note:
 > When the BE deletes an `id`, or upon reset/session close, it frees the index and signals the FEs.
@@ -109,10 +108,11 @@ Input State            | Action
 
 #### Parsing Rules (Backend)
 
-1. Scan the OSC string for `key=value` pairs.
-2. Identify document boundaries via the first `<` and the last `>`.
-3. Scan the OSC string for remaining `key=value` pairs.
-4. Accumulate all orientation attributes (`tr`(transform), `f`(flip), `rt`(rotate)) in the order of appearance to calculate the final 3-bit transformation state.
+- Scan the OSC string for `key=value` pairs.
+- Parse layer attributes inside `l=id(...)` with the same logic as primary attributes.
+- Identify document boundaries via the first `<` and the last `>`.
+- Accumulate orientation attributes (`tr`, `f`, `rt`) in the order of appearance to calculate the final state.
+- Scan the OSC string for remaining `key=value` pairs.
 
 #### Extensibility
 

--- a/doc/anyplex.md
+++ b/doc/anyplex.md
@@ -55,7 +55,7 @@ Field           | Description
 
 Attributes are divided into **Shared** (object-wide) and **Unique** (per-instance/cell).
 
-- **Shared Attributes**: `u`, `v`, `uw`, `vh`, `x`, `y`, `w`, `h`, `fit`, `rt`, `a`, `f`, `o`.
+- **Shared Attributes**: `l`, `u`, `v`, `uw`, `vh`, `x`, `y`, `w`, `h`, `fit`, `rt`, `a`, `f`, `o`.
   - These define the global geometry, orientation, and content mapping.
   - Updating a shared attribute for an existing `id` immediately affects **all cells** currently linked to that object.
 - **Unique Attributes**: `W`, `H`, `r`, `c`, `gc`.
@@ -68,6 +68,7 @@ Attributes are divided into **Shared** (object-wide) and **Unique** (per-instanc
 Attribute  | Scope  | Value/Range                      | Default                  | Description
 -----------|--------|----------------------------------|--------------------------|------------
 **id**     | -      | `<id>[/sub-id]`                  | empty string (`""`)      | Object reference ID.
+**l**      | Shared | `<id>[/sub-id][(<shared attributes>)]`  | empty string (`""`)      | Adds a layer by referencing registered object. Can be specified multiple times; layers are rendered in the order they appear (first is bottom).
 **u, v**   | Shared | `float`                          | `0.0`                    | Top-left of the source crop (0.0-1.0).
 **uw, vh** | Shared | `float`                          | `1.0`                    | Size of the source crop (0.0-1.0). Negative flips.
 **x, y**   | Shared | `float`                          | `0.0`                    | Offset of the Clipping Box **inside** the `W x H` area (cells).

--- a/doc/anyplex.md
+++ b/doc/anyplex.md
@@ -28,7 +28,7 @@ Scope                           | Role
   - Subsequent text written over the area does not destroy the underlying object. Metadata remains in the cell until explicitly replaced.
 - **Selection & Highlighting**: When a cell is selected (e.g., mouse selection or **SGR 7**), the frontend **applies a 0.5 opacity mask** to the object's pixels within that specific cell to ensure the selection remains visible.
 - **Searchability**: Any text contained within the document (e.g., `<text>` in SVG) is rendered as part of the graphic and is not indexed for terminal text search.
-- **Layering & Transparency**: Supports per-pixel alpha. The `o`(ontop) attribute determines Z-order: 
+- **Layering & Transparency**: Supports per-pixel alpha. The `o`(ontop) attribute determines Z-order:
   - `0`: `[Cell BG] -> [Object] -> [Text]`
   - `1`: `[Cell BG] -> [Text] -> [Object]`
   - The cell's background color always remains at the bottom. The terminal cursor is always drawn on top. Alpha blending should be performed in **linear color space**.

--- a/doc/anyplex.md
+++ b/doc/anyplex.md
@@ -58,6 +58,8 @@ Attributes are divided into **Shared** (object-wide) and **Unique** (per-instanc
 - **Shared Attributes**: `l`, `u`, `v`, `uw`, `vh`, `x`, `y`, `w`, `h`, `fit`, `rt`, `a`, `f`, `o`.
   - These define the global geometry, orientation, and content mapping.
   - Updating a shared attribute for an existing `id` immediately affects **all cells** currently linked to that object.
+- **Layer Attributes**: `u`, `v`, `uw`, `vh`, `x`, `y`, `w`, `h`, `fit`, `rt`, `a`, `f`, `o`.
+  - These define the global geometry, orientation, and content mapping for the specified layer.
 - **Unique Attributes**: `W`, `H`, `r`, `c`, `gc`.
   - These define the physical footprint on the terminal grid and the specific slice being rendered.
   - **W** and **H** define the **Grid Container** (the parcel of cells).
@@ -68,7 +70,7 @@ Attributes are divided into **Shared** (object-wide) and **Unique** (per-instanc
 Attribute  | Scope  | Value/Range                      | Default                  | Description
 -----------|--------|----------------------------------|--------------------------|------------
 **id**     | -      | `<id>[/sub-id]`                  | empty string (`""`)      | Object reference ID.
-**l**      | Shared | `<id>[/sub-id][(<shared attributes>)]`  | empty string (`""`)      | Adds a layer by referencing registered object. Can be specified multiple times; layers are rendered in the order they appear (first is bottom).
+**l**      | Shared | `<id>[/sub-id][(<layer attributes>)]`  | empty string (`""`)      | Adds a layer by referencing registered object. Can be specified multiple times; layers are rendered in the order they appear (first is bottom).
 **u, v**   | Shared | `float`                          | `0.0`                    | Top-left of the source crop (0.0-1.0).
 **uw, vh** | Shared | `float`                          | `1.0`                    | Size of the source crop (0.0-1.0). Negative flips.
 **x, y**   | Shared | `float`                          | `0.0`                    | Offset of the Clipping Box **inside** the `W x H` area (cells).

--- a/src/netxs/desktopio/application.hpp
+++ b/src/netxs/desktopio/application.hpp
@@ -22,7 +22,7 @@ namespace netxs::app
 
 namespace netxs::app::shared
 {
-    static const auto version = "v2026.04.16";
+    static const auto version = "v2026.04.18";
     static const auto repository = "https://github.com/directvt/vtm";
     static const auto usr_config = "~/.config/vtm/settings.xml"s;
     static const auto sys_config = "/etc/vtm/settings.xml"s;

--- a/src/netxs/desktopio/baseui.hpp
+++ b/src/netxs/desktopio/baseui.hpp
@@ -231,7 +231,7 @@ namespace netxs::events::userland
                 {
                     EVENT_XS( sync  , si32 ), // general: Signal to sync unknown image indexes. Arg: not used.
                     EVENT_XS( update, ui16 ), // general: Image metadata updated. Arg: image index.
-                    EVENT_XS( remove, ui16 ), // general: Image removed. Arg: image index.
+                    EVENT_XS( remove, std::vector<ui16> ), // general: Images removed. Arg: image index.
                 };
             };
             SUBSET_XS( command )

--- a/src/netxs/desktopio/canvas.hpp
+++ b/src/netxs/desktopio/canvas.hpp
@@ -1371,6 +1371,7 @@ namespace netxs
 
             static constexpr auto document_bit = 1;
             static constexpr auto sub_id_bit   = 2;
+            static constexpr auto layers_bit   = 3;
 
             struct bitmap_t
             {
@@ -1385,6 +1386,7 @@ namespace netxs
             };
             struct layer_t
             {
+                ui16           index{};
                 text           id;
                 text           sub_id; // Layer document's sub-element id.
                 wptr<image>    image_wptr;
@@ -1406,8 +1408,13 @@ namespace netxs
             std::vector<layer_t> layers;
             bool          updated_layers{};
 
+            auto empty()
+            {
+                return document.empty() && layers.empty();
+            }
             void set_changes(si32 new_changed_bits, many& changes, twod cellsz = {})
             {
+                if constexpr (debugmode) log("Received image update:");
                 changed_gb_attrs = new_changed_bits;
                 auto mask = (ui32)changed_gb_attrs;
                 auto j = 0u;
@@ -1417,6 +1424,7 @@ namespace netxs
                     if (i < imagens::gb::attr_count)
                     {
                         gb_attrs[i] = std::any_cast<fp32>(changes[j]);
+                        if constexpr (debugmode) log("  %%='%%'", imagens::gb::names[i], gb_attrs[i]);
                     }
                     j++;
                     mask &= mask - 1;
@@ -1429,17 +1437,29 @@ namespace netxs
                 {
                     bitmap.reset();
                 }
+                auto need_bitmap_reset = faux;
                 if (j < changes.size() && (document_changed = std::any_cast<si32>(changes[j++])))
                 {
                     if (j < changes.size() && netxs::get_bit<image::sub_id_bit>(document_changed))
                     {
                         sub_id = std::any_cast<text>(changes[j++]);
+                        need_bitmap_reset = true;
+                        if constexpr (debugmode) log("  sub_id='%%'", sub_id);
                     }
                     if (j < changes.size() && netxs::get_bit<image::document_bit>(document_changed))
                     {
                         document = std::any_cast<text>(changes[j++]);
                         dom = {}; // Request to regenerate DOM.
+                        need_bitmap_reset = true;
+                        if constexpr (debugmode) log("  document='%value%...'", document.substr(0, std::min(20, (si32)document.size())));
                     }
+                    if (j < changes.size() && netxs::get_bit<image::layers_bit>(document_changed)) // Receive foreign layer indexes.
+                    {
+                        load_layers(j, changes);
+                    }
+                }
+                if (need_bitmap_reset)
+                {
                     bitmap.reset();
                 }
                 else
@@ -1473,21 +1493,72 @@ namespace netxs
                     {
                         changes.push_back(document);
                     }
+                    if (netxs::get_bit<image::layers_bit>(document_changed))
+                    {
+                        pack_layers(changes);
+                    }
                 }
                 return changes;
             }
-            void receive_image_attributes(many& global_attributes)
+            void pack_layers(many& changes)
             {
-                if (global_attributes.size() > 3)
+                changes.reserve(layers.size() * imagens::gb::attr_count); // To avoid reallocations.
+                for (auto& l : layers)
+                {
+                    changes.push_back(l.index);
+                    changes.push_back(l.sub_id);
+                    auto mask = 0;
+                    auto& changed_layer_attr_bits = changes.emplace_back(mask); // Reserve a placeholder.
+                    for (auto i = 0u; i < l.opt_attrs.size(); i++)
+                    {
+                        if (auto& attr = l.opt_attrs[i])
+                        {
+                            mask |= 1 << i;
+                            changes.push_back(attr.value());
+                        }
+                    }
+                    changed_layer_attr_bits = mask; // Write to placeholder.
+                }
+            }
+            void load_layers(ui32 i, many& changes)
+            {
+                if (i < changes.size())
+                {
+                    if constexpr (debugmode) log("  layers update:");
+                    layers.clear();
+                    while (i < changes.size() - 1)
+                    {
+                        auto& l = layers.emplace_back(layer_t{ .index = std::any_cast<ui16>(changes[i++]) }); // Index.
+                        l.sub_id = std::any_cast<text>(changes[i++]); // Sub_id.
+                        if constexpr (debugmode) log("    index=%% sub_id=%%", l.index, l.sub_id);
+                        auto changed_layer_attr_bits = std::any_cast<si32>(changes[i++]); // Changed bits.
+                        auto mask = (ui32)changed_layer_attr_bits;
+                        while (mask != 0 && i < changes.size())
+                        {
+                            auto j = std::countr_zero(mask);
+                            if (j < imagens::gb::attr_count)
+                            {
+                                l.opt_attrs[j] = std::any_cast<fp32>(changes[i++]); // Attrs.
+                                if constexpr (debugmode) log("    %%=%%", imagens::gb::names[j], l.opt_attrs[j].value());
+                            }
+                            mask &= mask - 1;
+                        }
+                    }
+                }
+            }
+            void receive_image_attributes(many& global_attributes) // Receive full metadata set for unknown image.
+            {
+                if (global_attributes.size() >= imagens::gb::attr_count + 2)
                 {
                     auto i = 0u;
-                    for (; i < global_attributes.size() - 2; i++)
+                    for (; i < imagens::gb::attr_count; i++)
                     {
                         gb_attrs[i] = std::any_cast<fp32>(global_attributes[i]);
                         if constexpr (debugmode) log("  %attr%=%value%", imagens::gb::names[i], gb_attrs[i]);
                     }
                     sub_id   = std::any_cast<text>(global_attributes[i++]);
                     document = std::any_cast<text>(global_attributes[i++]);
+                    load_layers(i, global_attributes);
                     reset_changes();
                     if constexpr (debugmode) log("  sub_id='%%' document='%value%...'", sub_id, document.substr(0, std::min(20, (si32)document.size())));
                 }
@@ -1534,6 +1605,7 @@ namespace netxs
                 }
                 global_attributes.push_back(sub_id);
                 global_attributes.push_back(document);
+                pack_layers(global_attributes);
                 return global_attributes;
             }
         };
@@ -1627,7 +1699,21 @@ namespace netxs
             static auto cache = imagens::cache<imagens::image>{};
             return cache.storage();
         }
-
+        static auto register_image(ui16 last_ext_index, std::array<ui16, 65536>& ext_to_int_nat)
+        {
+            auto images = cell::images(); // Lock. //todo ?Should we place it outside of this hot loop?
+            auto image_ptr = ptr::shared(imagens::image{});
+            auto last_int_index = images.set(image_ptr);
+            if (last_int_index)
+            {
+                image_ptr->index = last_int_index;
+                images.unk.push_back(last_ext_index);
+                if constexpr (debugmode) log("request image index: last_int_index=%% last_ext_index=%%", last_int_index, last_ext_index);
+                ext_to_int_nat[last_ext_index] = last_int_index; // Update forward map.
+                //int_to_ext_nat[last_int_index] = last_ext_index; // Update reverse map.
+            }
+            return last_int_index;
+        }
         struct glyf
         {
             static auto jumbos()

--- a/src/netxs/desktopio/canvas.hpp
+++ b/src/netxs/desktopio/canvas.hpp
@@ -1391,7 +1391,7 @@ namespace netxs
                 text           sub_id; // Layer document's sub-element id.
                 wptr<image>    image_wptr;
                 opt_gb_attrs_t opt_attrs;
-                bitmap_t       image_bitmap;
+                bitmap_t       bitmap;
                 bool           touched{};
             };
 

--- a/src/netxs/desktopio/canvas.hpp
+++ b/src/netxs/desktopio/canvas.hpp
@@ -1380,12 +1380,13 @@ namespace netxs
                     fragment.reset();
                 }
             };
-            struct base_image_t
+            struct layer_t
             {
-                text           sub_id; // Parent document's sub-element id.
-                wptr<image>    parent_wptr;
+                text           id;
+                text           sub_id; // Layer document's sub-element id.
+                wptr<image>    image_wptr;
                 opt_gb_attrs_t opt_attrs;
-                bitmap_t       parent_bitmap;
+                bitmap_t       image_bitmap;
                 bool           touched{};
             };
 
@@ -1399,7 +1400,8 @@ namespace netxs
             imagens::docs dom;
             byte          stamp{}; // Increment on image update to sync with FE.
             bitmap_t      bitmap;
-            std::vector<base_image_t> parents;
+            std::vector<layer_t> layers;
+            bool          updated_layers{};
 
             void set_changes(si32 new_changed_bits, many& changes, twod cellsz = {})
             {

--- a/src/netxs/desktopio/canvas.hpp
+++ b/src/netxs/desktopio/canvas.hpp
@@ -1369,6 +1369,9 @@ namespace netxs
             using gb_attrs_t = std::array<fp32, imagens::gb::attr_count>;
             using lc_attrs_t = std::array<fp32, imagens::lc::attr_count>;
 
+            static constexpr auto document_bit = 1;
+            static constexpr auto sub_id_bit   = 2;
+
             struct bitmap_t
             {
                 sprite fragment{ *std::pmr::new_delete_resource() }; // Rasterized and trimmed fragment within the scaled_fragment_area. Using default resource allocator.
@@ -1393,7 +1396,7 @@ namespace netxs
             text          id;
             text          sub_id; // Document's sub-element id.
             text          document;
-            bool          document_changed{};
+            si32          document_changed{};
             gb_attrs_t    gb_attrs{};
             si32          changed_gb_attrs{}; // Contains bits indicating which imagens::gb::attr have changed.
             ui16          index{};
@@ -1426,11 +1429,17 @@ namespace netxs
                 {
                     bitmap.reset();
                 }
-                if (changes.size() > j)
+                if (j < changes.size() && (document_changed = std::any_cast<si32>(changes[j++])))
                 {
-                    document_changed = true;
-                    document = std::any_cast<text>(changes[j]);
-                    dom = {}; // Request to regenerate DOM.
+                    if (j < changes.size() && netxs::get_bit<image::sub_id_bit>(document_changed))
+                    {
+                        sub_id = std::any_cast<text>(changes[j++]);
+                    }
+                    if (j < changes.size() && netxs::get_bit<image::document_bit>(document_changed))
+                    {
+                        document = std::any_cast<text>(changes[j++]);
+                        dom = {}; // Request to regenerate DOM.
+                    }
                     bitmap.reset();
                 }
                 else
@@ -1455,22 +1464,52 @@ namespace netxs
                 }
                 if (document_changed)
                 {
-                    changes.push_back(document);
+                    changes.push_back(document_changed);
+                    if (netxs::get_bit<image::sub_id_bit>(document_changed))
+                    {
+                        changes.push_back(sub_id);
+                    }
+                    if (netxs::get_bit<image::document_bit>(document_changed))
+                    {
+                        changes.push_back(document);
+                    }
                 }
                 return changes;
+            }
+            void receive_image_attributes(many& global_attributes)
+            {
+                if (global_attributes.size() > 3)
+                {
+                    auto i = 0u;
+                    for (; i < global_attributes.size() - 2; i++)
+                    {
+                        gb_attrs[i] = std::any_cast<fp32>(global_attributes[i]);
+                        if constexpr (debugmode) log("  %attr%=%value%", imagens::gb::names[i], gb_attrs[i]);
+                    }
+                    sub_id   = std::any_cast<text>(global_attributes[i++]);
+                    document = std::any_cast<text>(global_attributes[i++]);
+                    reset_changes();
+                    if constexpr (debugmode) log("  sub_id='%%' document='%value%...'", sub_id, document.substr(0, std::min(20, (si32)document.size())));
+                }
             }
             void reset_changes()
             {
                 changed_gb_attrs = {};
                 document_changed = {};
             }
-            void check_and_set_document(qiew doc_str)
+            void check_and_set_document(qiew doc_str, qiew sub_id_str)
             {
                 if (doc_str && document != doc_str)
                 {
                     dom = {}; // Request to regenerate DOM.
                     document = doc_str;
-                    document_changed = true;
+                    netxs::set_bit<image::document_bit>(document_changed, true);
+                }
+                if (sub_id != sub_id_str)
+                {
+                    sub_id = sub_id_str;
+                    bitmap.reset();
+                    netxs::set_bit<image::sub_id_bit>(document_changed, true);
                 }
             }
             void check_and_set_attr(gb_attrs_t& new_gb_attrs)
@@ -1488,11 +1527,12 @@ namespace netxs
             auto get_global_attrs()
             {
                 auto global_attributes = many{};
-                global_attributes.reserve(gb_attrs.size() + 1);
+                global_attributes.reserve(gb_attrs.size() + 2);
                 for (auto& ga : gb_attrs)
                 {
                     global_attributes.push_back(ga);
                 }
+                global_attributes.push_back(sub_id);
                 global_attributes.push_back(document);
                 return global_attributes;
             }

--- a/src/netxs/desktopio/canvas.hpp
+++ b/src/netxs/desktopio/canvas.hpp
@@ -1369,7 +1369,26 @@ namespace netxs
             using gb_attrs_t = std::array<fp32, imagens::gb::attr_count>;
             using lc_attrs_t = std::array<fp32, imagens::lc::attr_count>;
 
-            //todo tie id, document, dom to shared sptr<>
+            struct bitmap_t
+            {
+                sprite fragment{ *std::pmr::new_delete_resource() }; // Rasterized and trimmed fragment within the scaled_fragment_area. Using default resource allocator.
+                rect   scaled_fragment_area; // Document full fragment area (sprite::fragment's transparent fields are trimmed).
+                twod   xy; // scaled_fragment_area offset inside the target cell region: round(xy * cell_sz)
+
+                void reset()
+                {
+                    fragment.reset();
+                }
+            };
+            struct base_image_t
+            {
+                text           sub_id; // Parent document's sub-element id.
+                wptr<image>    parent_wptr;
+                opt_gb_attrs_t opt_attrs;
+                bitmap_t       parent_bitmap;
+                bool           touched{};
+            };
+
             text          id;
             text          sub_id; // Document's sub-element id.
             text          document;
@@ -1377,12 +1396,10 @@ namespace netxs
             gb_attrs_t    gb_attrs{};
             si32          changed_gb_attrs{}; // Contains bits indicating which imagens::gb::attr have changed.
             ui16          index{};
-            sprite        fragment{ *std::pmr::new_delete_resource() }; // Rasterized and trimmed fragment within the scaled_fragment_area. Using default resource allocator.
-            rect          scaled_fragment_area; // Document full fragment area (sprite::fragment's transparent fields are trimmed).
-            fp2d          final_frag_sz; // Visible fragment size (float).
-            twod          xy; // round(xy * cell_sz)
             imagens::docs dom;
             byte          stamp{}; // Increment on image update to sync with FE.
+            bitmap_t      bitmap;
+            std::vector<base_image_t> parents;
 
             void set_changes(si32 new_changed_bits, many& changes, twod cellsz = {})
             {
@@ -1405,20 +1422,20 @@ namespace netxs
                                       | (1 << imagens::gb::h)
                                       | (1 << imagens::gb::fit)))
                 {
-                    reset_raster();
+                    bitmap.reset();
                 }
                 if (changes.size() > j)
                 {
                     document_changed = true;
                     document = std::any_cast<text>(changes[j]);
                     dom = {}; // Request to regenerate DOM.
-                    reset_raster();
+                    bitmap.reset();
                 }
                 else
                 {
                     auto x = gb_attrs[imagens::gb::x];
                     auto y = gb_attrs[imagens::gb::y];
-                    xy = twod{ std::round(fp2d{ x, y } * cellsz) };
+                    bitmap.xy = twod{ std::round(fp2d{ x, y } * cellsz) };
                 }
             }
             auto get_changes()
@@ -1476,10 +1493,6 @@ namespace netxs
                 }
                 global_attributes.push_back(document);
                 return global_attributes;
-            }
-            void reset_raster()
-            {
-                fragment.reset();
             }
         };
 

--- a/src/netxs/desktopio/canvas.hpp
+++ b/src/netxs/desktopio/canvas.hpp
@@ -4144,12 +4144,14 @@ namespace netxs
             auto hit = faux;
             for (auto& c : canvas)
             {
-                auto image_index = c.get_image_index();
-                //if (image_index == removed_image_index) //todo optimize
-                if (std::find(removed_image_indexes.begin(), removed_image_indexes.end(), image_index) != removed_image_indexes.end())
+                if (auto image_index = c.get_image_index())
                 {
-                    c.reset_px(); // Drop all image metadata.
-                    hit = true;
+                    //if (image_index == removed_image_index) //todo optimize
+                    if (std::find(removed_image_indexes.begin(), removed_image_indexes.end(), image_index) != removed_image_indexes.end())
+                    {
+                        c.reset_px(); // Drop all image metadata.
+                        hit = true;
+                    }
                 }
             }
             return hit;

--- a/src/netxs/desktopio/canvas.hpp
+++ b/src/netxs/desktopio/canvas.hpp
@@ -1196,7 +1196,7 @@ namespace netxs
         // global: stored in image
         #define global_attr_list \
             X(u  ) /* u-coor (0.0-1.0)                              */ \
-            X(v  ) /* u-coor (0.0-1.0)                              */ \
+            X(v  ) /* v-coor (0.0-1.0)                              */ \
             X(uw ) /* u-size (reset raster if changed)              */ \
             X(vh ) /* v-size (reset raster if changed)              */ \
             X(x  ) /* x                                             */ \

--- a/src/netxs/desktopio/canvas.hpp
+++ b/src/netxs/desktopio/canvas.hpp
@@ -1391,8 +1391,38 @@ namespace netxs
                 text           sub_id; // Layer document's sub-element id.
                 wptr<image>    image_wptr;
                 opt_gb_attrs_t opt_attrs;
+                gb_attrs_t     gb_attrs{}; // Evaluated attributes.
                 bitmap_t       bitmap;
                 bool           touched{};
+                twod           attr_WH; // The size at which the attributes are evaluated.
+                si32           attr_digest{}; // Digest in which attributes are evaluated.
+
+                void sync_attrs_with_base(image& base_image, twod image_WH, twod wh)
+                {
+                    if (attr_digest != base_image.attr_digest || attr_WH != image_WH) // Sync the layer attrs with the original image.
+                    {
+                        auto changed_bits = 0;
+                        auto prev_wh = twod{ gb_attrs[imagens::gb::w], gb_attrs[imagens::gb::h] };
+                        for (auto i = 0u; i < gb_attrs.size(); i++)
+                        {
+                            auto& a = opt_attrs[i];
+                            auto changed = std::exchange(gb_attrs[i], a ? a.value() : base_image.gb_attrs[i]) != gb_attrs[i];
+                            if (changed) changed_bits |= 1 << i;
+                        }
+                        if (gb_attrs[imagens::gb::w] == 0) gb_attrs[imagens::gb::w] = (fp32)wh.x;
+                        if (gb_attrs[imagens::gb::h] == 0) gb_attrs[imagens::gb::h] = (fp32)wh.y;
+                        auto same_size = prev_wh.x == gb_attrs[imagens::gb::w] && prev_wh.y == gb_attrs[imagens::gb::h];
+                        auto invalidate_bitmap = !same_size || (changed_bits & ((1 << imagens::gb::uw)
+                                                                              | (1 << imagens::gb::vh)
+                                                                              | (1 << imagens::gb::fit)));
+                        if (invalidate_bitmap)
+                        {
+                            bitmap.reset();
+                        }
+                        attr_digest = base_image.attr_digest;
+                        attr_WH = image_WH;
+                    }
+                }
             };
 
             text          id;
@@ -1407,6 +1437,7 @@ namespace netxs
             bitmap_t      bitmap;
             std::vector<layer_t> layers;
             bool          updated_layers{};
+            si32          attr_digest{}; // Stamp to sync with layers.
 
             auto empty()
             {
@@ -1415,6 +1446,7 @@ namespace netxs
             void set_changes(si32 new_changed_bits, many& changes, twod cellsz = {})
             {
                 if constexpr (debugmode) log("Received image update:");
+                attr_digest++;
                 changed_gb_attrs = new_changed_bits;
                 auto mask = (ui32)changed_gb_attrs;
                 auto j = 0u;
@@ -1550,6 +1582,7 @@ namespace netxs
             {
                 if (global_attributes.size() >= imagens::gb::attr_count + 2)
                 {
+                    attr_digest++;
                     auto i = 0u;
                     for (; i < imagens::gb::attr_count; i++)
                     {
@@ -1585,6 +1618,7 @@ namespace netxs
             }
             void check_and_set_attr(gb_attrs_t& new_gb_attrs)
             {
+                attr_digest++;
                 assert(new_gb_attrs.size() < sizeof(changed_gb_attrs) * 8);
                 for (auto i = 0u; i < new_gb_attrs.size(); i++)
                 {

--- a/src/netxs/desktopio/canvas.hpp
+++ b/src/netxs/desktopio/canvas.hpp
@@ -4139,13 +4139,14 @@ namespace netxs
             swap(block);
             digest++;
         }
-        bool remove_image_bits(ui16 removed_image_index)
+        bool remove_image_bits(std::vector<ui16>& removed_image_indexes)
         {
             auto hit = faux;
             for (auto& c : canvas)
             {
                 auto image_index = c.get_image_index();
-                if (image_index == removed_image_index)
+                //if (image_index == removed_image_index) //todo optimize
+                if (std::find(removed_image_indexes.begin(), removed_image_indexes.end(), image_index) != removed_image_indexes.end())
                 {
                     c.reset_px(); // Drop all image metadata.
                     hit = true;

--- a/src/netxs/desktopio/canvas.hpp
+++ b/src/netxs/desktopio/canvas.hpp
@@ -1436,15 +1436,15 @@ namespace netxs
             byte          stamp{}; // Increment on image update to sync with FE.
             bitmap_t      bitmap;
             std::vector<layer_t> layers;
-            bool          updated_layers{};
             si32          attr_digest{}; // Stamp to sync with layers.
 
             auto empty()
             {
                 return document.empty() && layers.empty();
             }
-            void set_changes(si32 new_changed_bits, many& changes, twod cellsz = {})
+            bool set_changes(si32 new_changed_bits, many& changes, twod cellsz = {})
             {
+                auto layers_updated = faux;
                 if constexpr (debugmode) log("Received image update:");
                 attr_digest++;
                 changed_gb_attrs = new_changed_bits;
@@ -1487,7 +1487,7 @@ namespace netxs
                     }
                     if (j < changes.size() && netxs::get_bit<image::layers_bit>(document_changed)) // Receive foreign layer indexes.
                     {
-                        load_layers(j, changes);
+                        layers_updated = load_layers(j, changes);
                     }
                 }
                 if (need_bitmap_reset)
@@ -1500,6 +1500,7 @@ namespace netxs
                     auto y = gb_attrs[imagens::gb::y];
                     bitmap.xy = twod{ std::round(fp2d{ x, y } * cellsz) };
                 }
+                return layers_updated;
             }
             auto get_changes()
             {
@@ -1534,13 +1535,14 @@ namespace netxs
             }
             void pack_layers(many& changes)
             {
-                changes.reserve(layers.size() * imagens::gb::attr_count); // To avoid reallocations.
+                changes.reserve(changes.size() + layers.size() * (3 + imagens::gb::attr_count));
                 for (auto& l : layers)
                 {
                     changes.push_back(l.index);
                     changes.push_back(l.sub_id);
                     auto mask = 0;
-                    auto& changed_layer_attr_bits = changes.emplace_back(mask); // Reserve a placeholder.
+                    auto changed_layer_attr_bits_index = changes.size(); // Placeholder index.
+                    changes.push_back(mask); // Reserve a placeholder.
                     for (auto i = 0u; i < l.opt_attrs.size(); i++)
                     {
                         if (auto& attr = l.opt_attrs[i])
@@ -1549,12 +1551,13 @@ namespace netxs
                             changes.push_back(attr.value());
                         }
                     }
-                    changed_layer_attr_bits = mask; // Write to placeholder.
+                    changes[changed_layer_attr_bits_index] = mask; // Write to placeholder.
                 }
             }
-            void load_layers(ui32 i, many& changes)
+            bool load_layers(ui32 i, many& changes)
             {
-                if (i < changes.size())
+                auto layers_updated = i < changes.size();
+                if (layers_updated)
                 {
                     if constexpr (debugmode) log("  layers update:");
                     layers.clear();
@@ -1577,9 +1580,11 @@ namespace netxs
                         }
                     }
                 }
+                return layers_updated;
             }
-            void receive_image_attributes(many& global_attributes) // Receive full metadata set for unknown image.
+            bool receive_image_attributes(many& global_attributes) // Receive full metadata set for unknown image.
             {
+                auto layers_updated = faux;
                 if (global_attributes.size() >= imagens::gb::attr_count + 2)
                 {
                     attr_digest++;
@@ -1591,10 +1596,11 @@ namespace netxs
                     }
                     sub_id   = std::any_cast<text>(global_attributes[i++]);
                     document = std::any_cast<text>(global_attributes[i++]);
-                    load_layers(i, global_attributes);
+                    layers_updated = load_layers(i, global_attributes);
                     reset_changes();
                     if constexpr (debugmode) log("  sub_id='%%' document='%value%...'", sub_id, document.substr(0, std::min(20, (si32)document.size())));
                 }
+                return layers_updated;
             }
             void reset_changes()
             {
@@ -1616,7 +1622,7 @@ namespace netxs
                     netxs::set_bit<image::sub_id_bit>(document_changed, true);
                 }
             }
-            void check_and_set_attr(gb_attrs_t& new_gb_attrs)
+            void check_and_set_attr(gb_attrs_t& new_gb_attrs, bool updated_layers)
             {
                 attr_digest++;
                 assert(new_gb_attrs.size() < sizeof(changed_gb_attrs) * 8);
@@ -1628,11 +1634,12 @@ namespace netxs
                         gb_attrs[i] = new_gb_attrs[i];
                     }
                 }
+                netxs::set_bit<image::layers_bit>(document_changed, updated_layers);
             }
             auto get_global_attrs()
             {
                 auto global_attributes = many{};
-                global_attributes.reserve(gb_attrs.size() + 2);
+                global_attributes.reserve(imagens::gb::attr_count + 2 + layers.size() * (3 + imagens::gb::attr_count));
                 for (auto& ga : gb_attrs)
                 {
                     global_attributes.push_back(ga);

--- a/src/netxs/desktopio/canvas.hpp
+++ b/src/netxs/desktopio/canvas.hpp
@@ -3957,6 +3957,20 @@ namespace netxs
             swap(block);
             digest++;
         }
+        bool remove_image_bits(ui16 removed_image_index)
+        {
+            auto hit = faux;
+            for (auto& c : canvas)
+            {
+                auto image_index = c.get_image_index();
+                if (image_index == removed_image_index)
+                {
+                    c.reset_px(); // Drop all image metadata.
+                    hit = true;
+                }
+            }
+            return hit;
+        }
     };
 }
 

--- a/src/netxs/desktopio/console.hpp
+++ b/src/netxs/desktopio/console.hpp
@@ -237,7 +237,7 @@ namespace netxs::ui
                         if (auto image_ptr = images.map[unknown_index])
                         {
                             auto& image = *image_ptr;
-                            if (image.document.size())
+                            if (!image.empty())
                             {
                                 list.thing.push(unknown_index, image.get_global_attrs());
                             }
@@ -265,7 +265,7 @@ namespace netxs::ui
                                 if (auto image_ptr = images.map[unknown_index])
                                 {
                                     auto& image = *image_ptr;
-                                    if (image.document.size())
+                                    if (!image.empty())
                                     {
                                         reply_list.push(unknown_index, image.get_global_attrs());
                                         reply_count++;

--- a/src/netxs/desktopio/console.hpp
+++ b/src/netxs/desktopio/console.hpp
@@ -1044,9 +1044,9 @@ namespace netxs::ui
             canvas.cmode = props.vtmode;
             canvas.face::area(base::area());
 
-            LISTEN(tier::general, e2::data::image::remove, image_index)
+            LISTEN(tier::general, e2::data::image::remove, image_indexes)
             {
-                conio.remove_img_request.send(canal, image_index);
+                conio.remove_img_request.send(canal, image_indexes);
             };
             LISTEN(tier::general, e2::data::image::update, image_index)
             {

--- a/src/netxs/desktopio/directvt.hpp
+++ b/src/netxs/desktopio/directvt.hpp
@@ -999,6 +999,7 @@ namespace netxs::directvt
         auto& operator << (std::ostream& s, time const& o) { return s << utf::to_hex_0x(o.time_since_epoch().count()); }
         auto& operator << (std::ostream& s, regs const& rs) { s << '{'; for (auto& r : rs) s << r; return s << '}'; }
         auto& operator << (std::ostream& s, many const& my) { s << '{'; for (auto& r : my) s << r.type().name(); return s << '}'; }
+        auto& operator << (std::ostream& s, std::vector<ui16> const& v) { s << '{'; for (auto& r : v) s << r << ", "; return s << '}'; }
 
         STRUCT_macro(frame_element,      (blob, data))
         STRUCT_macro(mouse_event,        (id_t, gear_id)
@@ -1075,7 +1076,7 @@ namespace netxs::directvt
         STRUCT_macro(unknown_img,        (ui16, index)) // Request unknown image list<unknown_img>.
         STRUCT_macro(img_element,        (ui16, index) (many, global_attributes)) // Reply image metadata list<img_element>. Access by imagens::gb::<attr_index>; The document_bits:(sub_id and document)+list_of_layers(index sub_id changed_bits attrs) is always placed at the end of the list.
         STRUCT_macro(update_img_request, (ui16, index) (si32, changed_bits) (many, changes)) // The document_bits:(sub_id and document)+list_of_layers(index sub_id changed_bits attrs) is always placed at the end of the list if set.
-        STRUCT_macro(remove_img_request, (ui16, index))
+        STRUCT_macro(remove_img_request, (std::vector<ui16>, indexes))
 
         #undef STRUCT_macro
         #undef STRUCT_macro_lite
@@ -2096,6 +2097,29 @@ namespace netxs::directvt
                         }
                     }
                 }
+            }
+            auto remove_image_indexes(auto& images, std::vector<ui16>& image_indexes)
+            {
+                auto hit = faux;
+                auto is_remote = s11n::nat[0];
+                if (is_remote)
+                {
+                    for (auto& image_index : image_indexes)
+                    {
+                        image_index = std::exchange(s11n::nat[image_index], 0);
+                        images.remove(image_index);
+                        hit |= !!image_index;
+                    }
+                }
+                else
+                {
+                    for (auto image_index : image_indexes)
+                    {
+                        images.remove(image_index);
+                        hit |= !!image_index;
+                    }
+                }
+                return hit;
             }
             // s11n: Receive jumbo clusters.
             void receive_jgc(s11n::xs::jgc_list& lock)

--- a/src/netxs/desktopio/directvt.hpp
+++ b/src/netxs/desktopio/directvt.hpp
@@ -1073,8 +1073,8 @@ namespace netxs::directvt
         STRUCT_macro(jgc_element,        (ui64, token) (text, cluster)) // Reply grapheme cluster list<jgc_element>.
 
         STRUCT_macro(unknown_img,        (ui16, index)) // Request unknown image list<unknown_img>.
-        STRUCT_macro(img_element,        (ui16, index) (many, global_attributes)) // Reply image metadata list<img_element>. Access by imagens::gb::<attr_index>; The document_bits:(sub_id and document) is always placed at the end of the list.
-        STRUCT_macro(update_img_request, (ui16, index) (si32, changed_bits) (many, changes)) // The document_bits:(sub_id and document) is always placed at the end of the list if set.
+        STRUCT_macro(img_element,        (ui16, index) (many, global_attributes)) // Reply image metadata list<img_element>. Access by imagens::gb::<attr_index>; The document_bits:(sub_id and document)+list_of_layers(index sub_id changed_bits attrs) is always placed at the end of the list.
+        STRUCT_macro(update_img_request, (ui16, index) (si32, changed_bits) (many, changes)) // The document_bits:(sub_id and document)+list_of_layers(index sub_id changed_bits attrs) is always placed at the end of the list if set.
         STRUCT_macro(remove_img_request, (ui16, index))
 
         #undef STRUCT_macro
@@ -1266,17 +1266,7 @@ namespace netxs::directvt
                                 last_int_index = ext_to_int_map[image_ext_index];
                                 if (!last_int_index) // Register a new empty image and get a new index.
                                 {
-                                    auto images = cell::images(); // Lock. //todo ?Should we place it outside of this hot loop?
-                                    auto image_ptr = ptr::shared(imagens::image{});
-                                    last_int_index = images.set(image_ptr);
-                                    if (last_int_index)
-                                    {
-                                        image_ptr->index = last_int_index;
-                                        images.unk.push_back(last_ext_index);
-                                        if constexpr (debugmode) log("%%: request image index: last_int_index=%% last_ext_index=%%", binary::process_id, last_int_index, last_ext_index);
-                                        ext_to_int_map[last_ext_index] = last_int_index; // Update forward map.
-                                        //int_to_ext_map[last_int_index] = last_ext_index; // Update reverse map.
-                                    }
+                                    last_int_index = cell::register_image(last_ext_index, ext_to_int_map);
                                 }
                             }
                             c.set_image_index(last_int_index);
@@ -2065,6 +2055,24 @@ namespace netxs::directvt
                             auto& image = *image_ptr;
                             if constexpr (debugmode) log("%%New image metadata:", prompt::s11n);
                             image.receive_image_attributes(new_image.global_attributes);
+                            for (auto& l : image.layers) // Translate layers indexes.
+                            {
+                                auto l_ext_index = l.index;
+                                auto l_int_index = s11n::nat[l_ext_index];
+                                if (l_int_index)
+                                {
+                                    if (auto l_layer_ptr = images.map[l_int_index])
+                                    {
+                                        l.image_wptr = l_layer_ptr;
+                                        l_int_index = l_layer_ptr->index;
+                                    }
+                                }
+                                else
+                                {
+                                    l_int_index = cell::register_image(l_ext_index, s11n::nat); // Register and enqueue request for unknown images.
+                                }
+                                l.index = l_int_index;
+                            }
                         }
                     }
                 }

--- a/src/netxs/desktopio/directvt.hpp
+++ b/src/netxs/desktopio/directvt.hpp
@@ -2041,10 +2041,44 @@ namespace netxs::directvt
                     list.thing.sendby(master);
                 }
             }
+            // s11n: Translate layer indexes from ext to int.
+            void translate_layers(auto& images, imagens::image& image, bool is_remote)
+            {
+                for (auto& l : image.layers) // Translate layers indexes.
+                {
+                    if (is_remote)
+                    {
+                        auto l_ext_index = l.index;
+                        auto l_int_index = s11n::nat[l_ext_index];
+                        if (!l_int_index)
+                        {
+                            l_int_index = cell::register_image(l_ext_index, s11n::nat); // Register and enqueue request for unknown images.
+                        }
+                        if (l_int_index)
+                        {
+                            if (auto l_layer_ptr = images.map[l_int_index])
+                            {
+                                l.image_wptr = l_layer_ptr;
+                                l_int_index = l_layer_ptr->index;
+                            }
+                        }
+                        l.index = l_int_index;
+                    }
+                    else // Update base image references.
+                    {
+                        if (auto l_layer_ptr = images.map[l.index])
+                        {
+                            l.image_wptr = l_layer_ptr;
+                        }
+                    }
+                }
+            }
             // s11n: Receive image metadata.
             void receive_img(s11n::xs::img_list& lock)
             {
                 auto images = cell::images();
+                auto is_remote = !!s11n::nat[0];
+                assert(is_remote == true);
                 for (auto& new_image : lock.thing)
                 {
                     auto remote_index = new_image.index;
@@ -2054,24 +2088,10 @@ namespace netxs::directvt
                         {
                             auto& image = *image_ptr;
                             if constexpr (debugmode) log("%%New image metadata:", prompt::s11n);
-                            image.receive_image_attributes(new_image.global_attributes);
-                            for (auto& l : image.layers) // Translate layers indexes.
+                            auto layers_updated = image.receive_image_attributes(new_image.global_attributes);
+                            if (layers_updated)
                             {
-                                auto l_ext_index = l.index;
-                                auto l_int_index = s11n::nat[l_ext_index];
-                                if (l_int_index)
-                                {
-                                    if (auto l_layer_ptr = images.map[l_int_index])
-                                    {
-                                        l.image_wptr = l_layer_ptr;
-                                        l_int_index = l_layer_ptr->index;
-                                    }
-                                }
-                                else
-                                {
-                                    l_int_index = cell::register_image(l_ext_index, s11n::nat); // Register and enqueue request for unknown images.
-                                }
-                                l.index = l_int_index;
+                                translate_layers(images, image, is_remote);
                             }
                         }
                     }

--- a/src/netxs/desktopio/directvt.hpp
+++ b/src/netxs/desktopio/directvt.hpp
@@ -1073,8 +1073,8 @@ namespace netxs::directvt
         STRUCT_macro(jgc_element,        (ui64, token) (text, cluster)) // Reply grapheme cluster list<jgc_element>.
 
         STRUCT_macro(unknown_img,        (ui16, index)) // Request unknown image list<unknown_img>.
-        STRUCT_macro(img_element,        (ui16, index) (many, global_attributes)) // Reply image metadata list<img_element>. Access by imagens::gb::<attr_index>; The document is always placed at the end of the list.
-        STRUCT_macro(update_img_request, (ui16, index) (si32, changed_bits) (many, changes)) // The document is always placed at the end of the list if set.
+        STRUCT_macro(img_element,        (ui16, index) (many, global_attributes)) // Reply image metadata list<img_element>. Access by imagens::gb::<attr_index>; The document_bits:(sub_id and document) is always placed at the end of the list.
+        STRUCT_macro(update_img_request, (ui16, index) (si32, changed_bits) (many, changes)) // The document_bits:(sub_id and document) is always placed at the end of the list if set.
         STRUCT_macro(remove_img_request, (ui16, index))
 
         #undef STRUCT_macro
@@ -2064,13 +2064,7 @@ namespace netxs::directvt
                         {
                             auto& image = *image_ptr;
                             if constexpr (debugmode) log("%%New image metadata:", prompt::s11n);
-                            for (auto i = 0u; i < new_image.global_attributes.size() - 1; i++)
-                            {
-                                image.gb_attrs[i] = std::any_cast<fp32>(new_image.global_attributes[i]);
-                                if constexpr (debugmode) log("  %attr%=%value%", imagens::gb::names[i], image.gb_attrs[i]);
-                            }
-                            image.document = std::any_cast<text>(new_image.global_attributes.back());
-                            if constexpr (debugmode) log("  document='%value%...'", image.document.substr(0, std::min(20, (si32)image.document.size())));
+                            image.receive_image_attributes(new_image.global_attributes);
                         }
                     }
                 }

--- a/src/netxs/desktopio/directvt.hpp
+++ b/src/netxs/desktopio/directvt.hpp
@@ -2107,8 +2107,11 @@ namespace netxs::directvt
                     for (auto& image_index : image_indexes)
                     {
                         image_index = std::exchange(s11n::nat[image_index], 0);
-                        images.remove(image_index);
-                        hit |= !!image_index;
+                        if (image_index)
+                        {
+                            images.remove(image_index);
+                            hit |= !!image_index;
+                        }
                     }
                 }
                 else

--- a/src/netxs/desktopio/generics.hpp
+++ b/src/netxs/desktopio/generics.hpp
@@ -412,26 +412,42 @@ namespace netxs::generics
         template<class Ring>
         struct iter
         {
-            Ring& buff;
-            si32  addr;
+            using iterator_category = std::random_access_iterator_tag;
+            using value_type        = typename Ring::type;
+            using difference_type   = si32;
+            using pointer           = std::conditional_t<std::is_const_v<Ring>, value_type const*, value_type*>;
+            using reference         = std::conditional_t<std::is_const_v<Ring>, value_type const&, value_type&>;
 
+            Ring* buff{};
+            si32  addr{};
+
+            constexpr iter() = default;
             constexpr iter(iter const&) = default;
             constexpr iter(Ring& buff, si32 addr)
-              : buff{ buff },
-                addr{ addr }
+              : buff{ &buff },
+                addr{ addr  }
             { }
 
-            auto& operator =  (iter const& i)       { assert(&i.buff == &buff); addr = i.addr; return *this;              }
-            auto  operator -  (si32 n)        const {      return iter<Ring>{ buff, buff.mod(addr - n) };                 }
-            auto  operator +  (si32 n)        const {      return iter<Ring>{ buff, buff.mod(addr + n) };                 }
-            auto  operator ++ (int)                 { auto temp = iter<Ring>{ buff, addr }; buff.inc(addr); return temp;  }
-            auto  operator -- (int)                 { auto temp = iter<Ring>{ buff, addr }; buff.dec(addr); return temp;  }
-            auto& operator ++ ()                    {                                       buff.inc(addr); return *this; }
-            auto& operator -- ()                    {                                       buff.dec(addr); return *this; }
-            auto& operator *  ()                    { return buff.buff[addr];                                             }
-            auto  operator -> ()                    { return buff.buff.begin() + addr;                                    }
-            auto  operator != (iter const& m) const { return addr != m.addr;                                              }
-            auto  operator == (iter const& m) const { return addr == m.addr;                                              }
+            auto& operator =  (iter const& i)       { buff = i.buff; addr = i.addr; return *this;                           }
+            auto  operator ++ (int)                 { auto temp = iter<Ring>{ *buff, addr }; buff->inc(addr); return temp;  }
+            auto  operator -- (int)                 { auto temp = iter<Ring>{ *buff, addr }; buff->dec(addr); return temp;  }
+            auto& operator ++ ()                    {                                        buff->inc(addr); return *this; }
+            auto& operator -- ()                    {                                        buff->dec(addr); return *this; }
+            auto& operator *  ()                    { return buff->buff[addr];                                              }
+            auto  operator -> ()                    { return buff->buff.begin() + addr;                                     }
+            auto  operator != (iter const& m) const { return addr != m.addr;                                                }
+            auto  operator == (iter const& m) const { return addr == m.addr;                                                }
+            auto  operator -  (iter const& m) const { return (difference_type)buff->dst(m.addr, addr);                      }
+            auto  operator <  (iter const& m) const { return (*this - m) < 0;                                               }
+            auto  operator >  (iter const& m) const { return (*this - m) > 0;                                               }
+            auto  operator <= (iter const& m) const { return (*this - m) <= 0;                                              }
+            auto  operator >= (iter const& m) const { return (*this - m) >= 0;                                              }
+            auto& operator += (si32 n)              { addr = buff->mod(addr + n); return *this;                             }
+            auto& operator -= (si32 n)              { addr = buff->mod(addr - n); return *this;                             }
+            friend auto operator + (iter i, si32 n) { i += n; return i;                                                     }
+            friend auto operator + (si32 n, iter i) { i += n; return i;                                                     }
+            friend auto operator - (iter i, si32 n) { i -= n; return i;                                                     }
+            reference operator[](difference_type n) const { return *(*this + (si32)n);                                      }
         };
 
         ring(si32 ring_size, si32 grow_by = 0, si32 grow_mx = 0)

--- a/src/netxs/desktopio/gui.hpp
+++ b/src/netxs/desktopio/gui.hpp
@@ -2422,11 +2422,6 @@ namespace netxs::gui
         {
             auto& image_dom = *dom[0];
             auto orig_full_sz_fp = fp2d{ image_dom.width(), image_dom.height() }; // Original doc size (float).
-            if (!std::isnormal(orig_full_sz_fp.x) || !std::isnormal(orig_full_sz_fp.y))
-            {
-                bitmap.fragment.set_area<irgb>(rect{});
-                return;
-            }
             auto u   = gb_attrs[imagens::gb::u  ];
             auto v   = gb_attrs[imagens::gb::v  ];
             auto uw  = gb_attrs[imagens::gb::uw ];
@@ -2437,6 +2432,13 @@ namespace netxs::gui
             auto h   = gb_attrs[imagens::gb::h  ];
             auto tr  = gb_attrs[imagens::gb::tr ];
             auto fit = gb_attrs[imagens::gb::fit];
+            if (!std::isnormal(orig_full_sz_fp.x) || !std::isnormal(orig_full_sz_fp.y))
+            {
+                bitmap.fragment.set_area<irgb>(rect{});
+                return;
+            }
+            if (!std::isnormal(uw)) uw = 1.f;
+            if (!std::isnormal(vh)) vh = 1.f;
             auto wh   = fp2d{ w, h };
             auto uv   = fp2d{ u, v };
             auto uvwh = fp2d{ uw, vh };
@@ -3101,14 +3103,11 @@ namespace netxs::gui
             void handle(s11n::xs::remove_img_request  lock)
             {
                 auto& image = lock.thing;
-                image.index &= 0xFFFF;
-                if (image.index)
+                auto images = cell::images(); // Lock.
+                auto hit = s11n::remove_image_indexes(images, image.indexes);
+                if (hit)
                 {
-                    auto images = cell::images(); // Lock.
-                    auto is_remote = s11n::nat[0];
-                    auto image_index = is_remote ? std::exchange(s11n::nat[image.index], 0) : image.index;
-                    images.map[image_index] = {};
-                    if (owner.remove_image_bits(image_index))
+                    if (owner.remove_image_bits(image.indexes))
                     {
                         netxs::set_flag<task::all>(owner.reload); // Trigger to redraw all to update unknown images.
                     }
@@ -4023,10 +4022,10 @@ namespace netxs::gui
                 }
             }
         }
-        bool remove_image_bits(ui16 removed_image_index)
+        bool remove_image_bits(std::vector<ui16>& removed_image_indexes)
         {
             auto bitmap_lock = stream.bitmap_dtvt.freeze();
-            auto hit = bitmap_lock.thing.image.remove_image_bits(removed_image_index);;
+            auto hit = bitmap_lock.thing.image.remove_image_bits(removed_image_indexes);
             return hit;
         }
         bool update_image_bits(ui16 updated_image_index)

--- a/src/netxs/desktopio/gui.hpp
+++ b/src/netxs/desktopio/gui.hpp
@@ -2597,8 +2597,24 @@ namespace netxs::gui
                     auto image_WH = c.get_image_WH() * cellsz;
                     auto inv      = c.inv();
                     placeholder.coor -= (image_cr - dot_11) * cellsz;
-                    //todo iterate over layers
-                    //...
+                    for (auto& l : image.layers) // Iterate over layers.
+                    {
+                        if (auto layer_ptr = l.image_wptr.lock())
+                        {
+                            imagens::image::gb_attrs_t gb_attrs;
+                            auto& layer = *layer_ptr;
+                            for (auto i = 0u; i < gb_attrs.size(); i++) //todo optimize (make it once on update)
+                            {
+                                auto& a = l.opt_attrs[i];
+                                gb_attrs[i] = a ? a.value() : layer.gb_attrs[i];
+                            }
+                            render_layer(canvas, placeholder, fgc, layer, l.sub_id, l.bitmap, gb_attrs, image_WH, inv);
+                        }
+                        else
+                        {
+                            //todo drop from image.layers
+                        }
+                    }
                     render_layer(canvas, placeholder, fgc, image, image.sub_id, image.bitmap, image.gb_attrs, image_WH, inv);
                 }
             }

--- a/src/netxs/desktopio/gui.hpp
+++ b/src/netxs/desktopio/gui.hpp
@@ -4011,19 +4011,8 @@ namespace netxs::gui
         }
         bool remove_image_bits(ui16 removed_image_index)
         {
-            auto hit = faux;
             auto bitmap_lock = stream.bitmap_dtvt.freeze();
-            auto& grid = bitmap_lock.thing.image;
-            for (auto& c : grid)
-            {
-                auto image_index = c.get_image_index();
-                if (image_index == removed_image_index)
-                {
-                    //todo optimize: scan bitmap_dtvt and find dirty regions, see layer::sync
-                    c.reset_px(); // Drop all image metadata.
-                    hit = true;
-                }
-            }
+            auto hit = bitmap_lock.thing.image.remove_image_bits(removed_image_index);;
             return hit;
         }
         bool update_image_bits(ui16 updated_image_index)

--- a/src/netxs/desktopio/gui.hpp
+++ b/src/netxs/desktopio/gui.hpp
@@ -2590,25 +2590,22 @@ namespace netxs::gui
             if (auto image_cr = c.get_image_cr(); image_cr.x != 0 && image_cr.y != 0)
             {
                 auto image_index = c.get_image_index();
+                auto wh = c.get_image_WH();
                 auto images = cell::images(); // Lock.
+                //todo make it recursive
                 if (auto image_ptr = images.exists(image_index)) // We form all image requests on dtvt recv stage.
                 {
                     auto& image = *image_ptr;
-                    auto image_WH = c.get_image_WH() * cellsz;
-                    auto inv      = c.inv();
+                    auto image_WH = wh * cellsz;
+                    auto inv = c.inv();
                     placeholder.coor -= (image_cr - dot_11) * cellsz;
                     for (auto& l : image.layers) // Iterate over layers.
                     {
                         if (auto layer_ptr = l.image_wptr.lock())
                         {
-                            imagens::image::gb_attrs_t gb_attrs;
                             auto& layer = *layer_ptr;
-                            for (auto i = 0u; i < gb_attrs.size(); i++) //todo optimize (make it once on update)
-                            {
-                                auto& a = l.opt_attrs[i];
-                                gb_attrs[i] = a ? a.value() : layer.gb_attrs[i];
-                            }
-                            render_layer(canvas, placeholder, fgc, layer, l.sub_id, l.bitmap, gb_attrs, image_WH, inv);
+                            l.sync_attrs_with_base(layer, image_WH, wh);
+                            render_layer(canvas, placeholder, fgc, layer, l.sub_id, l.bitmap, l.gb_attrs, image_WH, inv);
                         }
                         else
                         {

--- a/src/netxs/desktopio/gui.hpp
+++ b/src/netxs/desktopio/gui.hpp
@@ -1756,7 +1756,7 @@ namespace netxs::gui
             {
                 if (image_ptr)
                 {
-                    image_ptr->reset_raster();
+                    image_ptr->bitmap.reset();
                 }
             }
         }
@@ -2430,7 +2430,7 @@ namespace netxs::gui
                 auto orig_full_sz_fp = fp2d{ image_dom.width(), image_dom.height() }; // Original doc size (float).
                 if (!std::isnormal(orig_full_sz_fp.x) || !std::isnormal(orig_full_sz_fp.y))
                 {
-                    image.fragment.set_area<irgb>(rect{});
+                    image.bitmap.fragment.set_area<irgb>(rect{});
                     return;
                 }
                 auto u   = image.gb_attrs[imagens::gb::u  ];
@@ -2449,7 +2449,7 @@ namespace netxs::gui
                 auto final_frag_sz = orig_full_sz_fp * uvwh; // Rendered fragment size (float).
                 wh *= cellsz;
                 auto bounding_rect_pixels = std::round(wh); // Document bounding box size in pixels.
-                image.xy = twod{ std::round(fp2d{ x, y } * cellsz) };
+                image.bitmap.xy = twod{ std::round(fp2d{ x, y } * cellsz) };
 
                 if ((si32)tr & 1)
                 {
@@ -2467,11 +2467,11 @@ namespace netxs::gui
                 // Apply system limits.
                 auto px_limits = std::max(dot_11, skin::globals().max_value * cellsz);
                 final_frag_sz = std::clamp(final_frag_sz, fp2d{ dot_11 }, fp2d{ px_limits });
-                image.final_frag_sz = final_frag_sz;
+                //image.bitmap.final_frag_sz = final_frag_sz;
 
                 static thread_local auto full_doc_tmp_buffer = netxs::sprite{ *std::pmr::new_delete_resource() };
-                image.scaled_fragment_area = rect{ dot_00, std::ceil(final_frag_sz) };
-                full_doc_tmp_buffer.set_area<irgb>(image.scaled_fragment_area);
+                image.bitmap.scaled_fragment_area = rect{ dot_00, std::ceil(final_frag_sz) };
+                full_doc_tmp_buffer.set_area<irgb>(image.bitmap.scaled_fragment_area);
                 auto tmp_document_block = full_doc_tmp_buffer.raster<irgb>();
                 tmp_document_block.zeroize();
                 auto offset_inside_document = uv * orig_full_sz_fp * scale;
@@ -2479,10 +2479,10 @@ namespace netxs::gui
 
                 // Trim all transparent pixels.
                 auto nested_fragment_area = full_doc_tmp_buffer.get_minimal_non_transparent_area_for_pma<irgb>();
-                image.fragment.set_area<irgb>(nested_fragment_area);
+                image.bitmap.fragment.set_area<irgb>(nested_fragment_area);
                 if (nested_fragment_area)
                 {
-                    auto dst_fragment_block = image.fragment.raster<irgb>();
+                    auto dst_fragment_block = image.bitmap.fragment.raster<irgb>();
                     netxs::onbody(tmp_document_block, dst_fragment_block, [](auto& src, auto& dst){ dst = src; });
                 }
             }
@@ -2532,7 +2532,7 @@ namespace netxs::gui
         }
         void draw_image(auto& canvas, imagens::image& image, twod offset, argb fgc, bool semi_transparent, si32 xform)
         {
-            auto& image_mask = image.fragment;
+            auto& image_mask = image.bitmap.fragment;
             auto f_fgc = irgb::nonpma_srgb_to_pma_linear(fgc);
             auto global_alpha = semi_transparent ? 0.5f : 1.0f; // Triggers on SGR 7 (reverse video).
             assert(image_mask.type == sprite::color);
@@ -2553,7 +2553,7 @@ namespace netxs::gui
             };
             // xform on write
             auto canvas_clip = canvas.clip(); // Cell placeholder.
-            auto document_area = image.scaled_fragment_area.shift(offset); // Raster inside the document fragment.
+            auto document_area = image.bitmap.scaled_fragment_area.shift(offset); // Raster inside the document fragment.
             netxs::xform_render(canvas, canvas_clip, raster, document_area, xform, fx);
         }
         auto render_image(auto& canvas, rect placeholder, argb fgc, cell const& c)
@@ -2565,11 +2565,11 @@ namespace netxs::gui
                 if (auto image_ptr = images.exists(image_index)) // We form all image requests on dtvt recv stage.
                 {
                     auto& image = *image_ptr;
-                    if (image.fragment.type == sprite::undef && image.document.size())
+                    if (image.bitmap.fragment.type == sprite::undef && image.document.size())
                     {
                         rasterize_svg_document(image);
                     }
-                    if (image.fragment.area)
+                    if (image.bitmap.fragment.area)
                     {
                         auto image_align = (si32)image.gb_attrs[imagens::gb::a ];
                         auto image_xform = (si32)image.gb_attrs[imagens::gb::tr];
@@ -2583,7 +2583,7 @@ namespace netxs::gui
                         //    return 0.0f;
                         //};
                         //auto factors = fp2d{ get_factor(image_align & 0b0011), get_factor(image_align >> 2) };
-                        //auto fragment_area_coor = image.fragment.area.coor + (image_WH - image.scaled_fragment_area.size) * factors;
+                        //auto fragment_area_coor = image.bitmap.fragment.area.coor + (image_WH - image.bitmap.scaled_fragment_area.size) * factors;
 
                         auto get_off = [](auto align, auto diff)
                         {
@@ -2591,16 +2591,16 @@ namespace netxs::gui
                                  : (align == (si32)bias::center || !align) ? diff / 2
                                                                            : 0;
                         };
-                        auto align = twod{ get_off(image_align & 0b0011, image_WH.x - image.scaled_fragment_area.size.x),
-                                           get_off(image_align >> 2,     image_WH.y - image.scaled_fragment_area.size.y) };
-                        auto fragment_area_coor = image.scaled_fragment_area.coor + align;
+                        auto align = twod{ get_off(image_align & 0b0011, image_WH.x - image.bitmap.scaled_fragment_area.size.x),
+                                           get_off(image_align >> 2,     image_WH.y - image.bitmap.scaled_fragment_area.size.y) };
+                        auto fragment_area_coor = image.bitmap.scaled_fragment_area.coor + align;
                         if (image_xform & 1) // ok.
                         {
                             std::swap(fragment_area_coor.x, fragment_area_coor.y);
                         }
                         // Rendering.
                         image_cr = (image_cr - dot_11) * cellsz;
-                        auto offset = placeholder.coor - image_cr + image.xy + fragment_area_coor;
+                        auto offset = placeholder.coor - image_cr + image.bitmap.xy + fragment_area_coor;
                         draw_image(canvas, image, offset, fgc, c.inv(), image_xform);
                     }
                 }

--- a/src/netxs/desktopio/gui.hpp
+++ b/src/netxs/desktopio/gui.hpp
@@ -2548,6 +2548,43 @@ namespace netxs::gui
             auto document_area = bitmap.scaled_fragment_area.shift(offset); // Raster inside the document fragment.
             netxs::xform_render(canvas, canvas_clip, raster, document_area, xform, fx);
         }
+        auto render_layer(auto& canvas, rect placeholder, argb fgc, imagens::image& image, qiew sub_id, imagens::image::bitmap_t& bitmap, imagens::image::gb_attrs_t& gb_attrs, twod image_WH, bool inv)
+        {
+            if (bitmap.fragment.type == sprite::undef && image.document.size())
+            {
+                if (!image.dom[0])
+                {
+                    image.dom = generate_DOM(image.document);
+                }
+                if (image.dom[0])
+                {
+                    rasterize_svg_document(bitmap, image.dom, sub_id, gb_attrs);
+                }
+            }
+            if (bitmap.fragment.area)
+            {
+                auto image_align = (si32)gb_attrs[imagens::gb::a ];
+                auto image_xform = (si32)gb_attrs[imagens::gb::tr];
+
+                // Alignment.
+                auto get_off = [](auto align, auto diff)
+                {
+                    return (align == (si32)bias::right)            ? diff
+                         : (align == (si32)bias::center || !align) ? diff / 2
+                                                                   : 0;
+                };
+                auto align = twod{ get_off(image_align & 0b0011, image_WH.x - bitmap.scaled_fragment_area.size.x),
+                                   get_off(image_align >> 2,     image_WH.y - bitmap.scaled_fragment_area.size.y) };
+                auto fragment_area_coor = bitmap.scaled_fragment_area.coor + align;
+                if (image_xform & 1) // ok.
+                {
+                    std::swap(fragment_area_coor.x, fragment_area_coor.y);
+                }
+                // Rendering.
+                auto offset = placeholder.coor + bitmap.xy + fragment_area_coor;
+                draw_image(canvas, bitmap, offset, fgc, inv, image_xform);
+            }
+        }
         auto render_image(auto& canvas, rect placeholder, argb fgc, cell const& c)
         {
             if (auto image_cr = c.get_image_cr(); image_cr.x != 0 && image_cr.y != 0)
@@ -2557,53 +2594,12 @@ namespace netxs::gui
                 if (auto image_ptr = images.exists(image_index)) // We form all image requests on dtvt recv stage.
                 {
                     auto& image = *image_ptr;
+                    auto image_WH = c.get_image_WH() * cellsz;
+                    auto inv      = c.inv();
+                    placeholder.coor -= (image_cr - dot_11) * cellsz;
                     //todo iterate over layers
                     //...
-                    if (image.bitmap.fragment.type == sprite::undef && image.document.size())
-                    {
-                        if (!image.dom[0])
-                        {
-                            image.dom = generate_DOM(image.document);
-                        }
-                        if (image.dom[0])
-                        {
-                            rasterize_svg_document(image.bitmap, image.dom, image.sub_id, image.gb_attrs);
-                        }
-                    }
-                    if (image.bitmap.fragment.area)
-                    {
-                        auto image_align = (si32)image.gb_attrs[imagens::gb::a ];
-                        auto image_xform = (si32)image.gb_attrs[imagens::gb::tr];
-                        auto image_WH = c.get_image_WH() * cellsz;
-
-                        // Alignment.
-                        //auto get_factor = [](auto align)
-                        //{
-                        //    if (align == (si32)bias::center || !align) return 0.5f;
-                        //    if (align == (si32)bias::right)            return 1.0f;
-                        //    return 0.0f;
-                        //};
-                        //auto factors = fp2d{ get_factor(image_align & 0b0011), get_factor(image_align >> 2) };
-                        //auto fragment_area_coor = image.bitmap.fragment.area.coor + (image_WH - image.bitmap.scaled_fragment_area.size) * factors;
-
-                        auto get_off = [](auto align, auto diff)
-                        {
-                            return (align == (si32)bias::right)            ? diff
-                                 : (align == (si32)bias::center || !align) ? diff / 2
-                                                                           : 0;
-                        };
-                        auto align = twod{ get_off(image_align & 0b0011, image_WH.x - image.bitmap.scaled_fragment_area.size.x),
-                                           get_off(image_align >> 2,     image_WH.y - image.bitmap.scaled_fragment_area.size.y) };
-                        auto fragment_area_coor = image.bitmap.scaled_fragment_area.coor + align;
-                        if (image_xform & 1) // ok.
-                        {
-                            std::swap(fragment_area_coor.x, fragment_area_coor.y);
-                        }
-                        // Rendering.
-                        image_cr = (image_cr - dot_11) * cellsz;
-                        auto offset = placeholder.coor - image_cr + image.bitmap.xy + fragment_area_coor;
-                        draw_image(canvas, image.bitmap, offset, fgc, c.inv(), image_xform);
-                    }
+                    render_layer(canvas, placeholder, fgc, image, image.sub_id, image.bitmap, image.gb_attrs, image_WH, inv);
                 }
             }
         }

--- a/src/netxs/desktopio/gui.hpp
+++ b/src/netxs/desktopio/gui.hpp
@@ -2418,73 +2418,65 @@ namespace netxs::gui
                 glyph_mask.transform<irgb>(flip_swap, matrix);
             }
         }
-        void rasterize_svg_document(imagens::image& image)
+        void rasterize_svg_document(imagens::image::bitmap_t& bitmap, imagens::docs& dom, qiew sub_id, imagens::image::gb_attrs_t& gb_attrs)
         {
-            if (!image.dom[0])
+            auto& image_dom = *dom[0];
+            auto orig_full_sz_fp = fp2d{ image_dom.width(), image_dom.height() }; // Original doc size (float).
+            if (!std::isnormal(orig_full_sz_fp.x) || !std::isnormal(orig_full_sz_fp.y))
             {
-                image.dom = generate_DOM(image.document);
+                bitmap.fragment.set_area<irgb>(rect{});
+                return;
             }
-            if (image.dom[0])
+            auto u   = gb_attrs[imagens::gb::u  ];
+            auto v   = gb_attrs[imagens::gb::v  ];
+            auto uw  = gb_attrs[imagens::gb::uw ];
+            auto vh  = gb_attrs[imagens::gb::vh ];
+            auto x   = gb_attrs[imagens::gb::x  ];
+            auto y   = gb_attrs[imagens::gb::y  ];
+            auto w   = gb_attrs[imagens::gb::w  ];
+            auto h   = gb_attrs[imagens::gb::h  ];
+            auto tr  = gb_attrs[imagens::gb::tr ];
+            auto fit = gb_attrs[imagens::gb::fit];
+            auto wh   = fp2d{ w, h };
+            auto uv   = fp2d{ u, v };
+            auto uvwh = fp2d{ uw, vh };
+            auto final_frag_sz = orig_full_sz_fp * uvwh; // Rendered fragment size (float).
+            wh *= cellsz;
+            auto bounding_rect_pixels = std::round(wh); // Document bounding box size in pixels.
+            bitmap.xy = twod{ std::round(fp2d{ x, y } * cellsz) };
+
+            if ((si32)tr & 1)
             {
-                auto& image_dom = *image.dom[0];
-                auto orig_full_sz_fp = fp2d{ image_dom.width(), image_dom.height() }; // Original doc size (float).
-                if (!std::isnormal(orig_full_sz_fp.x) || !std::isnormal(orig_full_sz_fp.y))
-                {
-                    image.bitmap.fragment.set_area<irgb>(rect{});
-                    return;
-                }
-                auto u   = image.gb_attrs[imagens::gb::u  ];
-                auto v   = image.gb_attrs[imagens::gb::v  ];
-                auto uw  = image.gb_attrs[imagens::gb::uw ];
-                auto vh  = image.gb_attrs[imagens::gb::vh ];
-                auto x   = image.gb_attrs[imagens::gb::x  ];
-                auto y   = image.gb_attrs[imagens::gb::y  ];
-                auto w   = image.gb_attrs[imagens::gb::w  ];
-                auto h   = image.gb_attrs[imagens::gb::h  ];
-                auto tr  = image.gb_attrs[imagens::gb::tr ];
-                auto fit = image.gb_attrs[imagens::gb::fit];
-                auto wh  = fp2d{ w, h };
-                auto uv  = fp2d{ u, v };
-                auto uvwh = fp2d{ uw, vh };
-                auto final_frag_sz = orig_full_sz_fp * uvwh; // Rendered fragment size (float).
-                wh *= cellsz;
-                auto bounding_rect_pixels = std::round(wh); // Document bounding box size in pixels.
-                image.bitmap.xy = twod{ std::round(fp2d{ x, y } * cellsz) };
+                std::swap(bounding_rect_pixels.x, bounding_rect_pixels.y);
+            }
+            auto ratio = bounding_rect_pixels / final_frag_sz;
+            auto scale = fp2d{ dot_11 };
+            switch ((si32)fit)
+            {
+                case scale_mode::none:    /*final_frag_sz = final_frag_sz;*/ break;
+                case scale_mode::inside:  { auto _k = std::min(ratio.x, ratio.y); scale = { _k, _k }; final_frag_sz *= _k; } break;
+                case scale_mode::outside: { auto _k = std::max(ratio.x, ratio.y); scale = { _k, _k }; final_frag_sz *= _k; } break;
+                case scale_mode::stretch: scale = bounding_rect_pixels / final_frag_sz; final_frag_sz = bounding_rect_pixels; break;
+            }
+            // Apply system limits.
+            auto px_limits = std::max(dot_11, skin::globals().max_value * cellsz);
+            final_frag_sz = std::clamp(final_frag_sz, fp2d{ dot_11 }, fp2d{ px_limits });
 
-                if ((si32)tr & 1)
-                {
-                    std::swap(bounding_rect_pixels.x, bounding_rect_pixels.y);
-                }
-                auto ratio = bounding_rect_pixels / final_frag_sz;
-                auto scale = fp2d{ dot_11 };
-                switch ((si32)fit)
-                {
-                    case scale_mode::none:    /*final_frag_sz = final_frag_sz;*/ break;
-                    case scale_mode::inside:  { auto _k = std::min(ratio.x, ratio.y); scale = { _k, _k }; final_frag_sz *= _k; } break;
-                    case scale_mode::outside: { auto _k = std::max(ratio.x, ratio.y); scale = { _k, _k }; final_frag_sz *= _k; } break;
-                    case scale_mode::stretch: scale = bounding_rect_pixels / final_frag_sz; final_frag_sz = bounding_rect_pixels; break;
-                }
-                // Apply system limits.
-                auto px_limits = std::max(dot_11, skin::globals().max_value * cellsz);
-                final_frag_sz = std::clamp(final_frag_sz, fp2d{ dot_11 }, fp2d{ px_limits });
-                //image.bitmap.final_frag_sz = final_frag_sz;
+            static thread_local auto full_doc_tmp_buffer = netxs::sprite{ *std::pmr::new_delete_resource() };
+            bitmap.scaled_fragment_area = rect{ dot_00, std::ceil(final_frag_sz) };
+            full_doc_tmp_buffer.set_area<irgb>(bitmap.scaled_fragment_area);
+            auto tmp_document_block = full_doc_tmp_buffer.raster<irgb>();
+            tmp_document_block.zeroize();
+            auto offset_inside_document = uv * orig_full_sz_fp * scale;
+            rasterize_svg_DOM(tmp_document_block, dom, scale, offset_inside_document, sub_id);
 
-                static thread_local auto full_doc_tmp_buffer = netxs::sprite{ *std::pmr::new_delete_resource() };
-                image.bitmap.scaled_fragment_area = rect{ dot_00, std::ceil(final_frag_sz) };
-                full_doc_tmp_buffer.set_area<irgb>(image.bitmap.scaled_fragment_area);
-                auto tmp_document_block = full_doc_tmp_buffer.raster<irgb>();
-                tmp_document_block.zeroize();
-                auto offset_inside_document = uv * orig_full_sz_fp * scale;
-                rasterize_svg_DOM(tmp_document_block, image.dom, scale, offset_inside_document, image.sub_id);
-
-                // Trim all transparent pixels.
-                auto nested_fragment_area = full_doc_tmp_buffer.get_minimal_non_transparent_area_for_pma<irgb>();
-                image.bitmap.fragment.set_area<irgb>(nested_fragment_area);
-                if (nested_fragment_area)
-                {
-                    auto dst_fragment_block = image.bitmap.fragment.raster<irgb>();
-                    netxs::onbody(tmp_document_block, dst_fragment_block, [](auto& src, auto& dst){ dst = src; });
-                }
+            // Trim all transparent pixels.
+            auto nested_fragment_area = full_doc_tmp_buffer.get_minimal_non_transparent_area_for_pma<irgb>();
+            bitmap.fragment.set_area<irgb>(nested_fragment_area);
+            if (nested_fragment_area)
+            {
+                auto dst_fragment_block = bitmap.fragment.raster<irgb>();
+                netxs::onbody(tmp_document_block, dst_fragment_block, [](auto& src, auto& dst){ dst = src; });
             }
         }
         void draw_glyph(auto& canvas, sprite& glyph_mask, twod offset, argb fgc, bool semi_transparent = faux)
@@ -2530,9 +2522,9 @@ namespace netxs::gui
                 netxs::onclip(canvas, raster, fx);
             }
         }
-        void draw_image(auto& canvas, imagens::image& image, twod offset, argb fgc, bool semi_transparent, si32 xform)
+        void draw_image(auto& canvas, imagens::image::bitmap_t& bitmap, twod offset, argb fgc, bool semi_transparent, si32 xform)
         {
-            auto& image_mask = image.bitmap.fragment;
+            auto& image_mask = bitmap.fragment;
             auto f_fgc = irgb::nonpma_srgb_to_pma_linear(fgc);
             auto global_alpha = semi_transparent ? 0.5f : 1.0f; // Triggers on SGR 7 (reverse video).
             assert(image_mask.type == sprite::color);
@@ -2553,7 +2545,7 @@ namespace netxs::gui
             };
             // xform on write
             auto canvas_clip = canvas.clip(); // Cell placeholder.
-            auto document_area = image.bitmap.scaled_fragment_area.shift(offset); // Raster inside the document fragment.
+            auto document_area = bitmap.scaled_fragment_area.shift(offset); // Raster inside the document fragment.
             netxs::xform_render(canvas, canvas_clip, raster, document_area, xform, fx);
         }
         auto render_image(auto& canvas, rect placeholder, argb fgc, cell const& c)
@@ -2565,9 +2557,18 @@ namespace netxs::gui
                 if (auto image_ptr = images.exists(image_index)) // We form all image requests on dtvt recv stage.
                 {
                     auto& image = *image_ptr;
+                    //todo iterate over layers
+                    //...
                     if (image.bitmap.fragment.type == sprite::undef && image.document.size())
                     {
-                        rasterize_svg_document(image);
+                        if (!image.dom[0])
+                        {
+                            image.dom = generate_DOM(image.document);
+                        }
+                        if (image.dom[0])
+                        {
+                            rasterize_svg_document(image.bitmap, image.dom, image.sub_id, image.gb_attrs);
+                        }
                     }
                     if (image.bitmap.fragment.area)
                     {
@@ -2601,7 +2602,7 @@ namespace netxs::gui
                         // Rendering.
                         image_cr = (image_cr - dot_11) * cellsz;
                         auto offset = placeholder.coor - image_cr + image.bitmap.xy + fragment_area_coor;
-                        draw_image(canvas, image, offset, fgc, c.inv(), image_xform);
+                        draw_image(canvas, image.bitmap, offset, fgc, c.inv(), image_xform);
                     }
                 }
             }

--- a/src/netxs/desktopio/gui.hpp
+++ b/src/netxs/desktopio/gui.hpp
@@ -3107,10 +3107,9 @@ namespace netxs::gui
                 auto hit = s11n::remove_image_indexes(images, image.indexes);
                 if (hit)
                 {
-                    if (owner.remove_image_bits(image.indexes))
-                    {
-                        netxs::set_flag<task::all>(owner.reload); // Trigger to redraw all to update unknown images.
-                    }
+                    owner.remove_image_bits(image.indexes);
+                    // Always re-render viewport because of layers.
+                    netxs::set_flag<task::all>(owner.reload); // Trigger to redraw all to update unknown images.
                 }
             }
             void handle(s11n::xs::update_img_request  lock)

--- a/src/netxs/desktopio/gui.hpp
+++ b/src/netxs/desktopio/gui.hpp
@@ -3126,7 +3126,11 @@ namespace netxs::gui
                     if (auto image_ptr = images.map[image_index])
                     {
                         auto& image = *image_ptr;
-                        image.set_changes(image_data.changed_bits, image_data.changes, owner.cellsz);
+                        auto layers_updated = image.set_changes(image_data.changed_bits, image_data.changes, owner.cellsz);
+                        if (layers_updated)
+                        {
+                            s11n::translate_layers(images, image, is_remote);
+                        }
                         if (owner.update_image_bits(image_index))
                         {
                             //todo optimize: scan bitmap_dtvt

--- a/src/netxs/desktopio/intmath.hpp
+++ b/src/netxs/desktopio/intmath.hpp
@@ -18,6 +18,7 @@
 #include <coroutine>
 #include <cstring> // std::memcpy
 #include <deque>
+#include <execution>
 #include <filesystem>
 #include <fstream>
 #include <functional>

--- a/src/netxs/desktopio/intmath.hpp
+++ b/src/netxs/desktopio/intmath.hpp
@@ -223,6 +223,12 @@ namespace netxs
     {
         n = (n & ~(1 << P)) | (v << P);
     }
+    // intmath: Get a single p-bit to v.
+    template<sz_t P, class T>
+    auto get_bit(T&& n)
+    {
+        return n & (1 << P);
+    }
     // intmath: Set a single bit specified by F.
     template<auto F, class T>
     void set_flag(T&& n, bool v = true)

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -7521,6 +7521,7 @@ namespace netxs::ui
                         if (l_iter != image_cache.end()) // Process registered images only.
                         {
                             auto image_ptr = l_iter->second;
+                            layer.index = image_ptr->index;
                             layer.image_wptr = image_ptr;
                             layers.emplace_back(std::move(layer));
                         }
@@ -7673,11 +7674,14 @@ namespace netxs::ui
                 auto different_image_attrs = [&]
                 {
                     auto& image = *iter->second;
-                    auto changed = faux;
-                    for (auto i = 0u; i < image.gb_attrs.size(); i++)
+                    auto changed = layers.size();
+                    if (!changed)
                     {
-                        changed |= image.gb_attrs[i] != gb_attrs[i];
-                        if (changed) break;
+                        for (auto i = 0u; i < image.gb_attrs.size(); i++)
+                        {
+                            changed |= image.gb_attrs[i] != gb_attrs[i];
+                            if (changed) break;
+                        }
                     }
                     return changed || (doc_str && image.document != doc_str)
                                    || (image.sub_id != sub_id_str);
@@ -7699,14 +7703,14 @@ namespace netxs::ui
                 if (iter != image_cache.end() && same_doc_and_raster()) // Move existing image.
                 {
                     auto& image = *iter->second;
-                    image.updated_layers = layers.size();
-                    if (image.updated_layers)
+                    auto updated_layers = layers.size();
+                    if (updated_layers)
                     {
                         image.layers = std::move(layers);
                     }
                     image.reset_changes();
-                    image.check_and_set_attr(gb_attrs);
-                    if (image.changed_gb_attrs || image.updated_layers)
+                    image.check_and_set_attr(gb_attrs, updated_layers);
+                    if (image.changed_gb_attrs || image.document_changed)
                     {
                         image.stamp += 2;
                         base::signal(tier::general, e2::data::image::update, image.index);
@@ -7715,8 +7719,8 @@ namespace netxs::ui
                 else if (iter != image_cache.end() && different_image_attrs()) // Update existing image.
                 {
                     auto& image = *iter->second;
-                    image.updated_layers = layers.size();
-                    if (image.updated_layers)
+                    auto updated_layers = layers.size();
+                    if (updated_layers)
                     {
                         image.layers = std::move(layers);
                     }
@@ -7724,8 +7728,8 @@ namespace netxs::ui
                     image.bitmap.reset(); // Request to re-rasterize.
                     image.reset_changes();
                     image.check_and_set_document(doc_str, sub_id_str);
-                    image.check_and_set_attr(gb_attrs);
-                    if (image.changed_gb_attrs || image.document_changed || image.updated_layers)
+                    image.check_and_set_attr(gb_attrs, updated_layers);
+                    if (image.changed_gb_attrs || image.document_changed)
                     {
                         image.stamp += 2;
                         base::signal(tier::general, e2::data::image::update, image.index);
@@ -9762,7 +9766,11 @@ namespace netxs::ui
                     if (auto image_ptr = images.map[image_index])
                     {
                         auto& image = *image_ptr;
-                        image.set_changes(image_data.changed_bits, image_data.changes);
+                        auto layers_updated = image.set_changes(image_data.changed_bits, image_data.changes);
+                        if (layers_updated)
+                        {
+                            s11n::translate_layers(images, image, is_remote);
+                        }
                         owner.update_image_bits(image_index);
                         owner.base::enqueue([&, image_index](auto& /*boss*/) // To avoid deadlock under cell::images.
                         {

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -7561,9 +7561,10 @@ namespace netxs::ui
                 {
                     auto image_ptr = iter->second;
                     auto& image = *image_ptr;
+                    auto removed_image_indexes = e2::data::image::remove.param({ image.index });
                     image_cache.erase(iter);
                     images.remove(image.index);
-                    base::signal(tier::general, e2::data::image::remove, { image.index });
+                    base::signal(tier::general, e2::data::image::remove, removed_image_indexes);
                     if (io_log) log("%%Embedded object '%%' successfully unregistered", prompt::term, image.id);
                 }
             }

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -1360,6 +1360,8 @@ namespace netxs::ui
             rich  tail_frag; // bufferbase: IRM cached fragment.
             rich  char_2d; // bufferbase: 2D char image.
 
+            hook image_update_token;
+
             bufferbase(term& master)
                 : owner{ master },
                   panel{ dot_11 },
@@ -1380,8 +1382,13 @@ namespace netxs::ui
                   alive{ 0      }
             {
                 parser::style = ansi::def_style;
+                owner.LISTEN(tier::general, e2::data::image::remove, image_index, image_update_token)
+                {
+                    wipe_image_index(image_index);
+                };
             }
 
+            virtual void wipe_image_index(ui16 index) = 0;
             // bufferbase: Make a viewport screen copy.
             virtual void do_viewport_copy(face& dest) = 0;
 
@@ -3182,6 +3189,11 @@ namespace netxs::ui
                 bufferbase::uirev = faux;
                 bufferbase::uifwd = faux;
                 return bufferbase::selection_cancel();
+            }
+            // alt_screen: Remove all references to the image from the scrollback.
+            void wipe_image_index(ui16 removed_image_index) override
+            {
+                canvas.remove_image_bits(removed_image_index);
             }
         };
 
@@ -7143,6 +7155,21 @@ namespace netxs::ui
                     reverse_is_available = uirev ? 1 << 1 : 0;
                 }
                 return forward_is_available | reverse_is_available;
+            }
+            // scroll_buf: Remove all references to the image from the scrollback.
+            void wipe_image_index(ui16 removed_image_index) override
+            {
+                upbox.remove_image_bits(removed_image_index);
+                dnbox.remove_image_bits(removed_image_index);
+                auto wipe_batch = [&](auto policy) // Try to parallelize.
+                {
+                    std::for_each(policy, batch.begin(), batch.end(), [removed_image_index](auto& l)
+                    {
+                        l.remove_image_bits(removed_image_index);
+                    });
+                };
+                batch.length() > 100000 ? wipe_batch(std::execution::par)
+                                        : wipe_batch(std::execution::seq);
             }
         };
 

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -1382,13 +1382,16 @@ namespace netxs::ui
                   alive{ 0      }
             {
                 parser::style = ansi::def_style;
-                owner.LISTEN(tier::general, e2::data::image::remove, image_index, image_update_token)
+                owner.LISTEN(tier::general, e2::data::image::remove, image_indexes, image_update_token)
                 {
-                    wipe_image_index(image_index);
+                    if (owner.image_alive)
+                    {
+                        wipe_image_index(image_indexes);
+                    }
                 };
             }
 
-            virtual void wipe_image_index(ui16 index) = 0;
+            virtual void wipe_image_index(std::vector<ui16>& indexes) = 0;
             // bufferbase: Make a viewport screen copy.
             virtual void do_viewport_copy(face& dest) = 0;
 
@@ -3191,9 +3194,9 @@ namespace netxs::ui
                 return bufferbase::selection_cancel();
             }
             // alt_screen: Remove all references to the image from the scrollback.
-            void wipe_image_index(ui16 removed_image_index) override
+            void wipe_image_index(std::vector<ui16>& removed_image_indexes) override
             {
-                canvas.remove_image_bits(removed_image_index);
+                canvas.remove_image_bits(removed_image_indexes);
             }
         };
 
@@ -7157,15 +7160,15 @@ namespace netxs::ui
                 return forward_is_available | reverse_is_available;
             }
             // scroll_buf: Remove all references to the image from the scrollback.
-            void wipe_image_index(ui16 removed_image_index) override
+            void wipe_image_index(std::vector<ui16>& removed_image_indexes) override
             {
-                upbox.remove_image_bits(removed_image_index);
-                dnbox.remove_image_bits(removed_image_index);
+                upbox.remove_image_bits(removed_image_indexes);
+                dnbox.remove_image_bits(removed_image_indexes);
                 auto wipe_batch = [&](auto policy) // Try to parallelize.
                 {
-                    std::for_each(policy, batch.begin(), batch.end(), [removed_image_index](auto& l)
+                    std::for_each(policy, batch.begin(), batch.end(), [&](auto& l)
                     {
-                        l.remove_image_bits(removed_image_index);
+                        l.remove_image_bits(removed_image_indexes);
                     });
                 };
                 batch.length() > 100000 ? wipe_batch(std::execution::par)
@@ -7221,6 +7224,7 @@ namespace netxs::ui
         ui64       session_token; // term: Interactive session token.
         utf::unordered_map<text, netxs::sptr<imagens::image>> image_cache; // term: Image cache.
         face                                                  image_buffer; // term: Image temporary buffer.
+        bool                                                  image_alive{ true }; // term: Indicator for whether to clear images in the scrollback.
         vtty       ipccon; // term: IPC connector. Should be destroyed first.
 
         // term: Print the block to the scrollback buffer with scroll.
@@ -7559,7 +7563,7 @@ namespace netxs::ui
                     auto& image = *image_ptr;
                     image_cache.erase(iter);
                     images.remove(image.index);
-                    base::signal(tier::general, e2::data::image::remove, image.index);
+                    base::signal(tier::general, e2::data::image::remove, { image.index });
                     if (io_log) log("%%Embedded object '%%' successfully unregistered", prompt::term, image.id);
                 }
             }
@@ -8961,6 +8965,26 @@ namespace netxs::ui
         }
 
     public:
+        ~term()
+        {
+            image_alive = faux;
+            if (image_cache.size()) // Signal to wipe all image references.
+            {
+                auto images = cell::images(); // Lock.
+                auto removed_image_indexes = e2::data::image::remove.param();
+                removed_image_indexes.reserve(image_cache.size());
+                for (auto& [image_id, image_ptr] : image_cache) if (image_ptr)
+                {
+                    auto removed_index = image_ptr->index;
+                    removed_image_indexes.push_back(removed_index);
+                    images.remove(removed_index);
+                }
+                if (removed_image_indexes.size())
+                {
+                    base::signal(tier::general, e2::data::image::remove, removed_image_indexes);
+                }
+            }
+        }
         term()
             : defcfg{ bell::indexer.config },
               normal{ *this },
@@ -9736,22 +9760,16 @@ namespace netxs::ui
             void handle(s11n::xs::remove_img_request  lock)
             {
                 auto& image = lock.thing;
-                image.index &= 0xFFFF;
-                if (image.index)
+                auto images = cell::images(); // Lock.
+                auto hit = s11n::remove_image_indexes(images, image.indexes);
+                if (hit)
                 {
-                    auto images = cell::images(); // Lock.
-                    auto is_remote = s11n::nat[0];
-                    auto image_index = is_remote ? std::exchange(s11n::nat[image.index], 0) : image.index;
-                    if (image_index)
+                    owner.remove_image_bits(image.indexes);
+                    owner.base::enqueue([&, image_indexes = std::move(image.indexes)](auto& /*boss*/) // To avoid deadlock under cell::images.
                     {
-                        images.map[image_index] = {};
-                        owner.remove_image_bits(image_index);
-                        owner.base::enqueue([&, image_index](auto& /*boss*/) // To avoid deadlock under cell::images.
-                        {
-                            owner.base::signal(tier::general, e2::data::image::remove, image_index);
-                            owner.base::deface();
-                        });
-                    }
+                        owner.base::signal(tier::general, e2::data::image::remove, image_indexes);
+                        owner.base::deface();
+                    });
                 }
             }
             void handle(s11n::xs::update_img_request  lock)
@@ -10121,18 +10139,11 @@ namespace netxs::ui
             ipccon.run_dtvt_app(appcfg, base::size(), connect_fx, receiver_fx, shutdown_fx);
         }
         // dtvt: Drop removed image metadata from canvas.
-        void remove_image_bits(ui16 removed_image_index)
+        void remove_image_bits(std::vector<ui16>& removed_image_indexes)
         {
             auto bitmap_lock = stream.bitmap_dtvt.freeze();
             auto& grid = bitmap_lock.thing.image;
-            for (auto& c : grid)
-            {
-                auto image_index = c.get_image_index();
-                if (image_index == removed_image_index)
-                {
-                    c.reset_px(); // Drop all image metadata.
-                }
-            }
+            grid.remove_image_bits(removed_image_indexes);
         }
         // dtvt: Drop removed image metadata from canvas.
         void update_image_bits(ui16 updated_image_index)
@@ -10217,6 +10228,26 @@ namespace netxs::ui
             else                parent_canvas.fill(canvas, cell::shaders::transparent(opaque));
         }
 
+        ~dtvt()
+        {
+            // Signal to wipe all image references.
+            auto is_remote = std::exchange(stream.s11n::nat[0], 0);
+            if (is_remote) // Is remote.
+            {
+                auto images = cell::images(); // Lock.
+                auto removed_image_indexes = e2::data::image::remove.param();
+                removed_image_indexes.reserve(stream.s11n::nat.size());
+                for (auto removed_index : stream.s11n::nat) if (removed_index)
+                {
+                    removed_image_indexes.push_back(removed_index);
+                    images.remove(removed_index);
+                }
+                if (removed_image_indexes.size())
+                {
+                    base::signal(tier::general, e2::data::image::remove, removed_image_indexes);
+                }
+            }
+        }
         dtvt()
             : stream{*this },
               active{ true },

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -7679,7 +7679,8 @@ namespace netxs::ui
                         changed |= image.gb_attrs[i] != gb_attrs[i];
                         if (changed) break;
                     }
-                    return changed || (doc_str && image.document != doc_str);
+                    return changed || (doc_str && image.document != doc_str)
+                                   || (image.sub_id != sub_id_str);
                 };
                 auto same_doc_and_raster = [&]
                 {
@@ -7690,6 +7691,7 @@ namespace netxs::ui
                             && (image.gb_attrs[imagens::gb::h  ] == gb_attrs[imagens::gb::h  ])
                             && (image.gb_attrs[imagens::gb::fit] == gb_attrs[imagens::gb::fit])
                             && (((si32)image.gb_attrs[imagens::gb::tr ] & 1) == ((si32)gb_attrs[imagens::gb::tr ] & 1)) // Same orientation.
+                            && (image.sub_id == sub_id_str)
                             && (!doc_str || image.document == doc_str);
                     return ret;
                 };
@@ -7721,9 +7723,9 @@ namespace netxs::ui
                     image.changed_gb_attrs = {};
                     image.bitmap.reset(); // Request to re-rasterize.
                     image.reset_changes();
-                    image.check_and_set_document(doc_str);
+                    image.check_and_set_document(doc_str, sub_id_str);
                     image.check_and_set_attr(gb_attrs);
-                    if (image.changed_gb_attrs || image.updated_layers)
+                    if (image.changed_gb_attrs || image.document_changed || image.updated_layers)
                     {
                         image.stamp += 2;
                         base::signal(tier::general, e2::data::image::update, image.index);

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -7396,6 +7396,7 @@ namespace netxs::ui
             auto unregister = faux;
             auto new_gb_attrs = imagens::image::opt_gb_attrs_t{};
             auto new_lc_attrs = imagens::image::opt_lc_attrs_t{};
+            auto layers = std::vector<imagens::image::layer_t>{};
             // data: " id + attrs + doc"              Find by id and update/register and print.
             //       " [attrs] + doc "                Register empty id.
             //       " [id] "                         Find by id and print.
@@ -7406,47 +7407,54 @@ namespace netxs::ui
                 if (attrs_str.front() == '<') // Extract document body <tag1 ...> ... </tag2>
                 {
                     auto closing_bracket_pos = attrs_str.rfind('>'); // Fing the last '>' in the string.
-                    doc_str = attrs_str.substr(0, closing_bracket_pos + 1);
-                    attrs_str.remove_prefix(doc_str.size());
-                    // Check if document is empty.
-                    auto tmp = doc_str;
-                    tmp.pop_front(); // Pop  '<'.
-                    auto tag = utf::take_front<faux>(tmp, netxs::whitespaces_and<'>'>);
-                    if (tag || (tmp && tmp.front() == '>')) // 'tag>' or 'tag ...'
+                    if (closing_bracket_pos == text::npos)
                     {
-                        auto degenerate_doc = text{};
-                        degenerate_doc.reserve(5 + tag.size() * 2); // "<" + tag + "></" + tag + ">"
-                        degenerate_doc += '<';
-                        degenerate_doc += tag;
-                        degenerate_doc += "></";
-                        degenerate_doc += tag;
-                        degenerate_doc += '>';
-                        unregister = doc_str == degenerate_doc;
-                        if (unregister) doc_str = {};
+                        attrs_str = {};
+                        if (io_log) log("%%Broken 'OSC object' document (no closing bracket)", prompt::term);
                     }
                     else
                     {
-                        if (io_log) log("%%Broken 'OSC object' document (invalid structure)", prompt::term);
+                        doc_str = attrs_str.substr(0, closing_bracket_pos + 1);
+                        attrs_str.remove_prefix(doc_str.size());
+                        // Check if document is empty.
+                        auto tmp = doc_str;
+                        tmp.pop_front(); // Pop  '<'.
+                        auto tag = utf::take_front<faux>(tmp, netxs::whitespaces_and<'>'>);
+                        if (tag || (tmp && tmp.front() == '>')) // 'tag>' or 'tag ...'
+                        {
+                            auto degenerate_doc = text{};
+                            degenerate_doc.reserve(5 + tag.size() * 2); // "<" + tag + "></" + tag + ">"
+                            degenerate_doc += '<';
+                            degenerate_doc += tag;
+                            degenerate_doc += "></";
+                            degenerate_doc += tag;
+                            degenerate_doc += '>';
+                            unregister = doc_str == degenerate_doc;
+                            if (unregister) doc_str = {};
+                        }
+                        else
+                        {
+                            if (io_log) log("%%Broken 'OSC object' document (invalid structure)", prompt::term);
+                        }
                     }
                 }
                 else // Parse attributes.
                 {
-                    auto [attr_str, value_str] = utf::get_pair<'='>(attrs_str, netxs::whitespaces_and<'='>, netxs::whitespaces_and<' ', '<'>); // "... key=val<svg...>...</svg>"
+                    auto get_key_val = [](qiew& attrs_str)
+                    {
+                        return utf::get_pair<'='>(attrs_str, netxs::whitespaces_and<'='>, netxs::whitespaces_and<'(', '<'>); // "... key=val<svg...>...</svg>"
+                    };
                     //todo sub-id: id=qqq/www
-                    if (attr_str == "id") // id="string/string".
+                    auto take_id = [](qiew& value_str, auto& id_str, auto& sub_id_str)
                     {
                         id_str = utf::take_front<faux>(value_str, " /\\");
                         utf::trim_front(value_str, " /\\");
                         sub_id_str = value_str;
-                    }
-                    else if (attr_str == "gc") // gc="string". Grapheme cluster used to fill image area.
+                    };
+                    auto parse_gb_pair = [](qiew& attr_str, qiew value_str, auto& new_gb_attrs)
                     {
-                        gc_opt = value_str;
-                    }
-                    else // Regular attributes (si32 or dict).
-                    {
-                        if constexpr (debugmode) log(" attr_str=%%, value_str=%%", attr_str, value_str);
-                        if (auto gb = imagens::parse_pair(attr_str, value_str, imagens::gb::attr_index_map, imagens::gb_value_index_map))
+                        auto gb = imagens::parse_pair(attr_str, value_str, imagens::gb::attr_index_map, imagens::gb_value_index_map);
+                        if (gb)
                         {
                             auto [i, v] = gb.value();
                             auto& xform_ref = new_gb_attrs[imagens::gb::tr];
@@ -7469,11 +7477,73 @@ namespace netxs::ui
                             }
                             if constexpr (debugmode) log("  new_gb_attrs[%%]=%%", i, v);
                         }
-                        else if (auto lc = imagens::parse_pair(attr_str, value_str, imagens::lc::attr_index_map, imagens::lc_value_index_map))
+                        return !!gb;
+                    };
+
+                    auto [attr_str, value_str] = get_key_val(attrs_str);
+                    if (attr_str == "id") // id="string/string".
+                    {
+                        take_id(value_str, id_str, sub_id_str);
+                    }
+                    else if (attr_str == "l") // l="parent_id/sub_id"(parent_gb_attrs). Inherited image layer with overridden attributes.
+                    {
+                        auto layer_id = qiew{};
+                        auto layer_sub_id = qiew{};
+                        take_id(value_str, layer_id, layer_sub_id); // Take id/sub_id.
+                        auto layer = imagens::image::layer_t{};
+                        layer.id = layer_id;
+                        layer.sub_id = layer_sub_id;
+                        utf::trim_front(attrs_str, netxs::whitespaces);
+                        if (attrs_str && attrs_str.front() == '(' && attrs_str.size() > 1) // Parse overridden attributes.
                         {
-                            auto [i, v] = lc.value();
-                            new_lc_attrs[i] = v;
-                            if constexpr (debugmode) log("  new_lc_attrs[%%]=%%", i, v);
+                            attrs_str.pop_front(); // Pop  '('.
+                            auto closing_parenthesis_pos = attrs_str.find(')'); // Fing the last '>' in the string.
+                            auto layer_attrs_str = attrs_str.substr(0, closing_parenthesis_pos);
+                            if (closing_parenthesis_pos == text::npos)
+                            {
+                                attrs_str = {};
+                            }
+                            else
+                            {
+                                attrs_str.remove_prefix(layer_attrs_str.size() + 1);
+                            }
+                            while (layer_attrs_str)
+                            {
+                                auto [key_str, val_str] = get_key_val(layer_attrs_str);
+                                if (!parse_gb_pair(key_str, val_str, layer.opt_attrs))
+                                {
+                                    if (io_log) log("%%Unknown layer's key=val pair: '%%'='%%'", prompt::term, key_str, val_str);
+                                }
+                                utf::trim_front(layer_attrs_str, netxs::whitespaces);
+                            }
+                        }
+                        auto l_iter = image_cache.find(layer_id);
+                        if (l_iter != image_cache.end()) // Process registered images only.
+                        {
+                            auto image_ptr = l_iter->second;
+                            layer.image_wptr = image_ptr;
+                            layers.emplace_back(std::move(layer));
+                        }
+                        else
+                        {
+                            if (io_log) log("%%Unknown object reference: '%%%%%%'", prompt::term, layer_id, layer_sub_id ? "/" : "", layer_sub_id);
+                        }
+                    }
+                    else if (attr_str == "gc") // gc="string". Grapheme cluster used to fill image area.
+                    {
+                        gc_opt = value_str;
+                    }
+                    else // Regular attributes (si32 or dict).
+                    {
+                        if constexpr (debugmode) log(" attr_str=%%, value_str=%%", attr_str, value_str);
+                        if (!parse_gb_pair(attr_str, value_str, new_gb_attrs))
+                        {
+                            if (auto lc = imagens::parse_pair(attr_str, value_str, imagens::lc::attr_index_map, imagens::lc_value_index_map))
+                            {
+                                auto [i, v] = lc.value();
+                                new_lc_attrs[i] = v;
+                                if constexpr (debugmode) log("  new_lc_attrs[%%]=%%", i, v);
+                            }
                         }
                     }
                 }
@@ -7550,6 +7620,47 @@ namespace netxs::ui
                 h = std::isnormal(h) ? std::clamp(h, 0.001f, (fp32)max_size.y) : _H;
                 auto c = std::clamp((si32)_c, 0, (si32)_W);
                 auto r = std::clamp((si32)_r, 0, (si32)_H);
+                for (auto& l : layers) // Normalize layers.
+                {
+                    auto& l_w  = l.opt_attrs[imagens::gb::w ];
+                    auto& l_h  = l.opt_attrs[imagens::gb::h ];
+                    auto& l_uw = l.opt_attrs[imagens::gb::uw];
+                    auto& l_vh = l.opt_attrs[imagens::gb::vh];
+                    auto& l_tr = l.opt_attrs[imagens::gb::tr];
+                    if (l_uw)
+                    {
+                        if (l_uw == 0.f) l_uw = 1.f;
+                        else if (l_uw < 0.f)
+                        {
+                            l_uw = -l_uw.value();
+                            if (!l_tr) l_tr = 0.f;
+                            imagens::mirror_fx(l_tr.value(), imagens::flips::hz);
+                        }
+                    }
+                    if (l_vh)
+                    {
+                        if (l_vh == 0.f) l_vh = 1.f;
+                        else if (l_vh < 0.f)
+                        {
+                            l_vh = -l_vh.value();
+                            if (!l_tr) l_tr = 0.f;
+                            imagens::mirror_fx(l_tr.value(), imagens::flips::vt);
+                        }
+                    }
+                    if (l_w && std::isnormal(l_w.value())) l_w = std::clamp(l_w.value(), 0.001f, (fp32)max_size.x); else l_w = std::nullopt;
+                    if (l_h && std::isnormal(l_h.value())) l_h = std::clamp(l_h.value(), 0.001f, (fp32)max_size.y); else l_h = std::nullopt;
+                    if constexpr (debugmode)
+                    {
+                        if (auto l_image_ptr = l.image_wptr.lock())
+                        {
+                            log("layer: id='%%' subid='%%' index='%%'", l.id, l.sub_id, l_image_ptr->index);
+                            for (auto i = 0u; i < l.opt_attrs.size(); i++)
+                            {
+                                if (l.opt_attrs[i]) log(" attr_str=%%, value_str=%%", imagens::gb::names[i], l.opt_attrs[i].value());
+                            }
+                        }
+                    }
+                }
 
                 auto gc_str = gc_opt ? gc_opt.value() : " ";
                 auto brush = cell{ target->brush }.txt(gc_str, 1, 1, 1, 1); //todo make the character geometry configurable
@@ -7586,9 +7697,14 @@ namespace netxs::ui
                 if (iter != image_cache.end() && same_doc_and_raster()) // Move existing image.
                 {
                     auto& image = *iter->second;
+                    image.updated_layers = layers.size();
+                    if (image.updated_layers)
+                    {
+                        image.layers = std::move(layers);
+                    }
                     image.reset_changes();
                     image.check_and_set_attr(gb_attrs);
-                    if (image.changed_gb_attrs)
+                    if (image.changed_gb_attrs || image.updated_layers)
                     {
                         image.stamp += 2;
                         base::signal(tier::general, e2::data::image::update, image.index);
@@ -7597,12 +7713,17 @@ namespace netxs::ui
                 else if (iter != image_cache.end() && different_image_attrs()) // Update existing image.
                 {
                     auto& image = *iter->second;
+                    image.updated_layers = layers.size();
+                    if (image.updated_layers)
+                    {
+                        image.layers = std::move(layers);
+                    }
                     image.changed_gb_attrs = {};
                     image.bitmap.reset(); // Request to re-rasterize.
                     image.reset_changes();
                     image.check_and_set_document(doc_str);
                     image.check_and_set_attr(gb_attrs);
-                    if (image.changed_gb_attrs)
+                    if (image.changed_gb_attrs || image.updated_layers)
                     {
                         image.stamp += 2;
                         base::signal(tier::general, e2::data::image::update, image.index);
@@ -7614,7 +7735,8 @@ namespace netxs::ui
                     auto image_ptr = ptr::shared(imagens::image{ .id       = id_str,
                                                                  .sub_id   = sub_id_str,
                                                                  .document = doc_str,
-                                                                 .gb_attrs = gb_attrs });
+                                                                 .gb_attrs = gb_attrs,
+                                                                 .layers   = std::move(layers) });
                     if (auto image_index = images.set(image_ptr))
                     {
                         image_ptr->index = image_index;

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -7598,7 +7598,7 @@ namespace netxs::ui
                 {
                     auto& image = *iter->second;
                     image.changed_gb_attrs = {};
-                    image.reset_raster(); // Request to re-rasterize.
+                    image.bitmap.reset(); // Request to re-rasterize.
                     image.reset_changes();
                     image.check_and_set_document(doc_str);
                     image.check_and_set_attr(gb_attrs);


### PR DESCRIPTION
### Changes

- __This release is not compatible with previous releases.__
- [AnyPlex Protocol](https://github.com/directvt/vtm/blob/v2026.04.18/doc/anyplex.md), (tracked in #902):
  - Implement image layering (recursive rendering is not implemented yet).
  - Fix deletion of image references in the terminal scrollback.

#### Attribute Scoping

Attributes are divided into **Shared** (object-wide), **Layer** (layer specific) and **Unique** (per-instance/cell).

- **Shared Attributes**: `l`, `u`, `v`, `uw`, `vh`, `x`, `y`, `w`, `h`, `fit`, `rt`, `a`, `f`, `o`. Global to all instances of the `id`.
- **Layer Attributes**: All Shared attributes can be overridden per layer inside `l=id(key=val)`.
- **Unique Attributes**: `W`, `H`, `r`, `c`, `gc`. Specific to the instance and the grid slice.

#### Attributes

Attribute  | Scope  | Value/Range                      | Default                  | Description
-----------|--------|----------------------------------|--------------------------|------------
**l**      | Shared | `<id>[/sub-id][(<layer attrs>)]` | empty string (`""`)      | Adds a layer. Can be specified multiple times.