### PR TITLE
Fix issues with building on non-win32 platforms (std::execution)

### DIFF
--- a/src/netxs/apps/desk.hpp
+++ b/src/netxs/apps/desk.hpp
@@ -1018,12 +1018,12 @@ namespace netxs::app::desk
                 input::bindings::keybind(boss, bindings);
                 boss.base::add_methods(basename::taskbar,
                 {
-                    { "FocusNextItem",      [&] // (si32 n, si32 min_w, si32 max_w = si32max)
+                    { "FocusNextItem",      [&] // (si32 n, si32 min_w, si32 max_w = netxs::si32max)
                                             {
                                                 auto& gear = luafx.get_gear();
                                                 auto count = luafx.get_args_or(1, si32{ 1 });
                                                 auto min_w = luafx.get_args_or(2, si32{ 0 });
-                                                auto max_w = luafx.get_args_or(3, si32max);
+                                                auto max_w = luafx.get_args_or(3, netxs::si32max);
                                                 focus.for_first_focused_leaf(gear, [&](auto& focused_item)
                                                 {
                                                     auto& item_focus = focused_item.base::template plugin<pro::focus>(); //todo Apple clang requires template

--- a/src/netxs/apps/tile.hpp
+++ b/src/netxs/apps/tile.hpp
@@ -171,7 +171,7 @@ namespace netxs::app::tile
             {
                 if (window_state == winstate::normal)
                 {
-                    auto context2D = parent_canvas.bump({ 0, si32max / 2, 0, si32max / 2 });
+                    auto context2D = parent_canvas.bump({ 0, netxs::si32max / 2, 0, netxs::si32max / 2 });
                     client->render(parent_canvas);
                     parent_canvas.bump(context2D);
                 }

--- a/src/netxs/desktopio/ansivt.hpp
+++ b/src/netxs/desktopio/ansivt.hpp
@@ -1148,15 +1148,15 @@ namespace netxs::ansi
         static constexpr auto defwrp = wrap::on;    // deco: Default autowrap behavior.
         static constexpr auto maxtab = si32{ 255 }; // deco: Tab length limit.
 
-        dent margin     = {}; // deco: Paragraph margins.
+        int8 marg_l     = {}; // deco: Paragraph margins.
+        int8 marg_r     = {}; // deco: Paragraph margins.
+        int8 marg_t     = {}; // deco: Paragraph margins.
+        int8 marg_b     = {}; // deco: Paragraph margins.
         wrap wrapln : 2 = {}; // deco: Autowrap.
         bias adjust : 2 = {}; // deco: Horizontal alignment.
         rtol r_to_l : 2 = {}; // deco: RTL.
         feed rlfeed : 2 = {}; // deco: Reverse line feed.
         byte tablen : 8 = {}; // deco: Tab length.
-        //byte rekind : 2 = {}; // deco: Stored line aligning type.
-        //byte hasimg : 1 = {}; // deco: Line contains image cells.
-        //byte pad1;
 
         deco() = default;
         deco(si32 format)
@@ -1176,30 +1176,37 @@ namespace netxs::ansi
                    (si32)rlfeed << 6 |
                    (si32)tablen << 8;
         }
-        auto  wrp   () const  { return wrapln;                                      } // deco: Return Auto wrapping.
-        auto  jet   () const  { return adjust;                                      } // deco: Return Paragraph adjustment.
-        auto  rtl   () const  { return r_to_l;                                      } // deco: Return RTL.
-        auto  rlf   () const  { return rlfeed;                                      } // deco: Return Reverse line feed.
-        auto  tbs   () const  { return tablen;                                      } // deco: Return Reverse line feed.
-        auto& mgn   () const  { return margin;                                      } // deco: Return margins.
-        auto& wrp   (bool  b) { wrapln = b ? wrap::on  : wrap::off;   return *this; } // deco: Set auto wrapping.
-        auto& rtl   (bool  b) { r_to_l = b ? rtol::rtl : rtol::ltr;   return *this; } // deco: Set RTL.
-        auto& rlf   (bool  b) { rlfeed = b ? feed::rev : feed::fwd;   return *this; } // deco: Set revverse line feed.
-        auto& wrp   (wrap  n) { wrapln = n;                           return *this; } // deco: Auto wrapping.
-        auto& jet   (bias  n) { adjust = n;                           return *this; } // deco: Paragraph adjustment.
-        auto& rtl   (rtol  n) { r_to_l = n;                           return *this; } // deco: RTL.
-        auto& rlf   (feed  n) { rlfeed = n;                           return *this; } // deco: Reverse line feed.
-        auto& wrp_or(wrap  n) { if (wrapln == wrap::none) wrapln = n; return *this; } // deco: Auto wrapping.
-        auto& jet_or(bias  n) { if (adjust == bias::none) adjust = n; return *this; } // deco: Paragraph adjustment.
-        auto& rtl_or(rtol  n) { if (r_to_l == rtol::none) r_to_l = n; return *this; } // deco: RTL.
-        auto& rlf_or(feed  n) { if (rlfeed == feed::none) rlfeed = n; return *this; } // deco: Reverse line feed.
-        auto& tbs   (si32  n) { tablen = std::min(n, maxtab);         return *this; } // deco: fx_ccc_tbs.
-        auto& mgl   (si32  n) { margin.l = n;                         return *this; } // deco: fx_ccc_mgl.
-        auto& mgr   (si32  n) { margin.r = n;                         return *this; } // deco: fx_ccc_mgr.
-        auto& mgt   (si32  n) { margin.t = n;                         return *this; } // deco: fx_ccc_mgt.
-        auto& mgb   (si32  n) { margin.b = n;                         return *this; } // deco: fx_ccc_mgb.
-        auto& mgn   (fifo& q) { margin.set(q);                        return *this; } // deco: fx_ccc_mgn.
-        auto& rst   ()        { *this = {};                           return *this; } // deco: Reset.
+        auto  wrp   () const  { return wrapln;                                        } // deco: Return Auto wrapping.
+        auto  jet   () const  { return adjust;                                        } // deco: Return Paragraph adjustment.
+        auto  rtl   () const  { return r_to_l;                                        } // deco: Return RTL.
+        auto  rlf   () const  { return rlfeed;                                        } // deco: Return Reverse line feed.
+        auto  tbs   () const  { return tablen;                                        } // deco: Return Reverse line feed.
+        auto  mgn   () const  { return dent{ marg_l, marg_r, marg_t, marg_b };        } // deco: Return margins.
+        auto& rst   ()        { *this = {};                             return *this; } // deco: Reset.
+        auto& wrp   (bool  b) { wrapln = b ? wrap::on  : wrap::off;     return *this; } // deco: Set auto wrapping.
+        auto& rtl   (bool  b) { r_to_l = b ? rtol::rtl : rtol::ltr;     return *this; } // deco: Set RTL.
+        auto& rlf   (bool  b) { rlfeed = b ? feed::rev : feed::fwd;     return *this; } // deco: Set revverse line feed.
+        auto& wrp   (wrap  n) { wrapln = n;                             return *this; } // deco: Auto wrapping.
+        auto& jet   (bias  n) { adjust = n;                             return *this; } // deco: Paragraph adjustment.
+        auto& rtl   (rtol  n) { r_to_l = n;                             return *this; } // deco: RTL.
+        auto& rlf   (feed  n) { rlfeed = n;                             return *this; } // deco: Reverse line feed.
+        auto& wrp_or(wrap  n) { if (wrapln == wrap::none) wrapln = n;   return *this; } // deco: Auto wrapping.
+        auto& jet_or(bias  n) { if (adjust == bias::none) adjust = n;   return *this; } // deco: Paragraph adjustment.
+        auto& rtl_or(rtol  n) { if (r_to_l == rtol::none) r_to_l = n;   return *this; } // deco: RTL.
+        auto& rlf_or(feed  n) { if (rlfeed == feed::none) rlfeed = n;   return *this; } // deco: Reverse line feed.
+        auto& tbs   (si32  n) { tablen = std::min(n, maxtab);           return *this; } // deco: fx_ccc_tbs.
+        auto& mgl   (si32  n) { marg_l = netxs::saturate_cast<int8>(n); return *this; } // deco: fx_ccc_mgl.
+        auto& mgr   (si32  n) { marg_r = netxs::saturate_cast<int8>(n); return *this; } // deco: fx_ccc_mgr.
+        auto& mgt   (si32  n) { marg_t = netxs::saturate_cast<int8>(n); return *this; } // deco: fx_ccc_mgt.
+        auto& mgb   (si32  n) { marg_b = netxs::saturate_cast<int8>(n); return *this; } // deco: fx_ccc_mgb.
+        auto& mgn   (fifo& q) // deco: fx_ccc_mgn.
+        {
+            marg_l = netxs::saturate_cast<int8>(q.subarg(0));
+            marg_r = netxs::saturate_cast<int8>(q.subarg(0));
+            marg_t = netxs::saturate_cast<int8>(q.subarg(0));
+            marg_b = netxs::saturate_cast<int8>(q.subarg(0));
+            return *this;
+        }
         // deco: Reset to global default.
         constexpr auto& reset()
         {
@@ -1208,7 +1215,10 @@ namespace netxs::ansi
             r_to_l = rtol::ltr;
             rlfeed = feed::fwd;
             tablen = 8;
-            margin = {};
+            marg_l = 0;
+            marg_r = 0;
+            marg_t = 0;
+            marg_b = 0;
             return *this;
         }
         auto get_kind() const
@@ -1907,6 +1917,10 @@ namespace netxs::ansi
         {
             static auto marker = ansi::marker{};
             return marker;
+        }
+        auto& get_style() const
+        {
+            return style;
         }
         void check_height(si32 height)
         {

--- a/src/netxs/desktopio/ansivt.hpp
+++ b/src/netxs/desktopio/ansivt.hpp
@@ -2052,7 +2052,7 @@ namespace netxs::ansi
                         }
                         if (next == tail)
                         {
-                            utf8 = { head, prev }; // preserve ESC at the end
+                            utf8 = { head, prev }; // exclude final ESC
                             return utf8;
                         }
                     }
@@ -2067,7 +2067,7 @@ namespace netxs::ansi
                             {
                                 if (tail - step < 8)
                                 {
-                                    utf8 = { head, prev }; // preserve ESC at the end
+                                    utf8 = { head, prev }; // exclude final ESC
                                 }
                                 else
                                 {
@@ -2088,7 +2088,7 @@ namespace netxs::ansi
                         }
                         if (next == tail)
                         {
-                            utf8 = { head, prev }; // preserve ESC at the end
+                            utf8 = { head, prev }; // exclude final ESC
                             return utf8;
                         }
                     }
@@ -2112,7 +2112,7 @@ namespace netxs::ansi
                         }
                         if (next == tail)
                         {
-                            utf8 = { head, prev }; // preserve ESC at the end
+                            utf8 = { head, prev }; // exclude final ESC
                             return utf8;
                         }
                     }
@@ -2130,7 +2130,7 @@ namespace netxs::ansi
                     {
                         if (++next == tail)
                         {
-                            utf8 = { head, prev }; // preserve ESC at the end
+                            utf8 = { head, prev }; // exclude final ESC
                         }
                     }
                     // test Esc + byte: ESC 7 8 D E H M ...
@@ -2167,7 +2167,7 @@ namespace netxs::ansi
                 }
                 else
                 {
-                    utf8 = { head, prev }; // preserve ESC at the end
+                    utf8 = { head, prev }; // exclude final ESC
                     return utf8;
                 }
             }

--- a/src/netxs/desktopio/ansivt.hpp
+++ b/src/netxs/desktopio/ansivt.hpp
@@ -831,9 +831,9 @@ namespace netxs::ansi
                 if (utf8)
                 {
                     add("\033[M");
-                    utf::to_utf_from_code(std::clamp(ctrl,         0, si16max - 32) + 32, *this);
-                    utf::to_utf_from_code(std::clamp((si32)coor.x, 1, si16max - 32) + 32, *this);
-                    utf::to_utf_from_code(std::clamp((si32)coor.y, 1, si16max - 32) + 32, *this);
+                    utf::to_utf_from_code(std::clamp(ctrl,         0, netxs::si16max - 32) + 32, *this);
+                    utf::to_utf_from_code(std::clamp((si32)coor.x, 1, netxs::si16max - 32) + 32, *this);
+                    utf::to_utf_from_code(std::clamp((si32)coor.y, 1, netxs::si16max - 32) + 32, *this);
                 }
                 else
                 {

--- a/src/netxs/desktopio/ansivt.hpp
+++ b/src/netxs/desktopio/ansivt.hpp
@@ -497,30 +497,40 @@ namespace netxs::ansi
         auto& err() { return fgc(redlt); } // basevt: Add error color.
         template<class ...Args>
         auto& err(Args&&... data) { return pushsgr().fgc(redlt).add(std::forward<Args>(data)...).popsgr(); } // basevt: Add error message.
+        // basevt: Ansify/textify a single cell run region.
+        template<bool UseSGR = true, bool Initial = true, bool Finalize = true, bool Select_11_only = true>
+        auto& s11n(std::span<cell const> cell_run, rect region, cell& state)
+        {
+            auto allfx = [&](cell const& c)
+            {
+                c.scan_attr<svga::vtrgb, UseSGR>(state, block);
+                c.scan_text<svga::vtrgb, Select_11_only>(block);
+            };
+            region.trimby(rect{ dot_00, { (si32)cell_run.size(), 1 }});
+            if (region)
+            {
+                if constexpr (UseSGR && Initial) basevt::nil();
+                auto subrun = cell_run.subspan(region.coor.x, region.size.x);
+                netxs::for_each(subrun, allfx);
+                if constexpr (Finalize)
+                {
+                    if constexpr (UseSGR) basevt::nil();
+                }
+                else
+                {
+                    if (block.size()) basevt::eol();
+                }
+            }
+            return block;
+        }
         // basevt: Ansify/textify content of specified region.
         template<bool UseSGR = true, bool Initial = true, bool Finalize = true, bool Select_11_only = true>
         auto& s11n(core const& canvas, rect region, cell& state)
         {
             auto allfx = [&](cell const& c)
             {
-                auto utf8 = c.txt<svga::vtrgb>();
-                auto [w, h, x, y] = c.whxy();
                 c.scan_attr<svga::vtrgb, UseSGR>(state, block);
-                if (w == 0 || h == 0 || y != 1 || x != 1 || utf8.empty() || (byte)utf8.front() < 32) // 2D fragment is either non-standard or empty or C0.
-                {
-                    if constexpr (Select_11_only)
-                    {
-                        if (y > 1 || x > 2) add(' ');
-                    }
-                    else
-                    {
-                        add(' ');
-                    }
-                }
-                else
-                {
-                    add(utf8);
-                }
+                c.scan_text<svga::vtrgb, Select_11_only>(block);
             };
             auto eolfx = [&]
             {

--- a/src/netxs/desktopio/ansivt.hpp
+++ b/src/netxs/desktopio/ansivt.hpp
@@ -1125,24 +1125,28 @@ namespace netxs::ansi
     };
     struct deco
     {
-        enum type : si32
+        struct type
         {
-            leftside, // default
-            rghtside,
-            centered,
-            autowrap,
-            count,
+            static constexpr auto _counter = __COUNTER__ + 1;
+            static constexpr auto leftside = __COUNTER__ - _counter;
+            static constexpr auto rghtside = __COUNTER__ - _counter;
+            static constexpr auto centered = __COUNTER__ - _counter;
+            static constexpr auto autowrap = __COUNTER__ - _counter;
+            static constexpr auto count    = __COUNTER__ - _counter;
         };
 
         static constexpr auto defwrp = wrap::on;    // deco: Default autowrap behavior.
         static constexpr auto maxtab = si32{ 255 }; // deco: Tab length limit.
 
+        dent margin     = {}; // deco: Paragraph margins.
         wrap wrapln : 2 = {}; // deco: Autowrap.
         bias adjust : 2 = {}; // deco: Horizontal alignment.
         rtol r_to_l : 2 = {}; // deco: RTL.
         feed rlfeed : 2 = {}; // deco: Reverse line feed.
         byte tablen : 8 = {}; // deco: Tab length.
-        dent margin     = {}; // deco: Page margins.
+        //byte rekind : 2 = {}; // deco: Stored line aligning type.
+        //byte hasimg : 1 = {}; // deco: Line contains image cells.
+        //byte pad1;
 
         deco() = default;
         deco(si32 format)

--- a/src/netxs/desktopio/application.hpp
+++ b/src/netxs/desktopio/application.hpp
@@ -22,7 +22,7 @@ namespace netxs::app
 
 namespace netxs::app::shared
 {
-    static const auto version = "v2026.05.01";
+    static const auto version = "v2026.05.07";
     static const auto repository = "https://github.com/directvt/vtm";
     static const auto usr_config = "~/.config/vtm/settings.xml"s;
     static const auto sys_config = "/etc/vtm/settings.xml"s;

--- a/src/netxs/desktopio/canvas.hpp
+++ b/src/netxs/desktopio/canvas.hpp
@@ -4254,7 +4254,7 @@ namespace netxs
         }
         auto toxy(si32 offset) const // core: Convert offset to coor.
         {
-            assert(canvas.size() <= si32max);
+            assert(canvas.size() <= netxs::si32max);
             auto maxs = (si32)canvas.size();
             if (!maxs) return dot_00;
             offset = std::clamp(offset, 0, maxs - 1);
@@ -4264,7 +4264,7 @@ namespace netxs
         auto subline(si32 from, si32 upto) const // core: Get stripe.
         {
             if (from > upto) std::swap(from, upto);
-            assert(canvas.size() <= si32max);
+            assert(canvas.size() <= netxs::si32max);
             auto maxs = (si32)canvas.size();
             from = std::clamp(from, 0, maxs ? maxs - 1 : 0);
             upto = std::clamp(upto, 0, maxs);

--- a/src/netxs/desktopio/canvas.hpp
+++ b/src/netxs/desktopio/canvas.hpp
@@ -1044,6 +1044,8 @@ namespace netxs
         }
     };
 
+    using pals = std::remove_const_t<decltype(argb::vt256)>;
+
     // canvas: Generic RGBA.
     template<class T>
     struct irgb
@@ -2672,6 +2674,28 @@ namespace netxs
             auto w = gc.size_w() + 1;
             return w > 1 && w == /*x*/(st.mosaic() & cell::body::x_bits);
         }
+        // cell: Get text from cell.
+        template<svga Mode = svga::vtrgb, bool Select_11_only = true>
+        void scan_text(text& dest) const
+        {
+            auto shadow = gc.get<Mode>();
+            auto [w, h, x, y] = whxy();
+            if (w == 0 || h == 0 || y != 1 || x != 1 || shadow.empty() || (byte)shadow.front() < 32) // 2D fragment is either non-standard or empty or C0.
+            {
+                if constexpr (Select_11_only)
+                {
+                    if (y > 1 || x > 2) dest += whitespace;
+                }
+                else
+                {
+                    dest += whitespace;
+                }
+            }
+            else
+            {
+                dest += shadow;
+            }
+        }
         // cell: Convert to text. Ignore right half. Convert binary clusters (eg: ^C -> 0x03).
         template<bool Select_11_only = faux>
         void scan(text& dest) const
@@ -2796,6 +2820,253 @@ namespace netxs
         auto same_fragment(cell const& c) const
         {
             return gc == c.gc && st.xy() == c.st.xy();
+        }
+        // cell: Find the text_only_cells{ what, size } inside the canvas and place the result offset to the &from.
+        static auto lookup(auto canvas_begin, auto canvas_end, auto what_begin, auto size, auto& from)
+        {
+            size--;
+            auto head = canvas_begin;
+            auto tail = canvas_end - size;
+            auto iter = head + from;
+            auto base = what_begin;
+            auto dest = base;
+            auto&test =*base;
+            while (iter != tail)
+            {
+                if (test.same_fragment(*iter++))
+                {
+                    auto init = iter;
+                    auto stop = iter + size;
+                    while (init != stop && init->same_fragment(*++dest))
+                    {
+                        ++init;
+                    }
+                    if (init == stop)
+                    {
+                        from = (si32)std::distance(head, iter) - 1;
+                        return true;
+                    }
+                    else dest = base;
+                }
+            }
+            return faux;
+        }
+        // cell: Find the text_only_cells{ what, size } inside the canvas and place the result offset to the &from.
+        static auto find(std::span<cell const> canvas, std::span<cell const> what, auto&& from, feed dir = feed::fwd)
+        {
+            auto full = (si32)canvas.size();
+            auto size = (si32)what.size();
+            auto rest = full - from;
+            if (dir == feed::fwd)
+            {
+                if (size && size <= rest)
+                if (cell::lookup(canvas.begin(), canvas.end(), what.begin(), size, from))
+                {
+                    return true;
+                }
+            }
+            else
+            {
+                if (size && size <= from)
+                if (cell::lookup(canvas.rbegin(), canvas.rend(), what.rbegin(), size, rest))
+                {
+                    from = full - rest - 1; // Restore forward representation.
+                    return true;
+                }
+            }
+            return faux;
+        }
+        // cell: Clear canvas cells from the specified image bits.
+        static bool remove_image_bits(auto& canvas, std::vector<ui16>& removed_image_indexes)
+        {
+            auto hit = faux;
+            for (auto& c : canvas)
+            {
+                if (auto image_index = c.get_image_index())
+                {
+                    //if (image_index == removed_image_index) //todo ?optimize for single index
+                    if (std::find(removed_image_indexes.begin(), removed_image_indexes.end(), image_index) != removed_image_indexes.end())
+                    {
+                        c.reset_px(); // Drop all image metadata.
+                        hit = true;
+                    }
+                }
+            }
+            return hit;
+        }
+        // cell: Unpack indexed colors in canvas using palette.
+        static void unpack_indexed_colors(auto& canvas, pals const& palette, cell defclr)
+        {
+            auto def_fgc = defclr.fgc();
+            auto def_bgc = defclr.bgc();
+            for (auto& c : canvas)
+            {
+                c.fgc().unpack_indexed_color(palette, def_fgc);
+                c.bgc().unpack_indexed_color(palette, def_bgc);
+            }
+        }
+        // cell: Unpack canvas indexed colors using palette and place it to the dest.
+        static void unpack_indexed_colors_to(auto const& canvas, auto& dest, pals const& palette, cell defclr)
+        {
+            auto def_fgc = defclr.fgc();
+            auto def_bgc = defclr.bgc();
+            dest.size(canvas.size());
+            netxs::oncopy(canvas, dest, [&](auto& src, auto& dst)
+            {
+                dst = src;
+                dst.fgc().unpack_indexed_color(palette, def_fgc);
+                dst.bgc().unpack_indexed_color(palette, def_bgc);
+            });
+        }
+        // cell: Convert to raw utf-8 text (ignoring right halves).
+        template<bool Select_11_only = true>
+        static void to_utf8(auto const& canvas, text& crop)
+        {
+            crop.reserve(crop.size() + canvas.length());
+            netxs::for_each(canvas, [&](cell const& c){ c.scan<Select_11_only>(crop); });
+        }
+        // cell: Convert to raw utf-8 text (ignoring right halves).
+        template<bool Select_11_only = true>
+        static auto to_utf8(auto const& canvas)
+        {
+            auto crop = text{};
+            cell::to_utf8(canvas, crop);
+            return crop;
+        }
+        // cell: Detect a word bound.
+        template<feed Direction>
+        static auto word(std::span<cell const> canvas, si32 start)
+        {
+            if (start < 0 || start >= canvas.size()) return 0;
+            static constexpr auto rev = Direction == feed::fwd ? faux : true;
+            auto stop_by_zwsp = 0;
+            auto is_empty = [&](auto txt)
+            {
+                auto test = txt.empty()
+                         || txt.front() == whitespace
+                         ||(txt.front() == '^' && txt.size() == 2); // C0 characters.
+                if (test) stop_by_zwsp = 5; // Don't break by zwsp.
+                return test;
+            };
+            auto empty = [&](auto txt)
+            {
+                return is_empty(txt);
+            };
+            auto alpha = [&](auto txt)
+            {
+                //todo revise (https://unicode.org/reports/tr29/#Word_Boundaries)
+                auto c = utf::cluster<true>(txt).attr.cdpoint;
+                return (c >= '0' && c <= '9')//30-39: '0'-'9'
+                     ||(c >= '@' && c <= 'Z')//40-5A: '@','A'-'Z'
+                     ||(c >= 'a' && c <= 'z')//5F,61-7A: '_','a'-'z'
+                     || c == '_'             //60:    '`'
+                     || c == 0xA0            //A0  NO-BREAK SPACE (NBSP)
+                     ||(c >= 0xC0                // C0-10FFFF: "À" - ...
+                     && c < 0x2000)||(c > 0x206F // General Punctuation
+                     && c < 0x2200)||(c > 0x23FF // Mathematical Operators
+                     && c < 0x2500)||(c > 0x25FF // Box Drawing
+                     && c < 0x2E00)||(c > 0x2E7F // Supplemental Punctuation
+                     && c < 0x3000)||(c > 0x303F // CJK Symbols and Punctuation
+                     && c != 0x30FB              // U+30FB ( ・ ) KATAKANA MIDDLE DOT
+                     && c < 0xFE50)||(c > 0xFE6F // FE50  FE6F Small Form Variants
+                     && c < 0xFF00)||(c > 0xFF0F // Halfwidth and Fullwidth Forms
+                     && c < 0xFF1A)||(c > 0xFF1F //
+                     && c < 0xFF3B)||(c > 0xFF40 //
+                     && c < 0xFF5B)|| c > 0xFF65 //
+            ;};
+            auto is_email = [&](auto txt)
+            {
+                return !txt.empty() && txt.front() == '@';
+            };
+            auto email = [&](auto txt)
+            {
+                return !txt.empty() && (alpha(txt) || txt.front() == '.');
+            };
+            auto is_digit = [&](auto txt)
+            {
+                auto c = utf::cluster(txt).attr.cdpoint;
+                return (c >= '0'    && c <= '9')
+                     ||(c >= 0xFF10 && c <= 0xFF19) // U+FF10 (０) FULLWIDTH DIGIT ZERO - U+FF19 (９) FULLWIDTH DIGIT NINE
+                     || c == '.';
+            };
+            auto digit = [&](auto txt)
+            {
+                auto c = utf::cluster(txt).attr.cdpoint;
+                return c == '.'
+                    ||(c >= 'a' && c <= 'f')
+                    ||(c >= 'A' && c <= 'F')
+                    ||(c >= '0' && c <= '9')
+                    ||(c >= 0xFF10 && c <= 0xFF19); // U+FF10 (０) FULLWIDTH DIGIT ZERO - U+FF19 (９) FULLWIDTH DIGIT NINE
+            };
+            auto func = [&](auto check)
+            {
+                static constexpr auto right_half = rev ? 1 : 2;
+                auto count = 0;
+                auto allfx = [&](auto& c)
+                {
+                    auto txt = c.txt();
+                    auto has_zwsp = stop_by_zwsp <= 0 && txt.ends_with("\u200b");
+                    if (has_zwsp || (stop_by_zwsp && stop_by_zwsp < 2))
+                    {
+                        if constexpr (rev) stop_by_zwsp += 2; // Break here.
+                        else               stop_by_zwsp++;    // Include current cluster.
+                    }
+                    auto [w, h, x, y] = c.whxy();
+                    auto not_right_half = w != 2 || x != right_half;
+                    if (stop_by_zwsp == 2 || (not_right_half && !check(txt))) return true;
+                    count++;
+                    return faux;
+                };
+                start += rev ? 1 : 0;
+                auto head = start;
+                auto tail = rev ? 0 : (si32)canvas.size();
+                if constexpr (rev) std::swap(head, tail);
+                auto cell_run = canvas.subspan(head, tail - head);
+                netxs::for_each<rev>(cell_run, allfx);
+                if (count) count--;
+                start -= rev ? count + 1 : -count;
+            };
+
+            auto test = canvas[start].txt();
+            if constexpr (rev)
+            {
+                if (test.ends_with("\u200b")) stop_by_zwsp -= 2; // Skip zwsp in the first cell.
+            }
+            is_digit(test) ? func(digit) :
+            is_email(test) ? func(email) :
+            is_empty(test) ? func(empty) :
+                             func(alpha);
+            return start;
+        }
+        // cell: Find proc(c) == true.
+        template<feed Direction>
+        static auto seek(std::span<cell const> canvas, si32& start, auto proc)
+        {
+            if (canvas.empty()) return faux;
+            static constexpr auto rev = Direction == feed::fwd ? faux : true;
+            auto count = 0;
+            auto found = faux;
+            auto allfx = [&](auto& c)
+            {
+                if (proc(c))
+                {
+                    found = true;
+                    return true;
+                }
+                count++;
+                return faux;
+            };
+
+            start += rev ? 1 : 0;
+            auto head = start;
+            auto tail = rev ? 0 : (si32)canvas.size();
+            if constexpr (rev) std::swap(head, tail);
+            auto cell_run = canvas.subspan(head, tail - head);
+            netxs::for_each<rev>(cell_run, allfx);
+
+            if (count) count--;
+            start -= rev ? count + 1 : -count;
+            return found;
         }
         // cell: Reset grapheme cluster.
         void set_gc()
@@ -3637,7 +3908,6 @@ namespace netxs
     }
 
     using vrgb = netxs::raw_vector<irgb<si32>>;
-    using pals = std::remove_const_t<decltype(argb::vt256)>;
 
     // canvas: Core grid.
     class core
@@ -3655,7 +3925,6 @@ namespace netxs
         { }
 
     public:
-        using span = std::span<cell const>;
         using body = std::vector<cell>;
 
     protected:
@@ -3671,7 +3940,7 @@ namespace netxs
         core(core const&)              = default;
         core& operator = (core&&)      = default;
         core& operator = (core const&) = default;
-        core(span cells, twod size)
+        core(std::span<cell const> cells, twod size)
             : region{ dot_00, size },
               client{ dot_00, size },
               canvas( cells.begin(), cells.end() )
@@ -3768,7 +4037,7 @@ namespace netxs
         }
         auto crop(si32 at, si32 length) const // core: Return 1D fragment.
         {
-            auto fragment = core{ span{ canvas.begin() + at, canvas.begin() + at + length }, twod{ length, 1 } };
+            auto fragment = core{ std::span{ canvas.begin() + at, canvas.begin() + at + length }, twod{ length, 1 } };
             fragment.marker = marker;
             return fragment;
         }
@@ -3807,32 +4076,13 @@ namespace netxs
             wipe(marker);
             marker.link(my_id);
         }
-        template<class P, bool Plain = std::is_same_v<void, std::invoke_result_t<P, cell&>>>
-        auto each(P proc) // core: Exec a proc for each cell.
+        auto each(auto proc) // core: Exec a proc for each cell.
         {
-            for (auto& c : canvas)
-            {
-                if constexpr (Plain) proc(c);
-                else             if (proc(c)) return faux;
-            }
-            if constexpr (!Plain) return true;
+            return netxs::for_each(canvas, proc);
         }
         void each(rect region, auto fx) // core: Exec a proc for each cell of the specified region.
         {
             netxs::onrect(*this, region, fx);
-        }
-        template<bool Select_11_only = true>
-        void utf8(netxs::text& crop) // core: Convert to raw utf-8 text. Ignore right halves.
-        {
-            each([&](cell& c){ c.scan<Select_11_only>(crop); });
-        }
-        template<bool Select_11_only = true>
-        auto utf8() // core: Convert to raw utf-8 text. Ignore right halves.
-        {
-            auto crop = netxs::text{};
-            crop.reserve(canvas.size());
-            each([&](cell& c){ c.scan<Select_11_only>(crop); });
-            return crop;
         }
         auto copy(body& target) const // core: Copy only body of the canvas to the specified body bitmap.
         {
@@ -3936,137 +4186,26 @@ namespace netxs
             return region.size;
         }
         template<feed Direction>
-        auto seek(si32& x, auto proc) // core: Find proc(c) == true.
-        {
-            if (!region) return faux;
-            static constexpr auto rev = Direction == feed::fwd ? faux : true;
-            x += rev ? 1 : 0;
-            auto count = 0;
-            auto found = faux;
-            auto width = (rev ? 0 : region.size.x) - x;
-            auto field = rect{ twod{ x, 0 } + region.coor, { width, 1 }}.normalize();
-            auto allfx = [&](auto& c)
-            {
-                if (proc(c))
-                {
-                    found = true;
-                    return true;
-                }
-                count++;
-                return faux;
-            };
-            netxs::onrect<rev>(*this, field, allfx);
-            if (count) count--;
-            x -= rev ? count + 1 : -count;
-            return found;
-        }
-        template<feed Direction>
         auto word(twod coord) // core: Detect a word bound.
         {
-            if (!region) return 0;
-            static constexpr auto rev = Direction == feed::fwd ? faux : true;
-            auto stop_by_zwsp = 0;
-            auto is_empty = [&](auto txt)
+            if (region)
             {
-                auto test = txt.empty()
-                         || txt.front() == whitespace
-                         ||(txt.front() == '^' && txt.size() == 2); // C0 characters.
-                if (test) stop_by_zwsp = 5; // Don't break by zwsp.
-                return test;
-            };
-            auto empty = [&](auto txt)
-            {
-                return is_empty(txt);
-            };
-            auto alpha = [&](auto txt)
-            {
-                //todo revise (https://unicode.org/reports/tr29/#Word_Boundaries)
-                auto c = utf::cluster<true>(txt).attr.cdpoint;
-                return (c >= '0' && c <= '9')//30-39: '0'-'9'
-                     ||(c >= '@' && c <= 'Z')//40-5A: '@','A'-'Z'
-                     ||(c >= 'a' && c <= 'z')//5F,61-7A: '_','a'-'z'
-                     || c == '_'             //60:    '`'
-                     || c == 0xA0            //A0  NO-BREAK SPACE (NBSP)
-                     ||(c >= 0xC0                // C0-10FFFF: "À" - ...
-                     && c < 0x2000)||(c > 0x206F // General Punctuation
-                     && c < 0x2200)||(c > 0x23FF // Mathematical Operators
-                     && c < 0x2500)||(c > 0x25FF // Box Drawing
-                     && c < 0x2E00)||(c > 0x2E7F // Supplemental Punctuation
-                     && c < 0x3000)||(c > 0x303F // CJK Symbols and Punctuation
-                     && c != 0x30FB              // U+30FB ( ・ ) KATAKANA MIDDLE DOT
-                     && c < 0xFE50)||(c > 0xFE6F // FE50  FE6F Small Form Variants
-                     && c < 0xFF00)||(c > 0xFF0F // Halfwidth and Fullwidth Forms
-                     && c < 0xFF1A)||(c > 0xFF1F //
-                     && c < 0xFF3B)||(c > 0xFF40 //
-                     && c < 0xFF5B)|| c > 0xFF65 //
-            ;};
-            auto is_email = [&](auto txt)
-            {
-                return !txt.empty() && txt.front() == '@';
-            };
-            auto email = [&](auto txt)
-            {
-                return !txt.empty() && (alpha(txt) || txt.front() == '.');
-            };
-            auto is_digit = [&](auto txt)
-            {
-                auto c = utf::cluster(txt).attr.cdpoint;
-                return (c >= '0'    && c <= '9')
-                     ||(c >= 0xFF10 && c <= 0xFF19) // U+FF10 (０) FULLWIDTH DIGIT ZERO - U+FF19 (９) FULLWIDTH DIGIT NINE
-                     || c == '.';
-            };
-            auto digit = [&](auto txt)
-            {
-                auto c = utf::cluster(txt).attr.cdpoint;
-                return c == '.'
-                    ||(c >= 'a' && c <= 'f')
-                    ||(c >= 'A' && c <= 'F')
-                    ||(c >= '0' && c <= '9')
-                    ||(c >= 0xFF10 && c <= 0xFF19); // U+FF10 (０) FULLWIDTH DIGIT ZERO - U+FF19 (９) FULLWIDTH DIGIT NINE
-            };
-            auto func = [&](auto check)
-            {
-                static constexpr auto right_half = rev ? 1 : 2;
-                coord.x += rev ? 1 : 0;
-                auto count = decltype(coord.x){};
-                auto width = (rev ? 0 : region.size.x) - coord.x;
-                auto field = rect{ coord + region.coor, { width, 1 }}.normalize();
-                auto allfx = [&](auto& c)
-                {
-                    auto txt = c.txt();
-                    auto has_zwsp = stop_by_zwsp <= 0 && txt.ends_with("\u200b");
-                    if (has_zwsp || (stop_by_zwsp && stop_by_zwsp < 2))
-                    {
-                        if constexpr (rev) stop_by_zwsp += 2; // Break here.
-                        else               stop_by_zwsp++;    // Include current cluster.
-                    }
-                    auto [w, h, x, y] = c.whxy();
-                    auto not_right_half = w != 2 || x != right_half;
-                    if (stop_by_zwsp == 2 || (not_right_half && !check(txt))) return true;
-                    count++;
-                    return faux;
-                };
-                netxs::onrect<rev>(*this, field, allfx);
-                if (count) count--;
-                coord.x -= rev ? count + 1 : -count;
-            };
-
-            coord = std::clamp(coord, dot_00, region.size - dot_11);
-            auto test = begin(coord)->txt();
-            if constexpr (rev)
-            {
-                if (test.ends_with("\u200b")) stop_by_zwsp -= 2; // Skip zwsp in the first cell.
+                coord = std::clamp(coord, dot_00, region.size - dot_11);
+                auto start = coord.x + coord.y * region.size.x;
+                auto offset = cell::word<Direction>(canvas, start);
+                coord.x = (offset - 1) % region.size.x + 1;
+                coord.y = std::max(0, (offset - 1) / region.size.x);
             }
-            is_digit(test) ? func(digit) :
-            is_email(test) ? func(email) :
-            is_empty(test) ? func(empty) :
-                             func(alpha);
-            return coord.x;
+            else
+            {
+                coord = {};
+            }
+            return coord;
         }
         template<feed Direction>
         auto word(si32 offset) // core: Detect a word bound.
         {
-            return word<Direction>(twod{ offset, 0 });
+            return cell::word<Direction>(canvas, offset);
         }
         void cage(rect area, dent border, auto fx) // core: Draw the cage around specified area.
         {
@@ -4076,70 +4215,42 @@ namespace netxs
         {
             cage(area, dent{ border_width.x, border_width.x, border_width.y, border_width.y }, fx);
         }
-        template<class Text, class P = noop>
-        void text(twod pos, Text const& txt, bool rtl = faux, P print = {}) // core: Put the specified text substring to the specified coordinates on the canvas.
+        template<bool RtoL = faux, class Text, class P = noop>
+        void text(twod coord, Text const& block, P print = {}) // core: Put the specified text substring to the specified coordinates on the canvas.
         {
-            rtl ? txt.template output<true>(*this, pos, print)
-                : txt.template output<faux>(*this, pos, print);
+            block.template output<RtoL>(*this, coord, print);
+        }
+        template<bool RtoL = faux, class P = noop>
+        void text(twod coord, std::span<cell const> subline, P print = {}) // core: Put the specified text substring to the specified coordinates on the canvas.
+        {
+            auto place = rect{ coord, { (si32)subline.size(), 1 }};
+            auto joint = clip().trim(place);
+            if (joint)
+            {
+                if constexpr (RtoL)
+                {
+                    place.coor.x -= joint.coor.x - place.size.x + joint.size.x;
+                    place.coor.y  = joint.coor.y - place.coor.y;
+                }
+                else
+                {
+                    place.coor = joint.coor - place.coor;
+                }
+                auto skip_in_subline = place.coor.x;
+                auto size_of_subline = joint.size.x;
+                auto src_crop = subline.subspan(skip_in_subline, (size_t)size_of_subline);
+                joint.coor -= coor();
+                auto skip_in_canvas = joint.coor.x + joint.coor.y * size().x;
+                auto size_of_canvas = joint.size.x;
+                auto dst_crop = std::span{ canvas.begin() + skip_in_canvas, (size_t)size_of_canvas };
+                if constexpr (std::is_same_v<P, noop>) netxs::oncopy<RtoL>(dst_crop, src_crop, cell::shaders::fusefull);
+                else                                   netxs::oncopy<RtoL>(dst_crop, src_crop, print);
+            }
         }
         template<class Si32>
-        auto find(core const& what, Si32&& from, feed dir = feed::fwd) const // core: Find the substring and place its offset in &from.
+        auto find(auto const& what, Si32&& from, feed dir = feed::fwd) const // core: Find the substring and place its offset in &from.
         {
-            assert(     canvas.size() <= si32max);
-            assert(what.canvas.size() <= si32max);
-            auto full = (si32)     canvas.size();
-            auto size = (si32)what.canvas.size();
-            auto rest = full - from;
-            auto look = [&](auto canvas_begin, auto canvas_end, auto what_begin)
-            {
-                if (!size || size > rest) return faux;
-
-                size--;
-                auto head = canvas_begin;
-                auto tail = canvas_end - size;
-                auto iter = head + from;
-                auto base = what_begin;
-                auto dest = base;
-                auto&test =*base;
-                while (iter != tail)
-                {
-                    if (test.same_fragment(*iter++))
-                    {
-                        auto init = iter;
-                        auto stop = iter + size;
-                        while (init != stop && init->same_fragment(*++dest))
-                        {
-                            ++init;
-                        }
-
-                        if (init == stop)
-                        {
-                            from = (si32)std::distance(head, iter) - 1;
-                            return true;
-                        }
-                        else dest = base;
-                    }
-                }
-                return faux;
-            };
-
-            if (dir == feed::fwd)
-            {
-                if (look(canvas.begin(), canvas.end(), what.canvas.begin()))
-                {
-                    return true;
-                }
-            }
-            else
-            {
-                std::swap(rest, from); // Reverse.
-                if (look(canvas.rbegin(), canvas.rend(), what.canvas.rbegin()))
-                {
-                    from = full - from - 1; // Restore forward representation.
-                    return true;
-                }
-            }
-            return faux;
+            return cell::find(canvas, what.canvas, from, dir);
         }
         auto toxy(si32 offset) const // core: Convert offset to coor.
         {
@@ -4150,7 +4261,7 @@ namespace netxs
             auto sx = std::max(1, region.size.x);
             return twod{ offset % sx, offset / sx };
         }
-        auto line(si32 from, si32 upto) const // core: Get stripe.
+        auto subline(si32 from, si32 upto) const // core: Get stripe.
         {
             if (from > upto) std::swap(from, upto);
             assert(canvas.size() <= si32max);
@@ -4158,14 +4269,14 @@ namespace netxs
             from = std::clamp(from, 0, maxs ? maxs - 1 : 0);
             upto = std::clamp(upto, 0, maxs);
             auto size = upto - from;
-            return core{ span{ canvas.begin() + from, (size_t)size }, { size, 1 }};
+            return std::span{ canvas.begin() + from, (size_t)size };
         }
-        auto line(twod p1, twod p2) const // core: Get stripe.
+        auto subline(twod p1, twod p2) const // core: Get stripe.
         {
             if (p1.y > p2.y || (p1.y == p2.y && p1.x > p2.x)) std::swap(p1, p2);
             auto from = p1.x + p1.y * region.size.x;
             auto upto = p2.x + p2.y * region.size.x + 1;
-            return line(from, upto);
+            return subline(from, upto);
         }
         auto tile(core& image, auto fx) // core: Tile with a specified bitmap.
         {
@@ -4203,45 +4314,6 @@ namespace netxs
 
             swap(block);
             digest++;
-        }
-        bool remove_image_bits(std::vector<ui16>& removed_image_indexes)
-        {
-            auto hit = faux;
-            for (auto& c : canvas)
-            {
-                if (auto image_index = c.get_image_index())
-                {
-                    //if (image_index == removed_image_index) //todo optimize
-                    if (std::find(removed_image_indexes.begin(), removed_image_indexes.end(), image_index) != removed_image_indexes.end())
-                    {
-                        c.reset_px(); // Drop all image metadata.
-                        hit = true;
-                    }
-                }
-            }
-            return hit;
-        }
-        void unpack_indexed_colors(pals const& palette, cell defclr)
-        {
-            auto def_fgc = defclr.fgc();
-            auto def_bgc = defclr.bgc();
-            for (auto& c : canvas)
-            {
-                c.fgc().unpack_indexed_color(palette, def_fgc);
-                c.bgc().unpack_indexed_color(palette, def_bgc);
-            }
-        }
-        void unpack_indexed_colors(core& dest, pals const& palette, cell defclr) const
-        {
-            auto def_fgc = defclr.fgc();
-            auto def_bgc = defclr.bgc();
-            dest.size(region.size);
-            netxs::oncopy(*this, dest, [&](auto& src, auto& dst)
-            {
-                dst = src;
-                dst.fgc().unpack_indexed_color(palette, def_fgc);
-                dst.bgc().unpack_indexed_color(palette, def_bgc);
-            });
         }
     };
 }

--- a/src/netxs/desktopio/canvas.hpp
+++ b/src/netxs/desktopio/canvas.hpp
@@ -2354,11 +2354,7 @@ namespace netxs
         auto get_image_ontop() const
         {
             auto index = get_image_index();
-            auto ontop = faux;
-            if (index)
-            {
-                ontop = netxs::get_field<p2_ontop_1_mask>(p2);
-            }
+            auto ontop = netxs::get_field<p2_ontop_1_mask>(p2);
             return std::pair{ index, ontop };
         }
         auto& set_image_index(si32 n) { netxs::set_field<p2_index16_mask>(n, p2); return *this; }

--- a/src/netxs/desktopio/canvas.hpp
+++ b/src/netxs/desktopio/canvas.hpp
@@ -3659,11 +3659,11 @@ namespace netxs
         using body = std::vector<cell>;
 
     protected:
-        si32 digest = 0; // core: Resize stamp.
         rect region; // core: Physical square of canvas relative to current basis (top-left corner of the current rendering object, see face::change_basis).
         rect client; // core: Active canvas area relative to current basis.
         body canvas; // core: Cell data.
         cell marker; // core: Current brush.
+        si32 digest = 0; // core: Resize stamp.
 
     public:
         core()                         = default;

--- a/src/netxs/desktopio/canvas.hpp
+++ b/src/netxs/desktopio/canvas.hpp
@@ -2933,7 +2933,7 @@ namespace netxs
         template<feed Direction>
         static auto word(std::span<cell const> canvas, si32 start)
         {
-            if (start < 0 || start >= canvas.size()) return 0;
+            if (start < 0 || (size_t)start >= canvas.size()) return 0;
             static constexpr auto rev = Direction == feed::fwd ? faux : true;
             auto stop_by_zwsp = 0;
             auto is_empty = [&](auto txt)

--- a/src/netxs/desktopio/canvas.hpp
+++ b/src/netxs/desktopio/canvas.hpp
@@ -4248,9 +4248,9 @@ namespace netxs
             }
         }
         template<class Si32>
-        auto find(auto const& what, Si32&& from, feed dir = feed::fwd) const // core: Find the substring and place its offset in &from.
+        auto find(auto const& what, Si32&& from, feed dir = feed::fwd) const // core: Find the subspan and place its offset in &from.
         {
-            return cell::find(canvas, what.canvas, from, dir);
+            return cell::find(canvas, what, from, dir);
         }
         auto toxy(si32 offset) const // core: Convert offset to coor.
         {

--- a/src/netxs/desktopio/canvas.hpp
+++ b/src/netxs/desktopio/canvas.hpp
@@ -1665,7 +1665,7 @@ namespace netxs
                 changed_gb_attrs = {};
                 document_changed = {};
             }
-            void check_and_set_document(qiew doc_str, qiew sub_id_str)
+            void check_and_set_document(qiew doc_str, qiew sub_id_str = {})
             {
                 if (doc_str && document != doc_str)
                 {

--- a/src/netxs/desktopio/consrv.hpp
+++ b/src/netxs/desktopio/consrv.hpp
@@ -566,7 +566,7 @@ struct impl : consrv
                 auto& recs = iter->second;
                 for (auto& rec : recs.data)
                 {
-                    crop += rec.utf8();
+                    cell::to_utf8(rec, crop);
                     crop += '\0';
                 }
             }
@@ -1243,7 +1243,7 @@ struct impl : consrv
                             case VK_CONTROL:
                                 //todo unify
                                 cooked.ustr.clear();
-                                line.lyric->utf8(cooked.ustr); // Prepare data to copy to clipboard.
+                                cell::to_utf8(line.content(), cooked.ustr); // Prepare data to copy to clipboard.
                                 break;
                             case VK_PAUSE:   break;
                             case VK_APPS:    break;
@@ -1339,7 +1339,7 @@ struct impl : consrv
                                         cooked.ustr.clear();
                                         if (crlf_value)
                                         {
-                                            line.lyric->utf8(cooked.ustr);
+                                            cell::to_utf8(line.content(), cooked.ustr);
                                             cooked.ustr.push_back('\r');
                                             if (server.inpmod & nt::console::inmode::preprocess)
                                             {
@@ -1350,7 +1350,7 @@ struct impl : consrv
                                         {
                                             hist.save(line);
                                             line.move_to_end(true);
-                                            line.lyric->utf8(cooked.ustr);
+                                            cell::to_utf8(line.content(), cooked.ustr);
                                             cooked.ustr.push_back((char)c);
                                         }
                                         if (n == 0) pops++;

--- a/src/netxs/desktopio/consrv.hpp
+++ b/src/netxs/desktopio/consrv.hpp
@@ -1030,8 +1030,8 @@ struct impl : consrv
                     {
                         .dwMousePosition =
                         {
-                            .X = (si16)std::clamp<si32>((si32)coord.x, si16min, si16max),
-                            .Y = (si16)std::clamp<si32>((si32)coord.y, si16min, si16max),
+                            .X = (si16)std::clamp<si32>((si32)coord.x, netxs::si16min, netxs::si16max),
+                            .Y = (si16)std::clamp<si32>((si32)coord.y, netxs::si16min, netxs::si16max),
                         },
                         .dwButtonState     = (DWORD)bttns,
                         .dwControlKeyState = state,
@@ -1054,8 +1054,8 @@ struct impl : consrv
                     {
                         .dwSize =
                         {
-                            .X = (si16)std::min<si32>(winsize.x, si16max),
-                            .Y = (si16)std::min<si32>(winsize.y, si16max),
+                            .X = (si16)std::min<si32>(winsize.x, netxs::si16max),
+                            .Y = (si16)std::min<si32>(winsize.y, netxs::si16max),
                         }
                     }
                 }

--- a/src/netxs/desktopio/consrv.hpp
+++ b/src/netxs/desktopio/consrv.hpp
@@ -197,6 +197,7 @@ struct impl : consrv
 
     struct memo
     {
+        //todo use ui::line instead of ui::rich
         size_t                           seek{};
         std::list<std::pair<si32, rich>> undo{};
         std::list<std::pair<si32, rich>> redo{};

--- a/src/netxs/desktopio/controls.hpp
+++ b/src/netxs/desktopio/controls.hpp
@@ -2083,7 +2083,7 @@ namespace netxs::ui
             {
                 return node_type;
             }
-            void focus_next(input::hids& gear, si32 n, si32 min_w, si32 max_w = si32max)
+            void focus_next(input::hids& gear, si32 n, si32 min_w, si32 max_w = netxs::si32max)
             {
                 if (!n) return;
                 auto set_focus = [&](auto get_next)

--- a/src/netxs/desktopio/generics.hpp
+++ b/src/netxs/desktopio/generics.hpp
@@ -461,8 +461,8 @@ namespace netxs::generics
               mxsz{ std::clamp(grow_mx, 0, netxs::si32max - 2) }
         { }
 
-        virtual void undock_base_front(type&) { };
-        virtual void undock_base_back (type&) { };
+        virtual void undock_base_front(type& /*item*/, bool /*deallocate*/) { };
+        virtual void undock_base_back (type& /*item*/, bool /*deallocate*/) { };
 
         auto  current_it()         { return iter<      ring>{ *this, cart };          }
         auto  begin()              { return iter<      ring>{ *this, head };          }
@@ -483,6 +483,7 @@ namespace netxs::generics
         void  index(si32 i)        { assert((i > 0 && i < size) || i == 0); cart = mod(head + i); }
         void  prev()               { dec(cart); test();          }
         void  next()               { inc(cart); test();          }
+        auto  ring_size()          { return buff.size() - 1;     }
 
     private:
         void  test()
@@ -506,23 +507,23 @@ namespace netxs::generics
             return faux;
         }
         template<bool UseBack = faux>
-        inline void undock_front()
+        inline void undock_front(bool deallocate = faux)
         {
             auto& item = front();
             if constexpr (UseUndock)
             {
-                if constexpr (UseBack) undock_base_back (item);
-                else                   undock_base_front(item);
+                if constexpr (UseBack) undock_base_back (item, deallocate);
+                else                   undock_base_front(item, deallocate);
             }
             item = type{};
             if (cart == head) inc(head), cart = head;
             else              inc(head);
         }
-        inline void undock_back()
+        inline void undock_back(bool deallocate = faux)
         {
             auto& item = back();
-            if constexpr (UseUndock) undock_base_back(item);
-            item = type{};
+            if constexpr (UseUndock) undock_base_back(item, deallocate);
+            else                     item = type{};
             if (cart == tail) dec(tail), cart = tail;
             else              dec(tail);
         }
@@ -550,8 +551,15 @@ namespace netxs::generics
                 if (full())
                 {
                     auto& item = front();
-                    if constexpr (UseUndock) undock_base_front(item);
-                    item = type(std::forward<Args>(args)...);
+                    if constexpr (UseUndock)
+                    {
+                        static_assert(sizeof...(args) == 0);
+                        undock_base_front(item, faux);
+                    }
+                    else
+                    {
+                        item = type(std::forward<Args>(args)...);
+                    }
                     ++it_1;
                 }
                 else
@@ -559,7 +567,14 @@ namespace netxs::generics
                     ++size;
                     dec(head);
                     auto& item = front();
-                    item = type(std::forward<Args>(args)...);
+                    if constexpr (UseUndock)
+                    {
+                        static_assert(sizeof...(args) == 0);
+                    }
+                    else
+                    {
+                        item = type(std::forward<Args>(args)...);
+                    }
                 }
                 swap_block<true>(it_1, it_2, begin());
                 --it_2;
@@ -574,8 +589,15 @@ namespace netxs::generics
                 if (full())
                 {
                     auto& item = front();
-                    if constexpr (UseUndock) undock_base_front(item);
-                    item = type{};
+                    if constexpr (UseUndock)
+                    {
+                        static_assert(sizeof...(args) == 0);
+                        undock_base_front(item, faux);
+                    }
+                    else
+                    {
+                        item = type{};
+                    }
                     if (cart == head) inc(head), cart = head;
                     else              inc(head);
                 }
@@ -596,7 +618,14 @@ namespace netxs::generics
             else        ++size;
             inc(tail);
             auto& item = back();
-            item = type(std::forward<Args>(args)...);
+            if constexpr (UseUndock)
+            {
+                static_assert(sizeof...(args) == 0);
+            }
+            else
+            {
+                item = type(std::forward<Args>(args)...);
+            }
             return item;
         }
         template<class ...Args>
@@ -606,7 +635,14 @@ namespace netxs::generics
             else        ++size;
             dec(head);
             auto& item = front();
-            item = type(std::forward<Args>(args)...);
+            if constexpr (UseUndock)
+            {
+                static_assert(sizeof...(args) == 0);
+            }
+            else
+            {
+                item = type(std::forward<Args>(args)...);
+            }
             return item;
         }
         template<bool UseBack = faux>
@@ -664,8 +700,15 @@ namespace netxs::generics
         }
         void clear()
         {
-            if constexpr (UseUndock) while (size) pop_back(); //todo undock?
-            else                     size = 0;
+            if constexpr (UseUndock)
+            {
+                while (size)
+                {
+                    undock_back(true);
+                    --size;
+                }
+            }
+            else size = 0;
             cart = 0;
             head = 0;
             tail = peak - 1;
@@ -683,7 +726,7 @@ namespace netxs::generics
                         //todo optimize for !UseUndock
                         do
                         {
-                            if constexpr (UseUndock) undock_base_front(front());
+                            if constexpr (UseUndock) undock_base_front(front(), true);
                             inc(head);
                         }
                         while (--size != new_size);
@@ -697,7 +740,7 @@ namespace netxs::generics
                         //todo optimize for !UseUndock
                         do
                         {
-                            if constexpr (UseUndock) undock_base_back(back());
+                            if constexpr (UseUndock) undock_base_back(back(), true);
                             dec(tail);
                         }
                         while (--size != new_size);

--- a/src/netxs/desktopio/geometry.hpp
+++ b/src/netxs/desktopio/geometry.hpp
@@ -97,6 +97,10 @@ namespace netxs
         constexpr auto& operator %= (T i)          { x %= i;   y %= i;   return *this; }
         constexpr auto  operator <  (T i)    const { return x < i && y < i;            }
         constexpr auto  operator >  (T i)    const { return x > i && y > i;            }
+        constexpr auto  operator <= (T i)    const { return x <= i && y <= i;          }
+        constexpr auto  operator >= (T i)    const { return x >= i && y >= i;          }
+        constexpr auto  operator <= (xy2d p) const { return x <= p.x && y <= p.y;      }
+        constexpr auto  operator >= (xy2d p) const { return x >= p.x && y >= p.y;      }
         constexpr auto  operator +  (xy2d p) const { return xy2d{ x + p.x, y + p.y };  }
         constexpr auto  operator -  (xy2d p) const { return xy2d{ x - p.x, y - p.y };  }
         constexpr auto  operator *  (xy2d p) const { return xy2d{ x * p.x, y * p.y };  }

--- a/src/netxs/desktopio/geometry.hpp
+++ b/src/netxs/desktopio/geometry.hpp
@@ -216,7 +216,7 @@ namespace netxs
     static constexpr auto dot_22 = twod{ 2,2 };
     static constexpr auto dot_21 = twod{ 2,1 };
     static constexpr auto dot_33 = twod{ 3,3 };
-    static constexpr auto dot_mx = twod{ (si32)(fp32)(si32max / 2), (si32)(fp32)(si32max / 2) }; // Be sure that fp2d{ dot_mx } == twod{ dot_mx }.
+    static constexpr auto dot_mx = twod{ (si32)(fp32)(netxs::si32max / 2), (si32)(fp32)(netxs::si32max / 2) }; // Be sure that fp2d{ dot_mx } == twod{ dot_mx }.
 
     twod divround(twod p, si32 n) { return { divround(p.x, n  ), divround(p.y, n  ) }; }
     twod divround(si32 n, twod p) { return { divround(n  , p.x), divround(n  , p.y) }; }

--- a/src/netxs/desktopio/gui.hpp
+++ b/src/netxs/desktopio/gui.hpp
@@ -3421,7 +3421,7 @@ namespace netxs::gui
                 m.gear_id = gear.id;
                 w.gear_id = gear.id;
                 m.enabled = input::hids::stat::ok;
-                m.coordxy = { si16min, si16min };
+                m.coordxy = { netxs::si16min, netxs::si16min };
                 c.fast = true;
             }
         };

--- a/src/netxs/desktopio/gui.hpp
+++ b/src/netxs/desktopio/gui.hpp
@@ -4121,7 +4121,7 @@ namespace netxs::gui
         bool remove_image_bits(std::vector<ui16>& removed_image_indexes)
         {
             auto bitmap_lock = stream.bitmap_dtvt.freeze();
-            auto hit = bitmap_lock.thing.image.remove_image_bits(removed_image_indexes);
+            auto hit = cell::remove_image_bits(bitmap_lock.thing.image, removed_image_indexes);
             return hit;
         }
         bool update_image_bits(ui16 updated_image_index)
@@ -5009,7 +5009,7 @@ namespace netxs::gui
                 {
                     if (utf8.length()) // Update os window title.
                     {
-                        auto filtered = ui::para{ utf8 }.lyric->utf8();
+                        auto filtered = cell::to_utf8(ui::para{ utf8 }.content());
                         window_set_title(filtered);
                     }
                     auto window_id = id_t{};

--- a/src/netxs/desktopio/intmath.hpp
+++ b/src/netxs/desktopio/intmath.hpp
@@ -117,10 +117,10 @@ namespace netxs
     static constexpr auto fp32nan = std::numeric_limits<fp32>::quiet_NaN();
     static constexpr auto fp64nan = std::numeric_limits<fp64>::quiet_NaN();
     static constexpr auto debugmode
-        #if defined(DEBUG)
-        = true;
-        #else
+        #if defined(NDEBUG)
         = faux;
+        #else
+        = true;
         #endif
 
     [[maybe_unused]] static auto _k0 = 0; // LCtrl+Wheel.

--- a/src/netxs/desktopio/intmath.hpp
+++ b/src/netxs/desktopio/intmath.hpp
@@ -182,8 +182,8 @@ namespace netxs
     constexpr auto operator & (axes l, axes r) { return static_cast<si32>(l) & static_cast<si32>(r); }
 
     template<class T>
-    using to_signed_t = std::conditional_t<(si64)std::numeric_limits<std::remove_reference_t<T>>::max() <= si16max, si16,
-                        std::conditional_t<(si64)std::numeric_limits<std::remove_reference_t<T>>::max() <= si32max, si32, si64>>;
+    using to_signed_t = std::conditional_t<(si64)std::numeric_limits<std::remove_reference_t<T>>::max() <= netxs::si16max, si16,
+                        std::conditional_t<(si64)std::numeric_limits<std::remove_reference_t<T>>::max() <= netxs::si32max, si32, si64>>;
 
     template<class T>
     auto& any_get_or(std::any const& value, T& fallback)

--- a/src/netxs/desktopio/intmath.hpp
+++ b/src/netxs/desktopio/intmath.hpp
@@ -200,27 +200,23 @@ namespace netxs
     template<ui64 FieldMask>
     static constexpr si32 field_offset()
     {
-        auto mask = FieldMask;
-        if (mask == 0) return 0;
-        auto n = 0;
-        while ((mask & 1) == 0)
-        {
-            mask >>= 1;
-            ++n;
-        }
-        return n;
+        if constexpr (FieldMask == 0) return 0;
+        return (si32)std::countr_zero(FieldMask);
     }
     template<ui64 FieldMask>
     void set_field(si32 v, auto& token)
     {
         using TType = std::decay_t<decltype(token)>;
+        constexpr auto value_mask = FieldMask >> netxs::field_offset<FieldMask>();
         token &= static_cast<TType>(~FieldMask);
-        token |= ((TType)(std::make_unsigned_t<decltype(v)>)v << netxs::field_offset<FieldMask>());
+        token |= (((TType)(std::make_unsigned_t<decltype(v)>)v & value_mask) << netxs::field_offset<FieldMask>());
     }
     template<ui64 FieldMask>
     auto get_field(auto token)
     {
-        return (si32)((token & FieldMask) >> netxs::field_offset<FieldMask>());
+        using TType = std::decay_t<decltype(token)>;
+        auto val = ((std::make_unsigned_t<TType>)token & FieldMask) >> netxs::field_offset<FieldMask>();
+        return (si32)val;
     }
     // intmath: Set a single p-bit to v.
     template<sz_t P, class T>

--- a/src/netxs/desktopio/intmath.hpp
+++ b/src/netxs/desktopio/intmath.hpp
@@ -984,22 +984,49 @@ namespace netxs
         }
     }
 
-    // intmath: Copy the bitmap to the bitmap by invoking
-    //          handle(sprite1_element, sprite2_element) for each elem.
-    void oncopy(auto&& bitmap1, auto&& bitmap2, auto handle)
+    // intmath: Inovke a handle(container1_element, container2_element) for each element in equal conainers.
+    template<bool RtoL = faux>
+    void oncopy(auto&& items1, auto&& items2, auto handle)
     {
-        auto& size1 = bitmap1.size();
-        auto& size2 = bitmap2.size();
-        if (size1 == size2)
+        if (items1.size() == items2.size())
         {
-            auto data1 = bitmap1.begin();
-            auto data2 = bitmap2.begin();
-            auto limit = data1 + size1.y * size2.x;
-            while (limit != data1)
+            if constexpr (RtoL)
             {
-                handle(*data1++, *data2++);
+                auto iter1 = items1.begin();
+                auto iter2 = items2.rbegin();
+                auto limit = items2.rend();
+                while (limit != iter2)
+                {
+                    handle(*iter1++, *iter2++);
+                }
+            }
+            else
+            {
+                auto iter1 = items1.begin();
+                auto iter2 = items2.begin();
+                auto limit = items2.end();
+                while (limit != iter2)
+                {
+                    handle(*iter1++, *iter2++);
+                }
             }
         }
+    }
+    // intmath: Exec a handle for each item in container.
+    template<bool RtoL = faux, class T, class P, bool Plain = std::is_same_v<void, std::invoke_result_t<P, decltype(*(std::declval<T&>().begin()))>>>
+    auto for_each(T& container, P handle)
+    {
+        auto run = [&](auto&& items)
+        {
+            for (auto& c : items)
+            {
+                if constexpr (Plain) handle(c);
+                else             if (handle(c)) return faux;
+            }
+            if constexpr (!Plain) return true;
+        };
+        return RtoL ? run(container | std::views::reverse)
+                    : run(container);
     }
 
     // intmath: Intersect two sprites and

--- a/src/netxs/desktopio/intmath.hpp
+++ b/src/netxs/desktopio/intmath.hpp
@@ -117,10 +117,10 @@ namespace netxs
     static constexpr auto fp32nan = std::numeric_limits<fp32>::quiet_NaN();
     static constexpr auto fp64nan = std::numeric_limits<fp64>::quiet_NaN();
     static constexpr auto debugmode
-        #if defined(NDEBUG)
-        = faux;
-        #else
+        #if defined(DEBUG)
         = true;
+        #else
+        = faux;
         #endif
 
     [[maybe_unused]] static auto _k0 = 0; // LCtrl+Wheel.

--- a/src/netxs/desktopio/lixx.hpp
+++ b/src/netxs/desktopio/lixx.hpp
@@ -12779,7 +12779,7 @@ namespace netxs::lixx // li++, libinput++.
                                     auto edges = tp.evdev_device_mm_to_units(mm);
                                     tp.buttons.bottom_area.top_edge = edges.y;
                                     tp.buttons.bottom_area.rightbutton_left_edge = edges.x;
-                                    tp.buttons.bottom_area.middlebutton_left_edge = si32max;
+                                    tp.buttons.bottom_area.middlebutton_left_edge = netxs::si32max;
                                     // If middlebutton emulation is enabled, don't init a software area.
                                     if (tp.middlebutton.want_enabled) return;
                                     // The middle button is 25% of the touchpad and centered. Many touchpads don't have markings for the middle button at all so we need to make it big enough to reliably hit it but not too big so it takes away all the space.
@@ -13172,7 +13172,7 @@ namespace netxs::lixx // li++, libinput++.
                                         }
                                         else
                                         {
-                                            tp.buttons.top_area.bottom_edge = si32min;
+                                            tp.buttons.top_area.bottom_edge = netxs::si32min;
                                         }
                                     }
                                         void tp_sync_touch(tp_touch& t, si32 slot)
@@ -13824,7 +13824,7 @@ namespace netxs::lixx // li++, libinput++.
                             {
                                 case LIBINPUT_CONFIG_CLICK_METHOD_BUTTON_AREAS: tp_init_softbuttons(); break;
                                 case LIBINPUT_CONFIG_CLICK_METHOD_CLICKFINGER:
-                                case LIBINPUT_CONFIG_CLICK_METHOD_NONE: tp.buttons.bottom_area.top_edge = si32max; break;
+                                case LIBINPUT_CONFIG_CLICK_METHOD_NONE: tp.buttons.bottom_area.top_edge = netxs::si32max; break;
                             }
                         }
                     libinput_config_click_method tp_click_get_default_method()
@@ -14106,9 +14106,9 @@ namespace netxs::lixx // li++, libinput++.
                     }
                 void tp_init_palmdetect()
                 {
-                    tp.palm.right_edge = si32max;
-                    tp.palm.left_edge = si32min;
-                    tp.palm.upper_edge = si32min;
+                    tp.palm.right_edge = netxs::si32max;
+                    tp.palm.left_edge = netxs::si32min;
+                    tp.palm.upper_edge = netxs::si32min;
                     tp_init_palmdetect_arbitration();
                     if (tp.device_tags & EVDEV_TAG_EXTERNAL_TOUCHPAD
                      && !tp_is_tpkb_combo_below()
@@ -14167,7 +14167,7 @@ namespace netxs::lixx // li++, libinput++.
                         auto edges = tp.evdev_device_mm_to_units(mm);
                         tp.tp_scroll.right_edge = edges.x;
                         if (want_horiz_scroll) tp.tp_scroll.bottom_edge = edges.y;
-                        else                   tp.tp_scroll.bottom_edge = si32max;
+                        else                   tp.tp_scroll.bottom_edge = netxs::si32max;
                         auto i = 0;
                         for (auto& t : tp.touches)
                         {
@@ -14488,8 +14488,8 @@ namespace netxs::lixx // li++, libinput++.
                 if (h < 50) return;
                 tp.thumb.detect_thumbs      = true;
                 tp.thumb.use_pressure       = faux;
-                tp.thumb.pressure_threshold = si32max;
-                tp.thumb.size_threshold     = si32max;
+                tp.thumb.pressure_threshold = netxs::si32max;
+                tp.thumb.size_threshold     = netxs::si32max;
                 auto mm = fp64_coor{};
                 mm.y = h * 0.85; // Detect thumbs by pressure in the bottom 15mm, detect thumbs by lingering in the bottom 8mm.
                 auto edges = tp.evdev_device_mm_to_units(mm);

--- a/src/netxs/desktopio/richtext.hpp
+++ b/src/netxs/desktopio/richtext.hpp
@@ -608,52 +608,6 @@ namespace netxs::ui
         {
             return canvas.empty();
         }
-        void shrink(cell const& blank, si32 max_size = 0, si32 min_size = 0)
-        {
-            assert(min_size <= length());
-            auto head = begin();
-            auto tail = end();
-            auto stop = head + min_size;
-            while (stop != tail)
-            {
-                auto next = tail - 1;
-                if (*next != blank) break;
-                tail = next;
-            }
-            auto new_size = (si32)(tail - head);
-            if (max_size && max_size < new_size) new_size = max_size;
-            if (new_size != length()) crop(new_size);
-        }
-        template<bool AutoGrow = faux>
-        void splice(si32 at, si32 count, cell const& blank)
-        {
-            if (count <= 0) return;
-            auto len = length();
-            if constexpr (AutoGrow)
-            {
-                rich::resize(at + count);
-            }
-            else
-            {
-                if (at >= len) return;
-                count = std::min(count, len - at);
-            }
-            auto ptr = begin();
-            auto dst = ptr + at;
-            auto end = dst + count;
-            while (dst != end) *dst++ = blank;
-        }
-        template<class Span, class Shader>
-        void splice(si32 at, Span const& fragment, Shader fuse, cell const& c = {})
-        {
-            auto len = fragment.length();
-            rich::resize(len + at, c);
-            auto ptr = begin();
-            auto dst = ptr + at;
-            auto end = dst + len;
-            auto src = fragment.begin();
-            while (dst != end) fuse(*dst++, *src++);
-        }
         template<bool Copy = faux, class SrcIt, class DstIt, class Shader>
         static void forward_fill_proc(SrcIt data, DstIt dest, DstIt tail, Shader fuse)
         {
@@ -1624,11 +1578,6 @@ namespace netxs::ui
         line(line&& l)
             : canvas{ std::move(l.canvas) }
         {
-            //static constexpr auto j = sizeof(core);//112
-            //static constexpr auto i = sizeof(rich);//112
-            //static constexpr auto i2 = sizeof(line);//144 //104
-            //static constexpr auto i3 = sizeof(deco);//20
-
             marker = l.marker;
             style = l.style;
             index = l.index;
@@ -1722,11 +1671,10 @@ namespace netxs::ui
         // line: Return sub-line view.
         auto substr(si32 at, si32 width = netxs::si32max) const
         {
-            //auto w = size();
-            //auto a = std::max(0, at);
-            //return a < w ? std::span{ canvas.begin() + a, (size_t)std::min(std::max(0, width), w - a) }
-            //             : std::span{ canvas.begin() + 0, (size_t)0 };
-            return subline(at, at + std::max(0, width));
+            auto w = size();
+            auto a = std::max(0, at);
+            return a < w ? std::span{ canvas.begin() + a, (size_t)std::min(std::max(0, width), w - a) }
+                         : std::span{ canvas.begin() + 0, (size_t)0 };
         }
         // line: Collapse line to zero size.
         void wipe()
@@ -1770,21 +1718,18 @@ namespace netxs::ui
                 crop(oversize, c);
             }
         }
-        // line: Trim all blank cells from the line end up to min_size (crop to max_size if exeeds).
-        void shrink(cell const& blank, si32 max_size = 0, si32 min_size = 0)
+        // line: Trim all blank cells from the line end.
+        void shrink(cell const& blank)
         {
-            assert(min_size <= size());
             auto head = canvas.begin();
             auto tail = canvas.end();
-            auto stop = head + min_size;
-            while (stop != tail)
+            while (head != tail)
             {
                 auto next = tail - 1;
                 if (*next != blank) break;
                 tail = next;
             }
             auto new_size = (si32)(tail - head);
-            if (max_size && max_size < new_size) new_size = max_size;
             if (new_size != size()) crop(new_size);
         }
         // line: Place a number of blank cells at specified position.
@@ -1868,25 +1813,8 @@ namespace netxs::ui
         // line: Copy the specified sub-line to the dest.
         auto copy_piece(line& dest, si32 from, si32 width) const
         {
-            auto my_size = size();
-            if (from >= my_size)
-            {
-                dest.crop(0);
-                return;
-            }
-            auto new_width = from % my_size + width;
-            if (new_width > my_size)
-            {
-                width = my_size - from;
-            }
-            dest.crop(width);
-            auto src = begin() + from;
-            auto dst = dest.begin();
-            auto end = dest.end();
-            while (dst != end)
-            {
-                *dst++ = *src++;
-            }
+            auto s = substr(from, width);
+            dest.canvas.assign(s.begin(), s.end());
         }
         // line: Find the substring and place its offset in &from.
         auto find(line const& what, auto&& from, feed dir = feed::fwd) const
@@ -1941,8 +1869,8 @@ namespace netxs::ui
 
         operator writ const& () const { return **source; }
 
-        // rope: Return a substring rope the source content.
-        //       ! No checking of boundaries !
+        // rope: Return a substring rope of the source content.
+        //       ! No boundary checking !
         rope substr(si32 start, si32 width) const
         {
             auto first = source;

--- a/src/netxs/desktopio/richtext.hpp
+++ b/src/netxs/desktopio/richtext.hpp
@@ -1606,6 +1606,89 @@ namespace netxs::ui
         }
     };
 
+    struct line
+        : public rich
+    {
+        using rich::rich;
+        using type = deco::type;
+
+        line(line&& l)
+            : rich{ std::move(l) },
+             index{ l.index      }
+        {
+            static constexpr auto j = sizeof(core);//112
+            static constexpr auto i = sizeof(rich);//112
+            static constexpr auto i2 = sizeof(line);//144
+            static constexpr auto i3 = sizeof(deco);//
+            style = l.style;
+            _size = l._size;
+            _kind = l._kind;
+            l._size = {};
+            l._kind = {};
+        }
+        line(line const& l)
+            : rich{ l       },
+             style{ l.style },
+             index{ l.index }
+        { }
+        line(id_t line_id, deco const& line_style, span dt, twod sz)
+            : rich{ dt, sz     },
+             style{ line_style },
+             index{ line_id    }
+        { }
+        line(id_t line_id, deco const& line_style, cell const& blank)
+            : rich{ blank      },
+             style{ line_style },
+             index{ line_id    }
+        { }
+        line(id_t line_id, deco const& line_style, cell const& blank, si32 length)
+            : rich{ blank, length },
+             style{ line_style    },
+             index{ line_id       }
+        { }
+        line(core&& s)
+            : rich{ std::move(s) }
+        { }
+        line(netxs::view utf8)
+            : rich{ para{ utf8 }.content() }
+        { }
+
+        line& operator = (line&&)      = default;
+        line& operator = (line const&) = default;
+
+        deco style{};
+        id_t index{};
+        si32 _size{};
+        si32 _kind{};
+
+        friend void swap(line& lhs, line& rhs)
+        {
+            std::swap<rich>(lhs, rhs);
+            std::swap(lhs.index, rhs.index);
+            std::swap(lhs.style, rhs.style);
+            std::swap(lhs._size, rhs._size);
+            std::swap(lhs._kind, rhs._kind);
+        }
+        void wipe()
+        {
+            rich::kill();
+            _size = {};
+            _kind = {};
+        }
+        bool wrapped() const
+        {
+            assert(_kind == style.get_kind());
+            return _kind == type::autowrap;
+        }
+        si32 height(si32 panel_x) const
+        {
+            auto len = length();
+            assert(_kind == style.get_kind());
+            return len > panel_x && wrapped() ? (len + panel_x - 1) / panel_x
+                                              : 1;
+        }
+    };
+
     // richtext: Cascade of the identical paragraphs.
     class rope
     {

--- a/src/netxs/desktopio/richtext.hpp
+++ b/src/netxs/desktopio/richtext.hpp
@@ -1572,25 +1572,6 @@ namespace netxs::ui
         line()              = default;
         line(line&& l)      = default;
         line(line const& l) = default;
-        line(id_t line_id, deco const& line_style, std::span<cell const> proto)
-            : cells{ proto.begin(), proto.end() },
-              index{ line_id          },
-              wraps{ line_style.wrp() },
-              align{ line_style.jet() },
-              r_2_l{ line_style.rtl() }
-        { }
-        line(id_t line_id, deco const& line_style, cell const& blank, si32 len = 0)
-            : cells( len, blank       ),
-              brush{ blank            },
-              index{ line_id          },
-              wraps{ line_style.wrp() },
-              align{ line_style.jet() },
-              r_2_l{ line_style.rtl() }
-        { }
-        line(body::const_iterator head, body::const_iterator tail, cell brush)
-            : cells{ head, tail },
-              brush{ brush      }
-        { }
         line(std::span<cell const> copy)
             : cells{ copy.begin(), copy.end() }
         { }
@@ -1606,6 +1587,30 @@ namespace netxs::ui
         auto  begin() const { return cells.begin(); }
         auto  end() const   { return cells.end();   }
 
+        void reinitialize(id_t line_id, deco const& line_style, cell const& blank, si32 len = 0)
+        {
+            cells.assign(len, blank);
+            brush = blank;
+            index = line_id;
+            wraps = line_style.wrp();
+            align = line_style.jet();
+            r_2_l = line_style.rtl();
+            image = {};
+        }
+        void reinitialize(id_t line_id, deco const& line_style, std::span<cell const> proto)
+        {
+            cells.assign(proto.begin(), proto.end());
+            brush = {};
+            index = line_id;
+            wraps = line_style.wrp();
+            align = line_style.jet();
+            r_2_l = line_style.rtl();
+            image = {};
+        }
+        void deallocate()
+        {
+            body().swap(cells);
+        }
         // line: Return default object ID for the line owner.
         auto link() const
         {
@@ -1825,7 +1830,7 @@ namespace netxs::ui
             }
         }
         // line: Copy the specified sub-line to the dest.
-        auto copy_piece(line& dest, si32 from, si32 width) const
+        auto copy_piece(line& dest, si32 from, si32 width = netxs::si32max) const
         {
             auto s = substr(from, width);
             dest.cells.assign(s.begin(), s.end());

--- a/src/netxs/desktopio/richtext.hpp
+++ b/src/netxs/desktopio/richtext.hpp
@@ -1561,18 +1561,18 @@ namespace netxs::ui
         using type = deco::type;
         using body = std::vector<cell>;
 
-        body canvas; // line: Cell data.
-        cell marker; // line: Current brush.
-        deco style{};
-        id_t index{};
-        si32 _size{};
-        si32 _kind{};
+        body cells{}; // line: Cell data.
+        cell brush{}; // line: Current brush.
+        deco style{}; // line: Line style.
+        id_t index{}; // line: Line index.
+        si32 _size{}; // line: Registered line size.
+        si32 _kind{}; // line: Registered line kind (alignment).
 
         line() = default;
         line(line&& l)
-            : canvas{ std::move(l.canvas) }
+            : cells{ std::move(l.cells) }
         {
-            marker = l.marker;
+            brush = l.brush;
             style = l.style;
             index = l.index;
             _size = l._size;
@@ -1582,27 +1582,27 @@ namespace netxs::ui
         }
         line(line const& l) = default;
         line(id_t line_id, deco const& line_style, std::span<cell const> proto)
-            : canvas{ proto.begin(), proto.end() },
+            : cells{ proto.begin(), proto.end() },
                style{ line_style },
                index{ line_id    }
         { }
         line(id_t line_id, deco const& line_style, cell const& blank)
-            : marker{ blank      },
+            : brush{ blank      },
                style{ line_style },
                index{ line_id    }
         { }
         line(id_t line_id, deco const& line_style, cell const& blank, si32 len)
-            : canvas( len, blank ),
-              marker{ blank      },
+            : cells( len, blank ),
+              brush{ blank      },
                style{ line_style },
                index{ line_id    }
         { }
         line(body::const_iterator head, body::const_iterator tail, cell marker)
-            : canvas{ head, tail },
-              marker{ marker }
+            : cells{ head, tail },
+              brush{ marker }
         { }
         line(std::span<cell const> copy)
-            : canvas{ copy.begin(), copy.end() }
+            : cells{ copy.begin(), copy.end() }
         { }
         line(view utf8)
             : line{ para{ utf8 }.content() }
@@ -1611,25 +1611,25 @@ namespace netxs::ui
         line& operator = (line&&)      = default;
         line& operator = (line const&) = default;
 
-        auto  begin()       { return canvas.begin(); }
-        auto  end()         { return canvas.end();   }
-        auto  begin() const { return canvas.begin(); }
-        auto  end() const   { return canvas.end();   }
+        auto  begin()       { return cells.begin(); }
+        auto  end()         { return cells.end();   }
+        auto  begin() const { return cells.begin(); }
+        auto  end() const   { return cells.end();   }
 
         // line: Return default object ID for the line owner.
         auto link() const
         {
-            return marker.link();
+            return brush.link();
         }
         // line: Return true if line is empty.
         auto empty() const
         {
-            return canvas.empty();
+            return cells.empty();
         }
         // line: Return line length.
         auto size() const
         {
-            return (si32)canvas.size();
+            return (si32)cells.size();
         }
         // line: Return line length.
         auto length() const
@@ -1639,18 +1639,18 @@ namespace netxs::ui
         // line: Set line length.
         void size(si32 new_size)
         {
-            canvas.assign(new_size, marker);
+            cells.assign(new_size, brush);
         }
         // line: Exec a proc for each cell.
         auto each(auto proc)
         {
-            return netxs::for_each(canvas, proc);
+            return netxs::for_each(cells, proc);
         }
         // line: Return cell at p.
         auto& at(si32 p) const
         {
             assert(p >= 0 && p < size());
-            return *(canvas.begin() + p);
+            return *(cells.begin() + p);
         }
         // line: Get stripe.
         auto subline(si32 from, si32 upto) const
@@ -1660,20 +1660,20 @@ namespace netxs::ui
             from = std::clamp(from, 0, w ? w - 1 : 0);
             upto = std::clamp(upto, 0, w);
             auto size = upto - from;
-            return std::span{ canvas.begin() + from, (size_t)size };
+            return std::span{ cells.begin() + from, (size_t)size };
         }
         // line: Return sub-line view.
         auto substr(si32 at, si32 width = netxs::si32max) const
         {
             auto w = size();
             auto a = std::max(0, at);
-            return a < w ? std::span{ canvas.begin() + a, (size_t)std::min(std::max(0, width), w - a) }
-                         : std::span{ canvas.begin() + 0, (size_t)0 };
+            return a < w ? std::span{ cells.begin() + a, (size_t)std::min(std::max(0, width), w - a) }
+                         : std::span{ cells.begin() + 0, (size_t)0 };
         }
         // line: Collapse line to zero size.
         void wipe()
         {
-            canvas.resize(0);
+            cells.resize(0);
             _size = {};
             _kind = {};
         }
@@ -1694,14 +1694,14 @@ namespace netxs::ui
         // line: Resize preserving content.
         void crop(si32 new_length, cell const& c = {})
         {
-            canvas.resize(new_length, c);
+            cells.resize(new_length, c);
         }
         // line: Trim line if it exeeds max_size.
         void trimto(si32 max_size)
         {
             if (length() > max_size)
             {
-                canvas.resize(max_size);
+                cells.resize(max_size);
             }
         }
         // line: Resize if needed (preserving content).
@@ -1715,8 +1715,8 @@ namespace netxs::ui
         // line: Trim all blank cells from the line end.
         void shrink(cell const& blank)
         {
-            auto head = canvas.begin();
-            auto tail = canvas.end();
+            auto head = cells.begin();
+            auto tail = cells.end();
             while (head != tail)
             {
                 auto next = tail - 1;
@@ -1741,7 +1741,7 @@ namespace netxs::ui
                 if (at >= len) return;
                 count = std::min(count, len - at);
             }
-            auto ptr = canvas.begin();
+            auto ptr = cells.begin();
             auto dst = ptr + at;
             auto end = dst + count;
             while (dst != end) *dst++ = blank;
@@ -1751,7 +1751,7 @@ namespace netxs::ui
         {
             auto len = (si32)fragment.size();
             resize(len + at, c);
-            auto ptr = canvas.begin();
+            auto ptr = cells.begin();
             auto dst = ptr + at;
             auto end = dst + len;
             auto src = fragment.begin();
@@ -1766,7 +1766,7 @@ namespace netxs::ui
         {
             if (count <= 0) return;
             resize(at + count, c);
-            auto end = canvas.begin() + at;
+            auto end = cells.begin() + at;
             auto dst = end + count;
             auto src = proto.end();
             rich::reverse_fill_proc<Copy>(src, dst, end, fuse);
@@ -1780,7 +1780,7 @@ namespace netxs::ui
             auto vol = std::min(count, margin - pos);
             auto max = std::min(len + vol, at + margin - pos);
             resize(max);
-            auto ptr = canvas.begin();
+            auto ptr = cells.begin();
             auto dst = ptr + max;
             auto src = dst - vol;
             auto end = ptr + at;
@@ -1797,7 +1797,7 @@ namespace netxs::ui
                 auto pos = at % margin;
                 auto rem = std::min(margin - pos, len - at);
                 auto vol = std::min(count, rem);
-                auto dst = canvas.begin() + at;
+                auto dst = cells.begin() + at;
                 auto end = dst + rem;
                 auto src = dst + vol;
                 while (src != end) *dst++ = *src++;
@@ -1808,24 +1808,24 @@ namespace netxs::ui
         auto copy_piece(line& dest, si32 from, si32 width) const
         {
             auto s = substr(from, width);
-            dest.canvas.assign(s.begin(), s.end());
+            dest.cells.assign(s.begin(), s.end());
         }
         // line: Find the substring and place its offset in &from.
         auto find(line const& what, auto&& from, feed dir = feed::fwd) const
         {
-            return cell::find(canvas, what.canvas, from, dir);
+            return cell::find(cells, what.cells, from, dir);
         }
         // line: Detect a word bound.
         template<feed Direction>
         auto word(si32 offset)
         {
-            return cell::word<Direction>(canvas, offset);
+            return cell::word<Direction>(cells, offset);
         }
         // line: Find proc(c) == true.
         template<feed Direction>
         auto seek(si32& start, auto proc)
         {
-            return cell::seek<Direction>(canvas, start, proc);
+            return cell::seek<Direction>(cells, start, proc);
         }
     };
 

--- a/src/netxs/desktopio/richtext.hpp
+++ b/src/netxs/desktopio/richtext.hpp
@@ -1564,31 +1564,13 @@ namespace netxs::ui
         body cells{}; // line: Cell data.
         cell brush{}; // line: Current brush.
         id_t index{}; // line: Line index.
-        si32 _size{}; // line: Registered line size.
-        byte _kind : 2 = {}; // line: Registered line kind (alignment).
         wrap wraps : 2 = {}; // line: Autowrap.
         bias align : 2 = {}; // line: Horizontal alignment.
         rtol r_2_l : 2 = {}; // line: RTL.
         byte image : 1 = {}; // line: Line contains image cells.
 
-        line() = default;
-        line(line&& l)
-            : cells{ std::move(l.cells) }
-        {
-            static constexpr auto iii2 = sizeof(cell);//40
-            static constexpr auto iii1 = sizeof(body);//32
-            static constexpr auto iii4 = sizeof(deco);//20 //6
-            static constexpr auto iii3 = sizeof(line);//104 //88
-            brush = l.brush;
-            wraps = l.wraps;
-            align = l.align;
-            r_2_l = l.r_2_l;
-            index = l.index;
-            _size = l._size;
-            _kind = l._kind;
-            l._size = {};
-            l._kind = {};
-        }
+        line()              = default;
+        line(line&& l)      = default;
         line(line const& l) = default;
         line(id_t line_id, deco const& line_style, std::span<cell const> proto)
             : cells{ proto.begin(), proto.end() },
@@ -1678,14 +1660,6 @@ namespace netxs::ui
             return a < w ? std::span{ cells.begin() + a, (size_t)std::min(std::max(0, width), w - a) }
                          : std::span{ cells.begin() + 0, (size_t)0 };
         }
-        // line: Return line alignment kind.
-        auto get_kind() const
-        {
-            return wraps == wrap::on    ? type::autowrap :
-                   align == bias::left  ? type::leftside :
-                   align == bias::right ? type::rghtside :
-                                          type::centered ;
-        }
         auto  jet() const { return align;                                    } // line: Return line alignment.
         auto  wrp() const { return wraps;                                    } // line: Return line auto wrapping.
         auto  rtl() const { return r_2_l;                                    } // line: Return RTL.
@@ -1712,24 +1686,28 @@ namespace netxs::ui
         {
             return deco{}.wrp(wraps).jet(align).rtl(r_2_l);
         }
-        // line: Collapse line to zero size.
-        void wipe()
+        // line: Return line alignment kind.
+        auto get_kind() const
         {
-            cells.resize(0);
-            _size = {};
-            _kind = {};
+            return wraps == wrap::on    ? type::autowrap :
+                   align == bias::left  ? type::leftside :
+                   align == bias::right ? type::rghtside :
+                                          type::centered ;
+        }
+        // line: Return current line state.
+        auto get_state() const
+        {
+            return std::tuple{ get_kind(), length() };
         }
         // line: Return true if line is wrapped.
-        bool wrapped() const
+        auto wrapped() const
         {
-            assert(_kind == get_kind());
-            return _kind == type::autowrap;
+            return wraps == wrap::on;
         }
         // line: Return wrapped line height.
-        si32 height(si32 panel_x) const
+        auto height(si32 panel_x) const
         {
             auto len = size();
-            assert(_kind == get_kind());
             return len > panel_x && wrapped() ? (len + panel_x - 1) / panel_x
                                               : 1;
         }

--- a/src/netxs/desktopio/richtext.hpp
+++ b/src/netxs/desktopio/richtext.hpp
@@ -1606,12 +1606,18 @@ namespace netxs::ui
         }
     };
 
+    // richtext: 1D cell run.
     struct line
         : public rich
     {
-        using rich::rich;
         using type = deco::type;
 
+        deco style{};
+        id_t index{};
+        si32 _size{};
+        si32 _kind{};
+
+        line() = default;
         line(line&& l)
             : rich{ std::move(l) },
              index{ l.index      }
@@ -1655,11 +1661,6 @@ namespace netxs::ui
 
         line& operator = (line&&)      = default;
         line& operator = (line const&) = default;
-
-        deco style{};
-        id_t index{};
-        si32 _size{};
-        si32 _kind{};
 
         friend void swap(line& lhs, line& rhs)
         {

--- a/src/netxs/desktopio/richtext.hpp
+++ b/src/netxs/desktopio/richtext.hpp
@@ -1169,12 +1169,6 @@ namespace netxs::ui
             }
             return cluster;
         }
-        //todo unify
-        auto& at(si32 p) const
-        {
-            assert(p >= 0);
-            return *(core::begin() + p);
-        }
     };
 
     // richtext: Text paragraph.

--- a/src/netxs/desktopio/richtext.hpp
+++ b/src/netxs/desktopio/richtext.hpp
@@ -352,7 +352,8 @@ namespace netxs::ui
         {
             compose<Split>(block, [&](auto const& coord, auto const& subblock, auto isr_to_l)
                                   {
-                                      canvas.text(coord, subblock, isr_to_l, printfx);
+                                      isr_to_l ? canvas.text<true>(coord, subblock, printfx)
+                                               : canvas.text<faux>(coord, subblock, printfx);
                                   });
         }
         template<bool UseLocus = true, bool Split = faux, class T, class P = noop>
@@ -505,7 +506,7 @@ namespace netxs::ui
         { }
 
         constexpr
-        auto substr(si32 start, si32 length = si32max) const
+        auto substr(si32 start, si32 length = netxs::si32max) const
         {
             auto w = body.size().x;
             auto a = skip + std::max(0, start);
@@ -574,14 +575,14 @@ namespace netxs::ui
         auto length() const                                     { return size().x;                            }
         auto shadow() const                                     { return shot{ *this };                       }
         auto substr(si32 at, si32 width = netxs::si32max) const { return shadow().substr(at, width);          }
-        void trimto(si32 max_size, cell const& c = {})          { if (length() > max_size) crop(max_size, c); }
+        void trimto(si32 max_size)                              { if (length() > max_size) crop(max_size);    }
         void resize(si32 oversize, cell const& c = {})          { if (oversize > length()) crop(oversize, c); }
         auto take_piece(si32 at, si32 width = netxs::si32max) const
         {
             if (width == netxs::si32max) width = length() - at;
             return rich{ core::crop(at, width) };
         }
-        auto copy_piece(rich& dest, si32 from, si32 width) const
+        auto copy_piece(auto& dest, si32 from, si32 width) const
         {
             auto my_size = size();
             if (from >= my_size.x * my_size.y)
@@ -1280,7 +1281,7 @@ namespace netxs::ui
         auto   size() const { return lyric->size();   } // para: Return 2D volume size.
         auto&  back() const { return brush;           } // para: Return current brush.
         bool   busy() const { return length() || !parser::empty() || brush.busy(); } // para: Is it filled.
-        void   link(id_t id) { lyric->each([&](auto& c){ c.link(id); });  } // para: Set object ID for each cell.
+        void   link(id_t id) { netxs::for_each(content(), [&](auto& c){ c.link(id); });  } // para: Set object ID for each cell.
         template<bool ResetStyle = faux>
         void wipe(cell c = cell{}) // para: Clear the text and locus, and reset SGR attributes.
         {
@@ -1608,10 +1609,12 @@ namespace netxs::ui
 
     // richtext: 1D cell run.
     struct line
-        : public rich
     {
         using type = deco::type;
+        using body = std::vector<cell>;
 
+        body canvas; // line: Cell data.
+        cell marker; // line: Current brush.
         deco style{};
         id_t index{};
         si32 _size{};
@@ -1619,74 +1622,288 @@ namespace netxs::ui
 
         line() = default;
         line(line&& l)
-            : rich{ std::move(l) },
-             index{ l.index      }
+            : canvas{ std::move(l.canvas) }
         {
-            static constexpr auto j = sizeof(core);//112
-            static constexpr auto i = sizeof(rich);//112
-            static constexpr auto i2 = sizeof(line);//144
-            static constexpr auto i3 = sizeof(deco);//
+            //static constexpr auto j = sizeof(core);//112
+            //static constexpr auto i = sizeof(rich);//112
+            //static constexpr auto i2 = sizeof(line);//144 //104
+            //static constexpr auto i3 = sizeof(deco);//20
+
+            marker = l.marker;
             style = l.style;
+            index = l.index;
             _size = l._size;
             _kind = l._kind;
             l._size = {};
             l._kind = {};
         }
-        line(line const& l)
-            : rich{ l       },
-             style{ l.style },
-             index{ l.index }
-        { }
-        line(id_t line_id, deco const& line_style, span dt, twod sz)
-            : rich{ dt, sz     },
-             style{ line_style },
-             index{ line_id    }
+        line(line const& l) = default;
+        line(id_t line_id, deco const& line_style, std::span<cell const> proto)
+            : canvas{ proto.begin(), proto.end() },
+               style{ line_style },
+               index{ line_id    }
         { }
         line(id_t line_id, deco const& line_style, cell const& blank)
-            : rich{ blank      },
-             style{ line_style },
-             index{ line_id    }
+            : marker{ blank      },
+               style{ line_style },
+               index{ line_id    }
         { }
-        line(id_t line_id, deco const& line_style, cell const& blank, si32 length)
-            : rich{ blank, length },
-             style{ line_style    },
-             index{ line_id       }
+        line(id_t line_id, deco const& line_style, cell const& blank, si32 len)
+            : canvas( len, blank ),
+              marker{ blank      },
+               style{ line_style },
+               index{ line_id    }
         { }
-        line(core&& s)
-            : rich{ std::move(s) }
+        line(body::const_iterator head, body::const_iterator tail, cell marker)
+            : canvas{ head, tail },
+              marker{ marker }
         { }
-        line(netxs::view utf8)
-            : rich{ para{ utf8 }.content() }
+        line(std::span<cell const> copy)
+            : canvas{ copy.begin(), copy.end() }
+        { }
+        line(view utf8)
+            : line{ para{ utf8 }.content() }
         { }
 
         line& operator = (line&&)      = default;
         line& operator = (line const&) = default;
 
-        friend void swap(line& lhs, line& rhs)
+        auto  begin()       { return canvas.begin(); }
+        auto  end()         { return canvas.end();   }
+        auto  begin() const { return canvas.begin(); }
+        auto  end() const   { return canvas.end();   }
+
+        // line: Return default object ID for the line owner.
+        auto link() const
         {
-            std::swap<rich>(lhs, rhs);
-            std::swap(lhs.index, rhs.index);
-            std::swap(lhs.style, rhs.style);
-            std::swap(lhs._size, rhs._size);
-            std::swap(lhs._kind, rhs._kind);
+            return marker.link();
         }
+        // line: Return true if line is empty.
+        auto empty() const
+        {
+            return canvas.empty();
+        }
+        // line: Return line length.
+        auto size() const
+        {
+            return (si32)canvas.size();
+        }
+        // line: Return line length.
+        auto length() const
+        {
+            return size();
+        }
+        // line: Set line length.
+        void size(si32 new_size)
+        {
+            canvas.assign(new_size, marker);
+        }
+        // line: Exec a proc for each cell.
+        auto each(auto proc)
+        {
+            return netxs::for_each(canvas, proc);
+        }
+        // line: Return cell at p.
+        auto& at(si32 p) const
+        {
+            assert(p >= 0 && p < size());
+            return *(canvas.begin() + p);
+        }
+        // line: Get stripe.
+        auto subline(si32 from, si32 upto) const
+        {
+            if (from > upto) std::swap(from, upto);
+            auto w = size();
+            from = std::clamp(from, 0, w ? w - 1 : 0);
+            upto = std::clamp(upto, 0, w);
+            auto size = upto - from;
+            return std::span{ canvas.begin() + from, (size_t)size };
+        }
+        // line: Return sub-line view.
+        auto substr(si32 at, si32 width = netxs::si32max) const
+        {
+            //auto w = size();
+            //auto a = std::max(0, at);
+            //return a < w ? std::span{ canvas.begin() + a, (size_t)std::min(std::max(0, width), w - a) }
+            //             : std::span{ canvas.begin() + 0, (size_t)0 };
+            return subline(at, at + std::max(0, width));
+        }
+        // line: Collapse line to zero size.
         void wipe()
         {
-            rich::kill();
+            canvas.resize(0);
             _size = {};
             _kind = {};
         }
+        // line: Return true if line is wrapped.
         bool wrapped() const
         {
             assert(_kind == style.get_kind());
             return _kind == type::autowrap;
         }
+        // line: Return wrapped line height.
         si32 height(si32 panel_x) const
         {
-            auto len = length();
+            auto len = size();
             assert(_kind == style.get_kind());
             return len > panel_x && wrapped() ? (len + panel_x - 1) / panel_x
                                               : 1;
+        }
+        // line: Resize preserving content.
+        void crop(si32 new_length, cell const& c = {})
+        {
+            canvas.resize(new_length, c);
+        }
+        // line: Trim line if it exeeds max_size.
+        void trimto(si32 max_size)
+        {
+            if (length() > max_size)
+            {
+                canvas.resize(max_size);
+            }
+        }
+        // line: Resize if needed (preserving content).
+        void resize(si32 oversize, cell const& c = {})
+        {
+            if (oversize > size())
+            {
+                crop(oversize, c);
+            }
+        }
+        // line: Trim all blank cells from the line end up to min_size (crop to max_size if exeeds).
+        void shrink(cell const& blank, si32 max_size = 0, si32 min_size = 0)
+        {
+            assert(min_size <= size());
+            auto head = canvas.begin();
+            auto tail = canvas.end();
+            auto stop = head + min_size;
+            while (stop != tail)
+            {
+                auto next = tail - 1;
+                if (*next != blank) break;
+                tail = next;
+            }
+            auto new_size = (si32)(tail - head);
+            if (max_size && max_size < new_size) new_size = max_size;
+            if (new_size != size()) crop(new_size);
+        }
+        // line: Place a number of blank cells at specified position.
+        template<bool AutoGrow = faux>
+        void splice(si32 at, si32 count, cell const& blank)
+        {
+            if (count <= 0) return;
+            auto len = size();
+            if constexpr (AutoGrow)
+            {
+                resize(at + count);
+            }
+            else
+            {
+                if (at >= len) return;
+                count = std::min(count, len - at);
+            }
+            auto ptr = canvas.begin();
+            auto dst = ptr + at;
+            auto end = dst + count;
+            while (dst != end) *dst++ = blank;
+        }
+        // line: Place the specified fragment to the specified position.
+        void splice(si32 at, std::span<cell const> fragment, auto fuse, cell const& c = {})
+        {
+            auto len = (si32)fragment.size();
+            resize(len + at, c);
+            auto ptr = canvas.begin();
+            auto dst = ptr + at;
+            auto end = dst + len;
+            auto src = fragment.begin();
+            while (dst != end)
+            {
+                fuse(*dst++, *src++);
+            }
+        }
+        // line: Splice proto with auto grow.
+        template<bool Copy = faux>
+        void splice(si32 at, si32 count, std::span<cell const> proto, auto fuse, cell const& c = {})
+        {
+            if (count <= 0) return;
+            resize(at + count, c);
+            auto end = canvas.begin() + at;
+            auto dst = end + count;
+            auto src = proto.end();
+            rich::reverse_fill_proc<Copy>(src, dst, end, fuse);
+        }
+        // line: Insert n blanks at the specified position. Autogrow within segment only.
+        void insert(si32 at, si32 count, cell const& blank, si32 margin)
+        {
+            if (count <= 0 || margin == 0) return;
+            auto len = size();
+            auto pos = at % margin;
+            auto vol = std::min(count, margin - pos);
+            auto max = std::min(len + vol, at + margin - pos);
+            resize(max);
+            auto ptr = canvas.begin();
+            auto dst = ptr + max;
+            auto src = dst - vol;
+            auto end = ptr + at;
+            while (src != end) *--dst = *--src;
+            while (dst != end) *--dst = blank;
+        }
+        // line: Delete n chars and add blanks at the right margin.
+        void cutoff(si32 at, si32 count, cell const& blank, si32 margin)
+        {
+            if (count <= 0 || margin == 0) return;
+            auto len = size();
+            if (at < len)
+            {
+                auto pos = at % margin;
+                auto rem = std::min(margin - pos, len - at);
+                auto vol = std::min(count, rem);
+                auto dst = canvas.begin() + at;
+                auto end = dst + rem;
+                auto src = dst + vol;
+                while (src != end) *dst++ = *src++;
+                while (dst != end) *dst++ = blank;
+            }
+        }
+        // line: Copy the specified sub-line to the dest.
+        auto copy_piece(line& dest, si32 from, si32 width) const
+        {
+            auto my_size = size();
+            if (from >= my_size)
+            {
+                dest.crop(0);
+                return;
+            }
+            auto new_width = from % my_size + width;
+            if (new_width > my_size)
+            {
+                width = my_size - from;
+            }
+            dest.crop(width);
+            auto src = begin() + from;
+            auto dst = dest.begin();
+            auto end = dest.end();
+            while (dst != end)
+            {
+                *dst++ = *src++;
+            }
+        }
+        // line: Find the substring and place its offset in &from.
+        auto find(line const& what, auto&& from, feed dir = feed::fwd) const
+        {
+            return cell::find(canvas, what.canvas, from, dir);
+        }
+        // line: Detect a word bound.
+        template<feed Direction>
+        auto word(si32 offset)
+        {
+            return cell::word<Direction>(canvas, offset);
+        }
+        // line: Find proc(c) == true.
+        template<feed Direction>
+        auto seek(si32& start, auto proc)
+        {
+            return cell::seek<Direction>(canvas, start, proc);
         }
     };
 
@@ -2041,7 +2258,7 @@ namespace netxs::ui
         void data(si32 width, si32 /*height*/, core::body const& proto) override
         {
             auto& item = **layer;
-            item.lyric->splice(item.caret, width, proto, cell::shaders::full);
+            item.content().splice(item.caret, width, proto, cell::shaders::full);
             item.caret += width;
         }
         auto& current()       { return **layer; } // page: Access to the current paragraph.
@@ -2231,7 +2448,7 @@ namespace netxs::ui
                         while (c.arg--) dest.data += nline;
                     }
                 }
-                curln.lyric->each([&](cell& c)
+                netxs::for_each(curln.content(), [&](cell& c)
                 {
                     if (c.isspc()) c.txt(whitespace);
                     auto [w, h, x, y] = c.whxy();
@@ -2359,7 +2576,7 @@ namespace netxs::ui
                         while (c.arg--) dest.data += "\n";
                     }
                 }
-                curln.lyric->each([&](cell c)
+                netxs::for_each(curln.content(), [&](cell c)
                 {
                     if (c.isspc()) c.txt(whitespace);
                     auto [w, h, x, y] = c.whxy();
@@ -2436,7 +2653,7 @@ namespace netxs::ui
                         while (c.arg--) dest.data += "\n";
                     }
                 }
-                curln.lyric->each([&](cell c)
+                netxs::for_each(curln.content(), [&](cell c)
                 {
                     if (c.isspc()) c.txt(whitespace);
                     auto [w, h, x, y] = c.whxy();

--- a/src/netxs/desktopio/richtext.hpp
+++ b/src/netxs/desktopio/richtext.hpp
@@ -568,7 +568,7 @@ namespace netxs::ui
         using core::core;
 
         rich(core&& s)
-            : core{ std::forward<core>(s) }
+            : core{ std::move(s) }
         { }
 
         auto length() const                                     { return size().x;                            }

--- a/src/netxs/desktopio/richtext.hpp
+++ b/src/netxs/desktopio/richtext.hpp
@@ -1565,13 +1565,11 @@ namespace netxs::ui
         cell brush{}; // line: Current brush.
         id_t index{}; // line: Line index.
         si32 _size{}; // line: Registered line size.
-        si32 _kind{}; // line: Registered line kind (alignment).
-        //ui16 _size  : 16 = {}; // line: Registered line size.
-        //byte _kind  : 2 = {}; // line: Registered line kind (alignment).
-        wrap wrapln : 2 = {}; // line: Autowrap.
-        bias adjust : 2 = {}; // line: Horizontal alignment.
-        rtol r_to_l : 2 = {}; // line: RTL.
-        byte hasimg : 1 = {}; // line: Line contains image cells.
+        byte _kind : 2 = {}; // line: Registered line kind (alignment).
+        wrap wraps : 2 = {}; // line: Autowrap.
+        bias align : 2 = {}; // line: Horizontal alignment.
+        rtol r_2_l : 2 = {}; // line: RTL.
+        byte image : 1 = {}; // line: Line contains image cells.
 
         line() = default;
         line(line&& l)
@@ -1582,9 +1580,9 @@ namespace netxs::ui
             static constexpr auto iii4 = sizeof(deco);//20 //6
             static constexpr auto iii3 = sizeof(line);//104 //88
             brush = l.brush;
-            wrapln = l.wrapln;
-            adjust = l.adjust;
-            r_to_l = l.r_to_l;
+            wraps = l.wraps;
+            align = l.align;
+            r_2_l = l.r_2_l;
             index = l.index;
             _size = l._size;
             _kind = l._kind;
@@ -1594,25 +1592,18 @@ namespace netxs::ui
         line(line const& l) = default;
         line(id_t line_id, deco const& line_style, std::span<cell const> proto)
             : cells{ proto.begin(), proto.end() },
-              index{ line_id    },
-             wrapln{ line_style.wrp() },
-             adjust{ line_style.jet() },
-             r_to_l{ line_style.rtl() }
+              index{ line_id          },
+              wraps{ line_style.wrp() },
+              align{ line_style.jet() },
+              r_2_l{ line_style.rtl() }
         { }
-        line(id_t line_id, deco const& line_style, cell const& blank)
-            : brush{ blank      },
-              index{ line_id    },
-             wrapln{ line_style.wrp() },
-             adjust{ line_style.jet() },
-             r_to_l{ line_style.rtl() }
-        { }
-        line(id_t line_id, deco const& line_style, cell const& blank, si32 len)
-            : cells( len, blank ),
-              brush{ blank      },
-              index{ line_id    },
-             wrapln{ line_style.wrp() },
-             adjust{ line_style.jet() },
-             r_to_l{ line_style.rtl() }
+        line(id_t line_id, deco const& line_style, cell const& blank, si32 len = 0)
+            : cells( len, blank       ),
+              brush{ blank            },
+              index{ line_id          },
+              wraps{ line_style.wrp() },
+              align{ line_style.jet() },
+              r_2_l{ line_style.rtl() }
         { }
         line(body::const_iterator head, body::const_iterator tail, cell brush)
             : cells{ head, tail },
@@ -1687,39 +1678,39 @@ namespace netxs::ui
             return a < w ? std::span{ cells.begin() + a, (size_t)std::min(std::max(0, width), w - a) }
                          : std::span{ cells.begin() + 0, (size_t)0 };
         }
-        // line: Return line adjustment kind.
+        // line: Return line alignment kind.
         auto get_kind() const
         {
-            return wrapln == wrap::on    ? type::autowrap :
-                   adjust == bias::left  ? type::leftside :
-                   adjust == bias::right ? type::rghtside :
-                                           type::centered ;
+            return wraps == wrap::on    ? type::autowrap :
+                   align == bias::left  ? type::leftside :
+                   align == bias::right ? type::rghtside :
+                                          type::centered ;
         }
-        auto  jet() const { return adjust;                                    } // line: Return line adjustment.
-        auto  wrp() const { return wrapln;                                    } // line: Return line auto wrapping.
-        auto  rtl() const { return r_to_l;                                    } // line: Return RTL.
-        auto& wrp(wrap w) { wrapln = w;                         return *this; } // line: Set line auto wrapping.
-        auto& wrp(bool b) { wrapln = b ? wrap::on  : wrap::off; return *this; } // line: Set line auto wrapping.
-        auto& rtl(bool r) { r_to_l = r ? rtol::rtl : rtol::ltr; return *this; } // line: Set RTL.
-        auto& jet(bias j) { adjust = j;                         return *this; } // line: Set alignment.
+        auto  jet() const { return align;                                    } // line: Return line alignment.
+        auto  wrp() const { return wraps;                                    } // line: Return line auto wrapping.
+        auto  rtl() const { return r_2_l;                                    } // line: Return RTL.
+        auto& wrp(wrap w) { wraps = w;                         return *this; } // line: Set line auto wrapping.
+        auto& wrp(bool b) { wraps = b ? wrap::on  : wrap::off; return *this; } // line: Set line auto wrapping.
+        auto& rtl(bool r) { r_2_l = r ? rtol::rtl : rtol::ltr; return *this; } // line: Set RTL.
+        auto& jet(bias j) { align = j;                         return *this; } // line: Set alignment.
         // line: Check current line style.
         auto changed_style(deco const& new_style) const
         {
-            return wrapln != new_style.wrp()
-                || adjust != new_style.jet()
-                || r_to_l != new_style.rtl();
+            return wraps != new_style.wrp()
+                || align != new_style.jet()
+                || r_2_l != new_style.rtl();
         }
         // line: Set current line style.
         void set_style(deco const& new_style)
         {
-            wrapln = new_style.wrp();
-            adjust = new_style.jet();
-            r_to_l = new_style.rtl();
+            wraps = new_style.wrp();
+            align = new_style.jet();
+            r_2_l = new_style.rtl();
         }
         // line: Get current line style.
         auto get_style() const
         {
-            return deco{}.wrp(wrapln).jet(adjust).rtl(r_to_l);
+            return deco{}.wrp(wraps).jet(align).rtl(r_2_l);
         }
         // line: Collapse line to zero size.
         void wipe()
@@ -2291,7 +2282,7 @@ namespace netxs::ui
             auto bound = [](auto& r){ return r.coord.y; };
             auto found = std::ranges::lower_bound(ropes, anker.y, {}, bound);
             if (found != ropes.end()) return entry{ found->id(), found->coord };
-            else                      return entry{ 0,     twod{ 0, si32max } };
+            else                      return entry{ 0, twod{ 0, netxs::si32max }};
         }
 
         struct rtf_dest_t
@@ -2745,7 +2736,7 @@ namespace netxs::ui
 
             if (reset)
             {
-                anker.y = si32max;
+                anker.y = netxs::si32max;
                 textpage.stream(gain);
                 decoy = caret && inside(flow::cp());
             }

--- a/src/netxs/desktopio/richtext.hpp
+++ b/src/netxs/desktopio/richtext.hpp
@@ -273,7 +273,7 @@ namespace netxs::ui
         template<class T>
         auto sync(T const& block)
         {
-            combine(runstyle, block.style);
+            combine(runstyle, block.get_style());
         }
         // flow: Split specified textblock on the substrings
         //       and place it to the form by the specified proc.
@@ -1563,17 +1563,28 @@ namespace netxs::ui
 
         body cells{}; // line: Cell data.
         cell brush{}; // line: Current brush.
-        deco style{}; // line: Line style.
         id_t index{}; // line: Line index.
         si32 _size{}; // line: Registered line size.
         si32 _kind{}; // line: Registered line kind (alignment).
+        //ui16 _size  : 16 = {}; // line: Registered line size.
+        //byte _kind  : 2 = {}; // line: Registered line kind (alignment).
+        wrap wrapln : 2 = {}; // line: Autowrap.
+        bias adjust : 2 = {}; // line: Horizontal alignment.
+        rtol r_to_l : 2 = {}; // line: RTL.
+        byte hasimg : 1 = {}; // line: Line contains image cells.
 
         line() = default;
         line(line&& l)
             : cells{ std::move(l.cells) }
         {
+            static constexpr auto iii2 = sizeof(cell);//40
+            static constexpr auto iii1 = sizeof(body);//32
+            static constexpr auto iii4 = sizeof(deco);//20 //6
+            static constexpr auto iii3 = sizeof(line);//104 //88
             brush = l.brush;
-            style = l.style;
+            wrapln = l.wrapln;
+            adjust = l.adjust;
+            r_to_l = l.r_to_l;
             index = l.index;
             _size = l._size;
             _kind = l._kind;
@@ -1583,23 +1594,29 @@ namespace netxs::ui
         line(line const& l) = default;
         line(id_t line_id, deco const& line_style, std::span<cell const> proto)
             : cells{ proto.begin(), proto.end() },
-               style{ line_style },
-               index{ line_id    }
+              index{ line_id    },
+             wrapln{ line_style.wrp() },
+             adjust{ line_style.jet() },
+             r_to_l{ line_style.rtl() }
         { }
         line(id_t line_id, deco const& line_style, cell const& blank)
             : brush{ blank      },
-              style{ line_style },
-              index{ line_id    }
+              index{ line_id    },
+             wrapln{ line_style.wrp() },
+             adjust{ line_style.jet() },
+             r_to_l{ line_style.rtl() }
         { }
         line(id_t line_id, deco const& line_style, cell const& blank, si32 len)
             : cells( len, blank ),
               brush{ blank      },
-              style{ line_style },
-              index{ line_id    }
+              index{ line_id    },
+             wrapln{ line_style.wrp() },
+             adjust{ line_style.jet() },
+             r_to_l{ line_style.rtl() }
         { }
-        line(body::const_iterator head, body::const_iterator tail, cell marker)
+        line(body::const_iterator head, body::const_iterator tail, cell brush)
             : cells{ head, tail },
-              brush{ marker     }
+              brush{ brush      }
         { }
         line(std::span<cell const> copy)
             : cells{ copy.begin(), copy.end() }
@@ -1670,6 +1687,40 @@ namespace netxs::ui
             return a < w ? std::span{ cells.begin() + a, (size_t)std::min(std::max(0, width), w - a) }
                          : std::span{ cells.begin() + 0, (size_t)0 };
         }
+        // line: Return line adjustment kind.
+        auto get_kind() const
+        {
+            return wrapln == wrap::on    ? type::autowrap :
+                   adjust == bias::left  ? type::leftside :
+                   adjust == bias::right ? type::rghtside :
+                                           type::centered ;
+        }
+        auto  jet() const { return adjust;                                    } // line: Return line adjustment.
+        auto  wrp() const { return wrapln;                                    } // line: Return line auto wrapping.
+        auto  rtl() const { return r_to_l;                                    } // line: Return RTL.
+        auto& wrp(wrap w) { wrapln = w;                         return *this; } // line: Set line auto wrapping.
+        auto& wrp(bool b) { wrapln = b ? wrap::on  : wrap::off; return *this; } // line: Set line auto wrapping.
+        auto& rtl(bool r) { r_to_l = r ? rtol::rtl : rtol::ltr; return *this; } // line: Set RTL.
+        auto& jet(bias j) { adjust = j;                         return *this; } // line: Set alignment.
+        // line: Check current line style.
+        auto changed_style(deco const& new_style) const
+        {
+            return wrapln != new_style.wrp()
+                || adjust != new_style.jet()
+                || r_to_l != new_style.rtl();
+        }
+        // line: Set current line style.
+        void set_style(deco const& new_style)
+        {
+            wrapln = new_style.wrp();
+            adjust = new_style.jet();
+            r_to_l = new_style.rtl();
+        }
+        // line: Get current line style.
+        auto get_style() const
+        {
+            return deco{}.wrp(wrapln).jet(adjust).rtl(r_to_l);
+        }
         // line: Collapse line to zero size.
         void wipe()
         {
@@ -1680,14 +1731,14 @@ namespace netxs::ui
         // line: Return true if line is wrapped.
         bool wrapped() const
         {
-            assert(_kind == style.get_kind());
+            assert(_kind == get_kind());
             return _kind == type::autowrap;
         }
         // line: Return wrapped line height.
         si32 height(si32 panel_x) const
         {
             auto len = size();
-            assert(_kind == style.get_kind());
+            assert(_kind == get_kind());
             return len > panel_x && wrapped() ? (len + panel_x - 1) / panel_x
                                               : 1;
         }
@@ -1863,6 +1914,11 @@ namespace netxs::ui
 
         operator writ const& () const { return **source; }
 
+        // rope: Return style reference.
+        auto& get_style() const
+        {
+            return style;
+        }
         // rope: Return a substring rope of the source content.
         //       ! No boundary checking !
         rope substr(si32 start, si32 width) const

--- a/src/netxs/desktopio/richtext.hpp
+++ b/src/netxs/desktopio/richtext.hpp
@@ -1588,18 +1588,18 @@ namespace netxs::ui
         { }
         line(id_t line_id, deco const& line_style, cell const& blank)
             : brush{ blank      },
-               style{ line_style },
-               index{ line_id    }
+              style{ line_style },
+              index{ line_id    }
         { }
         line(id_t line_id, deco const& line_style, cell const& blank, si32 len)
             : cells( len, blank ),
               brush{ blank      },
-               style{ line_style },
-               index{ line_id    }
+              style{ line_style },
+              index{ line_id    }
         { }
         line(body::const_iterator head, body::const_iterator tail, cell marker)
             : cells{ head, tail },
-              brush{ marker }
+              brush{ marker     }
         { }
         line(std::span<cell const> copy)
             : cells{ copy.begin(), copy.end() }

--- a/src/netxs/desktopio/system.hpp
+++ b/src/netxs/desktopio/system.hpp
@@ -4993,7 +4993,7 @@ namespace netxs::os
                     auto& item = lock.thing;
                     if (item.utf8.length())
                     {
-                        auto filtered = para{ item.utf8 }.lyric->utf8();
+                        auto filtered = cell::to_utf8(para{ item.utf8 }.content());
                         #if defined(_WIN32)
                             ::SetConsoleTitleW(utf::to_utf(filtered).c_str());
                         #else

--- a/src/netxs/desktopio/system.hpp
+++ b/src/netxs/desktopio/system.hpp
@@ -5217,7 +5217,7 @@ namespace netxs::os
             auto c = input::sysclose{};
             auto w = input::syswinsz{};
             m.enabled = input::hids::stat::ok;
-            m.coordxy = { si16min, si16min };
+            m.coordxy = { netxs::si16min, netxs::si16min };
             c.fast = true;
             w.winsize = os::dtvt::gridsz;
             k.gear_id = gear_id;
@@ -6134,7 +6134,7 @@ namespace netxs::os
                                 if (!pos_y) continue;
 
                                 auto timecode = datetime::now();
-                                auto clamp = [](auto a){ return std::clamp(a, si32min / 2, si32max / 2); };
+                                auto clamp = [](auto a){ return std::clamp(a, netxs::si32min / 2, netxs::si32max / 2); };
                                 auto x = clamp(pos_x.value() - 1);
                                 auto y = clamp(pos_y.value() - 1);
                                 auto ctl = ctrl.value();

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -3502,7 +3502,7 @@ namespace netxs::ui
                             if (auto index = c.get_image_index())
                             {
                                 //todo
-                                //if (--image_ref_counts[index] == 0) 
+                                //if (--owner.image_ref_count[index] == 0) 
                                 //{
                                 //    release index
                                 //}
@@ -7611,22 +7611,60 @@ namespace netxs::ui
                 q = qiew{ head, tail };
                 if (ok) // Show image.
                 {
-                    auto svg_doc = term::rgba_to_svg(bitmap, size);
-                    //
-                    //
-                    static auto i = 0;
-                    auto print_via_osc = utf::fprint("id=_sixel%id% %doc% W=%% H=%% fit=stretch", i++, svg_doc, size.x / cellsz.x, size.y / cellsz.y);
-                    if constexpr (debugmode) log("svg:", utf::debase(print_via_osc));
-                    //todo check decsdm
+                    auto doc_str = term::rgba_to_svg(bitmap, size);
+                    auto fp_wh = fp2d{ size } / fp2d{ cellsz };
+                    auto wh = twod{ std::ceil(fp_wh) };
+                    auto c = owner.target->cell_under_cursor();
+                    auto images = cell::images(); // Lock.
+                    if (auto index = c.get_image_index()) // Check the image id at the current cursor position.
+                    {
+                        auto xy = c.get_image_cr();
+                        auto WH = c.get_image_WH();
+                        if (xy == dot_11 && wh == WH) // Update existing image.
+                        {
+                            if (auto image_ptr = images.map[index])
+                            {
+                                auto& image = *image_ptr;
+                                image.reset_changes();
+                                image.check_and_set_document(doc_str);
+                                if (image.document_changed)
+                                {
+                                    image.stamp += 2;
+                                    owner.base::signal(tier::general, e2::data::image::update, index);
+                                    owner.print_sixel_image(image, wh);
+                                }
+                                return;
+                            }
+                            else
+                            {
+                                if (owner.io_log) log("%%Broken image index: %%", prompt::term, index);
+                            }
+                        }
+                    }
+                    // Post a new image.
+                    //todo cache  auto iter = image_cache.find(doc_str); iter != image_cache.end();
+                    auto image_ptr = ptr::shared(imagens::image{ .document = doc_str });
+                    if (auto image_index = images.set(image_ptr))
+                    {
+                        auto& image = *image_ptr;
+                        image.id = "Sixel_"; // Set id="Sixel_FFFF".
+                        utf::to_hex(image_index, image.id);
+                        image.index = image_index;
+                        image.gb_attrs[imagens::gb::w  ] = (fp32)wh.x;
+                        image.gb_attrs[imagens::gb::h  ] = (fp32)wh.y;
+                        image.gb_attrs[imagens::gb::uw ] = (fp32)wh.x / fp_wh.x; // Keep paddings.
+                        image.gb_attrs[imagens::gb::vh ] = (fp32)wh.y / fp_wh.y; //
+                        image.gb_attrs[imagens::gb::fit] = scale_mode::stretch;
+                        owner.print_sixel_image(image, wh);
+                        // All sixel images will be removed on undock.
+                        //owner.sixel_cache[image.id] = image_ptr;
+                    }
                     //todo sync original fragments
                     //todo add a bitmap raster bit (introduce payload category: svg, raw, ...) to the imagens::image
                     //todo store the payload in byts instead of text
                     //todo implement own bitmap (raw category) rasterization (with interpolation)
                     //todo hashing by sixel_string
                     //todo implement scrollback lifetime management for sixel images (destroy it in line dtor if reference_count[id] == 0)
-                    //todo print to target_buffer
-                    owner.osc_images(print_via_osc);
-                    owner.data_in("\n\r");
                 }
                 else
                 {
@@ -7684,8 +7722,10 @@ namespace netxs::ui
         ui32       event_sources; // term: vt-input-mode event reporting bit-field.
         ui64       session_token; // term: Interactive session token.
         utf::unordered_map<text, netxs::sptr<imagens::image>> image_cache; // term: Image cache.
+        //utf::unordered_map<text, netxs::sptr<imagens::image>> sixel_cache; // term: Sixel cache.
         face                                                  image_buffer; // term: Image temporary buffer.
         bool                                                  image_alive{ true }; // term: Indicator for whether to clear images in the scrollback.
+        std::array<ui64, 65536>                               image_ref_count{}; // term: Each slot contains a count of the number of cells containing an id corresponding to the slot index.
         sixel_t    sixels; // term: Sixel mode state.
         vtty       ipccon; // term: IPC connector. Should be destroyed first.
 
@@ -7762,6 +7802,29 @@ namespace netxs::ui
                 coor.y++;
             }
             scrollback.cup2(save);
+        }
+        // term: Print sixel image to the scrollback.
+        void print_sixel_image(imagens::image& image, twod wh)
+        {
+            auto brush = cell{ target->parser::brush }
+                .txt(" ", 1, 1, 1, 1)
+                .set_image_index(image.index)
+                .set_image_stamp(image.stamp)
+                .set_image_WH(wh.x, wh.y)
+                .set_image_ontop(faux);
+            image_buffer.core::size<true>(wh, brush);
+            auto head = image_buffer.begin();
+            for (auto row = 1; row <= wh.y; row++)
+            {
+                for (auto col = 1; col <= wh.x; col++)
+                {
+                    (*head++).set_image_cr(col, row);
+                }
+            }
+            //todo image cell accounting
+            //todo respect decsdm (trim image + don't move cursor)
+            draw_block(image_buffer, cell::shaders::full);
+            data_in("\n\r");
         }
         // term: CSI srcTop ; srcLeft ; srcBottom ; srcRight ; srcBuffIndex ; dstTop ; dstLeft ; dstBuffIndex $ v  — Copy rectangular area (DECCRA). BuffIndex: 1..6, 1 is default index. All coords are 1-based (inclusive).
         void deccra(fifo& q)
@@ -8210,7 +8273,6 @@ namespace netxs::ui
                     {
                         image.layers = std::move(layers);
                     }
-                    image.changed_gb_attrs = {};
                     image.rasters_reset(); // Request to re-rasterize.
                     image.reset_changes();
                     image.check_and_set_document(doc_str, sub_id_str);
@@ -9505,11 +9567,15 @@ namespace netxs::ui
         ~term()
         {
             image_alive = faux;
+            //if (image_cache.size() || sixel_cache.size()) // Signal to wipe all image references.
             if (image_cache.size()) // Signal to wipe all image references.
             {
                 auto images = cell::images(); // Lock.
                 auto removed_image_indexes = e2::data::image::remove.param();
                 removed_image_indexes.reserve(image_cache.size());
+                //removed_image_indexes.reserve(image_cache.size() + sixel_cache.size());
+                //for (auto cache : { &image_cache, &sixel_cache }) //todo C++23: std::views::concat(image_cache, sixel_cache)
+                //for (auto& [image_id, image_ptr] : *cache) if (image_ptr)
                 for (auto& [image_id, image_ptr] : image_cache) if (image_ptr)
                 {
                     auto removed_index = image_ptr->index;

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -1245,12 +1245,15 @@ namespace netxs::ui
             {
                 using rich::rich;
                 using type = deco::type;
-                using id_t = ui32;
 
                 line(line&& l)
-                    : rich { std::forward<rich>(l) },
-                      index{ l.index }
+                    : rich{ std::move(l) },
+                     index{ l.index      }
                 {
+                    static constexpr auto j = sizeof(core);//112
+                    static constexpr auto i = sizeof(rich);//112
+                    static constexpr auto i2 = sizeof(line);//144
+                    static constexpr auto i3 = sizeof(deco);//
                     style = l.style;
                     _size = l._size;
                     _kind = l._kind;
@@ -1259,26 +1262,26 @@ namespace netxs::ui
                 }
                 line(line const& l)
                     : rich{ l       },
-                     index{ l.index },
-                     style{ l.style }
+                     style{ l.style },
+                     index{ l.index }
                 { }
                 line(id_t line_id, deco const& line_style, span dt, twod sz)
                     : rich{ dt, sz     },
-                     index{ line_id    },
-                     style{ line_style }
+                     style{ line_style },
+                     index{ line_id    }
                 { }
                 line(id_t line_id, deco const& line_style, cell const& blank)
                     : rich{ blank      },
-                     index{ line_id    },
-                     style{ line_style }
+                     style{ line_style },
+                     index{ line_id    }
                 { }
                 line(id_t line_id, deco const& line_style, cell const& blank, si32 length)
                     : rich{ blank, length },
-                     index{ line_id       },
-                     style{ line_style    }
+                     style{ line_style    },
+                     index{ line_id       }
                 { }
                 line(core&& s)
-                    : rich{ std::forward<core>(s) }
+                    : rich{ std::move(s) }
                 { }
                 line(netxs::view utf8)
                     : rich{ para{ utf8 }.content() }
@@ -1287,10 +1290,10 @@ namespace netxs::ui
                 line& operator = (line&&)      = default;
                 line& operator = (line const&) = default;
 
-                id_t index{};
                 deco style{};
+                id_t index{};
                 si32 _size{};
-                type _kind{};
+                si32 _kind{};
 
                 friend void swap(line& lhs, line& rhs)
                 {
@@ -3371,7 +3374,6 @@ namespace netxs::ui
         {
             struct index_item
             {
-                using id_t = line::id_t;
                 id_t index;
                 si32 start;
                 si32 width;
@@ -3413,7 +3415,7 @@ namespace netxs::ui
             struct buff : public ring
             {
                 using ring::ring;
-                using type = line::type;
+                using type = deco::type;
                 using maps = std::map<si32, si32>[type::count];
 
                 si32 caret{}; // buff: Current line cursor horizontal position.
@@ -3428,13 +3430,13 @@ namespace netxs::ui
                 bool rolls{}; // buff: The scrollback buffer ring was scrolled.
 
                 // buff: Decrease height.
-                void dec_height(si32& block_vsize, type line_kind, si32 line_size)
+                void dec_height(si32& block_vsize, si32 line_kind, si32 line_size)
                 {
                     if (line_size > width && line_kind == type::autowrap) block_vsize -= (line_size + width - 1) / width;
                     else                                                  block_vsize -= 1;
                 }
                 // buff: Increase height.
-                void add_height(si32& block_vsize, type line_kind, si32 line_size)
+                void add_height(si32& block_vsize, si32 line_kind, si32 line_size)
                 {
                     if (line_size > width && line_kind == type::autowrap) block_vsize += (line_size + width - 1) / width;
                     else                                                  block_vsize += 1;
@@ -3469,7 +3471,7 @@ namespace netxs::ui
                     }
                 }
                 // buff: Register a new line.
-                void invite(type& line_kind, si32& line_size, type new_kind, si32 new_size)
+                void invite(si32& line_kind, si32& line_size, si32 new_kind, si32 new_size)
                 {
                     ++sizes[new_kind][new_size];
                     add_height(vsize, new_kind, new_size);
@@ -3477,7 +3479,7 @@ namespace netxs::ui
                     line_kind = new_kind;
                 }
                 // buff: Refresh scrollback height.
-                void recalc(type& line_kind, si32& line_size, type new_kind, si32 new_size)
+                void recalc(si32& line_kind, si32& line_size, si32 new_kind, si32 new_size)
                 {
                     if (line_size != new_size
                      || line_kind != new_kind)
@@ -3490,7 +3492,7 @@ namespace netxs::ui
                     }
                 }
                 // buff: Discard the specified metrics.
-                void undock(type line_kind, si32 line_size)
+                void undock(si32 line_kind, si32 line_size)
                 {
                     auto& lens = sizes[line_kind];
                     auto  iter = lens.find(line_size); assert(iter != lens.end());
@@ -3552,7 +3554,10 @@ namespace netxs::ui
                     rolls = true;
                 }
                 // buff: Remove information about the specified line from accounting.
-                void undock_base_back(line& l) override { undock(l._kind, l._size); }
+                void undock_base_back(line& l) override
+                {
+                    undock(l._kind, l._size);
+                }
                 // buff: Return the item position in the scrollback using its id.
                 auto index_by_id(ui32 item_id) const
                 {

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -3499,7 +3499,7 @@ namespace netxs::ui
                         l.image = {};
                         for (auto& c : l.cells) 
                         {
-                            if (auto index = c.get_image_index())
+                            //if (auto index = c.get_image_index())
                             {
                                 //todo
                                 //if (--owner.image_ref_count[index] == 0) 

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -7363,12 +7363,7 @@ namespace netxs::ui
             {
                 cell::remove_image_bits(upbox, removed_image_indexes);
                 cell::remove_image_bits(dnbox, removed_image_indexes);
-                #if defined (__ANDROID__)
-                    std::for_each(batch.begin(), batch.end(), [&](auto& l)
-                    {
-                        cell::remove_image_bits(l, removed_image_indexes);
-                    });
-                #else
+                #if defined(_WIN32)
                     auto wipe_batch = [&](auto policy) // Try to parallelize.
                     {
                         std::for_each(policy, batch.begin(), batch.end(), [&](auto& l)
@@ -7376,8 +7371,13 @@ namespace netxs::ui
                             cell::remove_image_bits(l, removed_image_indexes);
                         });
                     };
-                    batch.length() > 100000 ? wipe_batch(std::execution::par)
+                    batch.length() > 500000 ? wipe_batch(std::execution::par)
                                             : wipe_batch(std::execution::seq);
+                #else
+                    std::for_each(batch.begin(), batch.end(), [&](auto& l)
+                    {
+                        cell::remove_image_bits(l, removed_image_indexes);
+                    });
                 #endif
             }
         };

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -595,7 +595,7 @@ namespace netxs::ui
             void set(text const& property, qiew txt = {})
             {
                 if (txt.empty()) txt = owner.appcfg.cmd; // Deny empty titles.
-                owner.target->flush();
+                owner.target->parser::flush();
                 if (property == ansi::osc_label_title)
                 {
                                   props[ansi::osc_label] = txt;
@@ -644,7 +644,7 @@ namespace netxs::ui
             // w_tracking: Manage terminal window props (XTWINOPS).
             void manage(fifo& q)
             {
-                owner.target->flush();
+                owner.target->parser::flush();
                 static constexpr auto all_title = si32{ 0  }; // Sub commands.
                 static constexpr auto label     = si32{ 1  }; // Sub commands.
                 static constexpr auto title     = si32{ 2  }; // Sub commands.
@@ -1038,10 +1038,10 @@ namespace netxs::ui
                 dest.px = c.px;
                 dest.p2 = c.p2;
             }
-            void fgc(tint c)  { argb::set_indexed_color(owner.target->brush.fgc(), c); }
-            void bgc(tint c)  { argb::set_indexed_color(owner.target->brush.bgc(), c); }
-            void fgc(fifo& q) { owner.target->brush.fgc().parse_input(q, [](si32 i){ return argb::get_indexed_color_token(i); }); }
-            void bgc(fifo& q) { owner.target->brush.bgc().parse_input(q, [](si32 i){ return argb::get_indexed_color_token(i); }); }
+            void fgc(tint c)  { argb::set_indexed_color(owner.target->parser::brush.fgc(), c); }
+            void bgc(tint c)  { argb::set_indexed_color(owner.target->parser::brush.bgc(), c); }
+            void fgc(fifo& q) { owner.target->parser::brush.fgc().parse_input(q, [](si32 i){ return argb::get_indexed_color_token(i); }); }
+            void bgc(fifo& q) { owner.target->parser::brush.bgc().parse_input(q, [](si32 i){ return argb::get_indexed_color_token(i); }); }
         };
 
         // term: Generic terminal buffer.
@@ -1247,7 +1247,7 @@ namespace netxs::ui
 
                 deco style{}; // Parser style state.
                 mark brush{}; // Parser brush state.
-                si32 decsg{}; // Parser DEC Special Graphcs Mode.
+                si32 decsg{}; // Parser DEC Special Graphics Mode.
                 twod coord{}; // Screen coord state.
                 bool decom{}; // Origin mode  state.
                 sgrs stack{}; // Stach for saved sgr attributes.
@@ -3432,14 +3432,14 @@ namespace netxs::ui
                 // buff: Push the specified line back.
                 void invite(line& l)
                 {
-                    invite(l._kind, l._size, l.style.get_kind(), l.length());
+                    invite(l._kind, l._size, l.get_kind(), l.length());
                 }
                 // buff: Push a new line back.
                 template<class ...Args>
                 auto& invite(Args&&... args)
                 {
                     auto& l = ring::push_back(std::forward<Args>(args)...);
-                    invite(l._kind, l._size, l.style.get_kind(), l.length());
+                    invite(l._kind, l._size, l.get_kind(), l.length());
                     return l;
                 }
                 // buff: Insert a new line at the specified position.
@@ -3447,7 +3447,7 @@ namespace netxs::ui
                 auto& insert(si32 at, Args&&... args)
                 {
                     auto& l = *ring::insert(at, std::forward<Args>(args)...);
-                    invite(l._kind, l._size, l.style.get_kind(), l.length());
+                    invite(l._kind, l._size, l.get_kind(), l.length());
                     return l;
                 }
                 // buff: Remove specified line info from accounting and update metrics based on scroll height.
@@ -3495,7 +3495,7 @@ namespace netxs::ui
                 // buff: Refresh metrics due to modified line.
                 void recalc(line& l)
                 {
-                    recalc(l._kind, l._size, l.style.get_kind(), l.length());
+                    recalc(l._kind, l._size, l.get_kind(), l.length());
                 }
                 // buff: Rewrite the indices from the specified position to the end or to the top (negative from).
                 void reindex(si32 from)
@@ -4308,7 +4308,7 @@ namespace netxs::ui
                     }
 
                     auto& curln = batch.current();
-                    auto  align = curln.style.jet();
+                    auto  align = curln.jet();
 
                     if (align == bias::left
                      || align == bias::none) return coor;
@@ -4368,10 +4368,10 @@ namespace netxs::ui
                     {
                         auto newix = batch.index_by_id(mapln.index);
                         batch.index(newix);
-
-                        if (batch->style != parser::style)
+                        auto& curln2 = batch.current();
+                        if (curln2.changed_style(parser::style))
                         {
-                            _set_style(parser::style);
+                            _set_style(curln2, parser::style);
                             assert(newix == batch.index_by_id(index[coord.y].index));
                         }
                     }
@@ -4506,13 +4506,13 @@ namespace netxs::ui
                     auto curit = block.begin();
                     auto curid = start == 0 ? batch.front().index
                                             : batch[start - 1].index + 1;
-                    auto style = ansi::def_style;
-                    style.wrp(wrap::off);
+                    auto new_style = ansi::def_style;
+                    new_style.wrp(wrap::off);
                     while (size.y-- > 0)
                     {
                         auto oldsz = batch.size;
                         auto proto = std::span{ curit, (size_t)size.x };
-                        auto curln = line{ curid++, style, proto };
+                        auto curln = line{ curid++, new_style, proto };
                         curln.shrink(block.mark());
                         batch.insert(start, std::move(curln));
                         start += batch.size - oldsz; // Due to circulation in the ring.
@@ -4599,7 +4599,7 @@ namespace netxs::ui
             auto screen_to_offset(line& curln, twod coor)
             {
                 auto length = curln.length();
-                auto adjust = curln.style.jet();
+                auto adjust = curln.jet();
                 if (curln.wrapped() && length > panel.x)
                 {
                     auto endpos = length - 1;
@@ -4628,16 +4628,15 @@ namespace netxs::ui
                     if (coor.y < last / panel.x) return coor;
                     size = last % panel.x + 1;
                 }
-                coor.x = xconv<feed::rev>(coor.x, curln.style.jet(), size);
+                coor.x = xconv<feed::rev>(coor.x, curln.jet(), size);
                 return coor;
             }
             // scroll_buf: Update current SGR attributes. (! Check coord.y context)
-            void _set_style(deco const& new_style)
+            void _set_style(line& curln, deco const& new_style)
             {
-                auto& curln = batch.current();
-                auto  wraps = curln.wrapped();
-                auto  width = curln.length();
-                curln.style = new_style;
+                auto wraps = curln.wrapped();
+                auto width = curln.length();
+                curln.set_style(new_style);
 
                 if (batch.caret > width) // Dangling cursor.
                 {
@@ -4712,13 +4711,13 @@ namespace netxs::ui
             // scroll_buf: Proceed style update (parser callback).
             void meta(deco const& old_style) override
             {
-                if (batch->style != parser::style)
+                auto& curln = batch.current();
+                if (curln.changed_style(parser::style))
                 {
-                    if (coord.y >= y_top
-                     && coord.y <= y_end)
+                    if (coord.y >= y_top && coord.y <= y_end)
                     {
                         coord.y -= y_top;
-                        _set_style(parser::style);
+                        _set_style(curln, parser::style);
                         coord.y += y_top;
                     }
                 }
@@ -5391,7 +5390,7 @@ namespace netxs::ui
                     auto& curln = *head;
                     auto height = curln.height(panel.x);
                     auto length = curln.length();
-                    auto adjust = curln.style.jet();
+                    auto adjust = curln.jet();
                     dest.output(curln, coor, [&](auto& dst, auto& src){ owner.ctrack.mix_with_bgc(dst, src); });
                     //dest.output_proxy(curln, coor, [&](auto const& coord, auto const& subblock, auto isr_to_l)
                     //{
@@ -5399,7 +5398,7 @@ namespace netxs::ui
                     //});
                     if (find)
                     {
-                        match.style.wrp(curln.style.wrp());
+                        match.wrp(curln.wrp());
                         auto offset = si32{ 0 };
                         auto work = [&](auto shader)
                         {
@@ -5640,7 +5639,7 @@ namespace netxs::ui
                 {
                     auto after = batch.index_by_id(curid);
                     auto tmpln = std::move(batch[after]);
-                    auto curit = batch.ring::insert(after + 1, tmpln.index, tmpln.style, parser::brush);
+                    auto curit = batch.ring::insert(after + 1, tmpln.index, tmpln.get_style(), parser::brush);
                     auto endit = batch.end();
 
                     auto& newln = *curit;
@@ -6549,8 +6548,8 @@ namespace netxs::ui
             // scroll_buf: Calc selection offset in cells.
             auto selection_offset(auto& curln, auto coor, auto close)
             {
-                auto align = curln.style.jet();
-                auto wraps = curln.style.wrp();
+                auto align = curln.jet();
+                auto wraps = curln.wrp();
                 auto width = curln.length();
                 if (wraps == wrap::on)
                 {
@@ -6696,11 +6695,12 @@ namespace netxs::ui
                         auto s = deco{};
                         build([&](auto& curln)
                         {
-                            if (s != curln.style)
+                            auto d = curln.get_style();
+                            if (s != d)
                             {
-                                if (auto wrp = curln.style.wrp(); s.wrp() != wrp) yield.wrp(wrp);
-                                if (auto jet = curln.style.jet(); s.jet() != jet) yield.jet(jet);
-                                s = curln.style;
+                                if (auto wrp = curln.wrp(); s.wrp() != wrp) yield.wrp(wrp);
+                                if (auto jet = curln.jet(); s.jet() != jet) yield.jet(jet);
+                                s = d;
                             }
                             auto block = escx{};
                             if (use_true_color) cell::unpack_indexed_colors_to(curln, baked, owner.ctrack.color, owner.defclr);
@@ -6832,7 +6832,7 @@ namespace netxs::ui
                                 }
                                 else
                                 {
-                                    auto align = curln.style.jet();
+                                    auto align = curln.jet();
                                     auto coord = coor;
                                     switch (align)
                                     {
@@ -6930,26 +6930,26 @@ namespace netxs::ui
                 {
                     if (upmid.role == grip::idle) return;
                     auto i_top = std::clamp(batch.index_by_id(upmid.link), 0, batch.size);
-                    auto j = batch[i_top].style.jet();
+                    auto j = batch[i_top].jet();
                     auto align = a != bias::none ? a
                                                  : j == bias::left   ? bias::right
                                                  : j == bias::right  ? bias::center
                                                                      : bias::left;
                     selection_foreach([&](auto& curln)
                     {
-                        curln.style.jet(align);
+                        curln.jet(align);
                         batch.recalc(curln);
                     });
-                    if (a != bias::none) style.jet(a);
+                    if (a != bias::none) parser::style.jet(a);
                     resize_viewport(panel, true); // Recalc batch.basis.
                 }
                 else
                 {
-                    auto j = style.jet();
-                    style.jet(a != bias::none ? a
-                                              : j == bias::left   ? bias::right
-                                              : j == bias::right  ? bias::center
-                                                                  : bias::left);
+                    auto j = parser::style.jet();
+                    parser::style.jet(a != bias::none ? a
+                                                      : j == bias::left   ? bias::right
+                                                      : j == bias::right  ? bias::center
+                                                                          : bias::left);
                 }
             }
             // scroll_buf: Sel wrapping mode for selected lines.
@@ -6959,21 +6959,21 @@ namespace netxs::ui
                 {
                     if (upmid.role == grip::idle) return;
                     auto i_top = std::clamp(batch.index_by_id(upmid.link), 0, batch.size);
-                    auto wraps = w == wrap::none ? batch[i_top].style.wrp() == wrap::on ? wrap::off : wrap::on
+                    auto wraps = w == wrap::none ? batch[i_top].wrp() == wrap::on ? wrap::off : wrap::on
                                                  : w;
                     upmid.coor.y = dnmid.coor.y = 0;
                     selection_foreach([&](auto& curln)
                     {
-                        curln.style.wrp(wraps);
+                        curln.wrp(wraps);
                         batch.recalc(curln);
                     });
-                    if (w != wrap::none) style.wrp(w);
+                    if (w != wrap::none) parser::style.wrp(w);
                     resize_viewport(panel, true); // Recalc batch.basis.
                 }
                 else
                 {
-                    style.wrp(w == wrap::none ? style.wrp() == wrap::on ? wrap::off : wrap::on
-                                              : w);
+                    parser::style.wrp(w == wrap::none ? parser::style.wrp() == wrap::on ? wrap::off : wrap::on
+                                                      : w);
                 }
             }
             // scroll_buf: Update selection internals.
@@ -8055,7 +8055,7 @@ namespace netxs::ui
                 }
 
                 auto gc_str = gc_opt ? gc_opt.value() : " ";
-                auto brush = cell{ target->brush }.txt(gc_str, 1, 1, 1, 1); //todo make the character geometry configurable
+                auto brush = cell{ target->parser::brush }.txt(gc_str, 1, 1, 1, 1); //todo make the character geometry configurable
                 auto print_image_buffer = [&]
                 {
                     gc_str ? draw_block(image_buffer, cell::shaders::full)
@@ -8223,7 +8223,7 @@ namespace netxs::ui
         // term: Soft terminal reset (DECSTR).
         void decstr()
         {
-            target->flush();
+            target->parser::flush();
             normal.clear_all();
             altbuf.clear_all();
             target = &normal;
@@ -8257,7 +8257,7 @@ namespace netxs::ui
                     target->cup0(dot_00);
                     break;
                 case 7:    // Enable auto-wrap.
-                    target->style.wrp(wrap::on);
+                    target->parser::style.wrp(wrap::on);
                     break;
                 case 12:   // Enable cursor blinking.
                     caret.blink_period();
@@ -8316,8 +8316,8 @@ namespace netxs::ui
                 case 1047: // Use alternate screen buffer.
                 case 1049: // Save cursor pos and use alternate screen buffer, clearing it first.  This control combines the effects of the 1047 and 1048  modes.
                     if (target != &normal && target != &altbuf) break; // Suppress mode change for additional screen buffers (windows console).
-                    altbuf.style = target->style; // Inherit the normal buffer brush.
-                    altbuf.brush = target->brush; //
+                    altbuf.parser::style = target->parser::style; // Inherit the normal buffer brush.
+                    altbuf.parser::brush = target->parser::brush; //
                     altbuf.clear_all();
                     altbuf.resize_viewport(target->panel); // Reset viewport to the basis.
                     target = &altbuf;
@@ -8333,13 +8333,13 @@ namespace netxs::ui
         // term: Set terminal parameters. (DECSET).
         void decset(si32 n)
         {
-            target->flush();
+            target->parser::flush();
             _decset(n);
         }
         // term: Set terminal parameters. (DECSET).
         void decset(fifo& q)
         {
-            target->flush();
+            target->parser::flush();
             while (auto next = q(0)) _decset(next);
         }
         // term: Switch buffer to normal and reset viewport to the basis.
@@ -8380,7 +8380,7 @@ namespace netxs::ui
                     target->cup0(dot_00);
                     break;
                 case 7:    // Disable auto-wrap.
-                    target->style.wrp(wrap::off);
+                    target->parser::style.wrp(wrap::off);
                     break;
                 case 12:   // Disable cursor blinking.
                     caret.blink_period(span::zero());
@@ -8452,13 +8452,13 @@ namespace netxs::ui
         // term: Reset terminal parameters. (DECRST).
         void decrst(si32 n)
         {
-            target->flush();
+            target->parser::flush();
             _decrst(n);
         }
         // term: Reset terminal parameters. (DECRST).
         void decrst(fifo& q)
         {
-            target->flush();
+            target->parser::flush();
             while (auto next = q(0)) _decrst(next);
         }
         // term: Set terminal parameters.
@@ -8494,13 +8494,13 @@ namespace netxs::ui
         // term: Set terminal parameters.
         void modset(fifo& q)
         {
-            target->flush();
+            target->parser::flush();
             while (auto next = q(0)) _modset(next);
         }
         // term: Reset terminal parameters.
         void modrst(fifo& q)
         {
-            target->flush();
+            target->parser::flush();
             while (auto next = q(0)) _modrst(next);
         }
         // term: Reset terminal parameters.
@@ -8542,14 +8542,14 @@ namespace netxs::ui
         // term: Request terminal mode. (DECRQM).
         void decrqm(fifo& q)
         {
-            target->flush();
+            target->parser::flush();
             while (auto next = q(0)) _decrqm(next);
             answer(escbuf);
         }
         // term: Set scrollback buffer size and grow step.
         void sbsize(fifo& q)
         {
-            target->flush();
+            target->parser::flush();
             auto ring_size = q.subarg(defcfg.def_length);
             auto grow_step = q.subarg(defcfg.def_growdt);
             auto grow_mxsz = q.subarg(defcfg.def_growmx);
@@ -8558,7 +8558,7 @@ namespace netxs::ui
         // term: Check and update scrollback buffer limits.
         void sb_min(si32 min_length)
         {
-            target->flush();
+            target->parser::flush();
             if (normal.batch.step == 0 && normal.batch.peak < min_length)
             {
                 normal.resize_history(min_length);
@@ -8648,9 +8648,9 @@ namespace netxs::ui
         {
             auto& console = *target;
             defclr.txt('\0').fgc(defcfg.def_fcolor).bgc(defcfg.def_bcolor).link(base::id);
-            console.brush.reset();
-            console.style.reset();
-            console.style.wrp(defcfg.def_wrpmod);
+            console.parser::brush.reset();
+            console.parser::style.reset();
+            console.parser::style.wrp(defcfg.def_wrpmod);
             console.setpad(defcfg.def_margin);
             selection_selmod(defcfg.def_selmod);
             caret.style(defcfg.def_cursor);
@@ -9750,7 +9750,7 @@ namespace netxs::ui
                                                         auto args_count = luafx.args_count();
                                                         if (!args_count)
                                                         {
-                                                            auto state = target->style.wrp() == wrap::off ? 0 : 1;
+                                                            auto state = target->parser::style.wrp() == wrap::off ? 0 : 1;
                                                             luafx.set_return(state);
                                                         }
                                                         else
@@ -9766,7 +9766,7 @@ namespace netxs::ui
                                                         auto args_count = luafx.args_count();
                                                         if (!args_count)
                                                         {
-                                                            auto align = target->style.jet();
+                                                            auto align = target->parser::style.jet();
                                                             auto state = align == bias::left || align == bias::none  ? 0 :
                                                                                                 align == bias::right ? 1 : 2;
                                                             luafx.set_return(state);
@@ -9829,7 +9829,7 @@ namespace netxs::ui
                 { methods::ScrollbackSize,          [&]
                                                     {
                                                         luafx.run_with_gear_wo_return([&](auto& gear){ gear.set_handled(); });
-                                                        target->flush();
+                                                        target->parser::flush();
                                                         auto args_count = luafx.args_count();
                                                         if (!args_count)
                                                         {
@@ -9846,14 +9846,14 @@ namespace netxs::ui
                                                     }},
                 { methods::SetBackground,           [&]
                                                     {
-                                                        target->flush();
-                                                        auto brush = target->brush;
+                                                        target->parser::flush();
+                                                        auto brush = target->parser::brush;
                                                         set_color(brush.txt('\0'));
                                                         luafx.set_return();
                                                     }},
                 { methods::ScrollbackPadding,       [&]
                                                     {
-                                                        target->flush();
+                                                        target->parser::flush();
                                                         auto args_count = luafx.args_count();
                                                         if (!args_count)
                                                         {
@@ -9868,7 +9868,7 @@ namespace netxs::ui
                                                     }},
                 { methods::TabLength,               [&]
                                                     {
-                                                        target->flush();
+                                                        target->parser::flush();
                                                         auto args_count = luafx.args_count();
                                                         if (!args_count)
                                                         {
@@ -9884,23 +9884,23 @@ namespace netxs::ui
                                                     }},
                 { methods::RightToLeft,             [&]
                                                     {
-                                                        target->flush();
+                                                        target->parser::flush();
                                                         auto args_count = luafx.args_count();
                                                         if (!args_count)
                                                         {
-                                                            luafx.set_return(!!target->brush.rtl());
+                                                            luafx.set_return(!!target->parser::brush.rtl());
                                                         }
                                                         else
                                                         {
                                                             auto rtl = luafx.get_args_or(1, 0);
-                                                            target->style.rtl(rtl ? rtol::rtl : rtol::ltr);
-                                                            target->brush.rtl(rtl);
+                                                            target->parser::style.rtl(rtl ? rtol::rtl : rtol::ltr);
+                                                            target->parser::brush.rtl(rtl);
                                                             luafx.set_return();
                                                         }
                                                     }},
                 { methods::ResetAttributes,         [&]
                                                     {
-                                                        target->flush();
+                                                        target->parser::flush();
                                                         setdef();
                                                         luafx.set_return();
                                                     }},
@@ -9966,7 +9966,7 @@ namespace netxs::ui
                                                     }},
                 { methods::CodePage,                [&]
                                                     {
-                                                        target->flush();
+                                                        target->parser::flush();
                                                         if (!ipccon.termlink)
                                                         {
                                                             luafx.set_return();
@@ -10537,7 +10537,7 @@ namespace netxs::ui
             auto data = para{ utf8 };
             auto kant = text(2, ' ');
             auto pads = text(data.length() + kant.size() * 2, ' ');
-            return page{ ansi::bgc(reddk).fgc(whitelt).jet(bias::center).wrp(wrap::off).cup(dot_00).cpp({50,50}).cuu(1)
+            return page{ ansi::bgc(reddk).fgc(whitelt).jet(bias::center).wrp(wrap::off).cup(dot_00).cpp({ 50, 50 }).cuu(1)
                               .add(pads,       '\n',
                              kant, utf8, kant, '\n',
                                    pads,       '\n') };

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -3331,16 +3331,22 @@ namespace netxs::ui
 
             struct buff : public ring
             {
+                static constexpr auto sizea_size = 65536;
                 using ring::ring;
                 using type = deco::type;
-                using maps = std::map<si32, si32>[type::count]; //todo ?use std::array<si32, 65536>[type::count]
+                using mapa = std::array<si32, sizea_size>[type::count];
+                using maps = std::map<si32, si32>[type::count];
+                using maxl = std::array<si32, type::count>;
 
                 si32 caret{}; // buff: Current line cursor horizontal position.
                 si32 vsize{}; // buff: Scrollback vertical size (height).
                 si32 width{}; // buff: Viewport width.
                 si32 basis{}; // buff: Working area basis. Vertical position of O(0, 0) in the scrollback.
                 si32 slide{}; // buff: Viewport vertical position in the scrollback.
-                maps sizes{}; // buff: Line length accounting database.
+                si32 simpl{}; // buff: Non-wrapped lines count (1-cell height: leftside, rghtside, centered).
+                mapa sizea{}; // buff: Fast line length accounting.
+                maps sizes{}; // buff: Huge line length accounting.
+                maxl maxes{}; // buff: Max line length cache.
                 id_t ancid{}; // buff: The nearest line id to the slide.
                 si32 ancdy{}; // buff: Slide's top line offset.
                 bool round{}; // buff: Is the slide position approximate.
@@ -3362,35 +3368,51 @@ namespace netxs::ui
                 template<auto N>
                 auto max()
                 {
-                    return sizes[N].empty() ? 0
-                                            : sizes[N].rbegin()->first;
+                    return maxes[N];
+                }
+                auto _recalc_max(si32 kind)
+                {
+                    if (!sizes[kind].empty())
+                    {
+                        return sizes[kind].rbegin()->first;
+                    }
+                    else
+                    {
+                        auto& arr = sizea[kind];
+                        auto it = std::find_if(arr.rbegin(), arr.rend(), [](si32 count){ return count > 0; });
+                        return it != arr.rend() ? (si32)(std::distance(it, arr.rend()) - 1) : 0;
+                    }
                 }
                 // buff: Recalculate unlimited scrollback height without reflow.
                 void set_width(si32 new_width)
                 {
-                    vsize = 0;
+                    vsize = simpl;
                     width = std::max(1, new_width);
-                    for (auto kind : { type::leftside,
-                                       type::rghtside,
-                                       type::centered })
+                    auto sum_height = [&](auto count, auto line_size)
                     {
-                        for (auto [line_size, pool] : sizes[kind])
+                        if (line_size > width) vsize += count * ((line_size + width - 1) / width);
+                        else                   vsize += count;
+                    };
+                    auto limit = std::min(sizea_size, maxes[type::autowrap] + 1);
+                    for (auto line_size = 0; line_size < limit; line_size++)
+                    {
+                        if (auto count = sizea[type::autowrap][line_size])
                         {
-                            assert(pool > 0);
-                            vsize += pool;
+                            sum_height(count, line_size);
                         }
                     }
-                    auto kind = type::autowrap;
-                    for (auto [line_size, pool] : sizes[kind])
+                    for (auto [line_size, count] : sizes[type::autowrap])
                     {
-                        if (line_size > width) vsize += pool * ((line_size + width - 1) / width);
-                        else                   vsize += pool;
+                        sum_height(count, line_size);
                     }
                 }
                 // buff: Register a new line.
                 void invite(line& l, si32 new_kind, si32 new_size)
                 {
-                    ++sizes[new_kind][new_size];
+                    if (new_kind != type::autowrap) simpl++;
+                    if (new_size < sizea_size) sizea[new_kind][new_size]++;
+                    else                       sizes[new_kind][new_size]++;
+                    if (new_size > maxes[new_kind]) maxes[new_kind] = new_size; // Update max length.
                     add_height(vsize, new_kind, new_size);
                     l._size = new_size;
                     l._kind = new_kind;
@@ -3401,7 +3423,10 @@ namespace netxs::ui
                     if (l._size != new_size || l._kind != new_kind)
                     {
                         undock(l._kind, l._size);
-                        ++sizes[new_kind][new_size];
+                        if (new_kind != type::autowrap) simpl++;
+                        if (new_size > maxes[new_kind]) maxes[new_kind] = new_size;
+                        if (new_size < sizea_size) sizea[new_kind][new_size]++;
+                        else                       sizes[new_kind][new_size]++;
                         add_height(vsize, new_kind, new_size);
                         l._size = new_size;
                         l._kind = new_kind;
@@ -3410,10 +3435,29 @@ namespace netxs::ui
                 // buff: Discard the specified metrics.
                 void undock(si32 line_kind, si32 line_size)
                 {
-                    auto& lens = sizes[line_kind];
-                    auto  iter = lens.find(line_size); assert(iter != lens.end());
-                    auto  pool = --(*iter).second;
-                    if (pool == 0) lens.erase(iter);
+                    if (line_kind != type::autowrap) simpl--;
+                    auto was_max = line_size == maxes[line_kind]; // Check if it was max length line.
+                    if (line_size < sizea_size)
+                    {
+                        sizea[line_kind][line_size]--;
+                        assert(sizea[line_kind][line_size] >= 0);
+                    }
+                    else
+                    {
+                        auto& lens = sizes[line_kind];
+                        auto  iter = lens.find(line_size); assert(iter != lens.end());
+                        auto  pool = --(*iter).second;
+                        if (pool == 0) lens.erase(iter);
+                    }
+                    if (was_max) // Lazy max length recalc.
+                    {
+                        auto still_exists = line_size < sizea_size ? sizea[line_kind][line_size] > 0
+                                                                   : sizes[line_kind].contains(line_size);
+                        if (!still_exists)
+                        {
+                            maxes[line_kind] = _recalc_max(line_kind);
+                        }
+                    }
                     dec_height(vsize, line_kind, line_size);
                 }
                 // buff: Check buffer size.
@@ -3537,6 +3581,8 @@ namespace netxs::ui
                     caret = 0;
                     basis = 0;
                     slide = 0;
+                    simpl = 0;
+                    maxes.fill(0);
                     invite(0, deco{}.wrp(auto_wrap), cell{}); // At least one line must exist.
                     ancid = back().index;
                     ancdy = 0;
@@ -3560,10 +3606,10 @@ namespace netxs::ui
 
             friend auto& operator << (std::ostream& s, scroll_buf& c) // For debug.
             {
-                return s << "{ " << c.batch.max<deco::type::leftside>() << ","
-                                 << c.batch.max<deco::type::rghtside>() << ","
-                                 << c.batch.max<deco::type::centered>() << ","
-                                 << c.batch.max<deco::type::autowrap>() << " }";
+                return s << "{ " << c.batch.maxes[deco::type::leftside] << ","
+                                 << c.batch.maxes[deco::type::rghtside] << ","
+                                 << c.batch.maxes[deco::type::centered] << ","
+                                 << c.batch.maxes[deco::type::autowrap] << " }";
             }
 
             buff batch; // scroll_buf: Scrollback container.
@@ -4249,9 +4295,9 @@ namespace netxs::ui
             bool recalc_pads(dent& oversz_ref) override
             {
                 auto coor = get_coord();
-                auto rght = std::max({0, batch.max<deco::type::leftside>() - panel.x, coor.x - panel.x + 1 }); // Take into account the cursor position.
-                auto left = std::max( 0, batch.max<deco::type::rghtside>() - panel.x);
-                auto cntr = std::max( 0, batch.max<deco::type::centered>() - panel.x);
+                auto rght = std::max({0, batch.maxes[deco::type::leftside] - panel.x, coor.x - panel.x + 1 }); // Take into account the cursor position.
+                auto left = std::max( 0, batch.maxes[deco::type::rghtside] - panel.x);
+                auto cntr = std::max( 0, batch.maxes[deco::type::centered] - panel.x);
                 auto bttm = std::max( 0, batch.vsize - batch.basis - arena          );
                 auto both = cntr >> 1;
                 left = shore + std::max(left, both + (cntr & 1));

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -1275,7 +1275,7 @@ namespace netxs::ui
             ui64  alive; // bufferbase: Selection is active (digest).
             line  match; // bufferbase: Search pattern for highlighting.
 
-            rich  tail_frag; // bufferbase: IRM cached fragment.
+            line  tail_frag; // bufferbase: IRM cached fragment.
             rich  char_2d; // bufferbase: 2D char image.
 
             hook image_update_token;
@@ -2556,7 +2556,7 @@ namespace netxs::ui
                         if (use_true_color)
                         {
                             auto baked = core{};
-                            canvas.unpack_indexed_colors(baked, owner.ctrack.color, owner.defclr);
+                            cell::unpack_indexed_colors_to(canvas, baked, owner.ctrack.color, owner.defclr);
                             buffer.s11n<true>(baked, square);
                         }
                         else
@@ -2584,7 +2584,7 @@ namespace netxs::ui
                         if (use_true_color)
                         {
                             auto baked = core{};
-                            canvas.unpack_indexed_colors(baked, owner.ctrack.color, owner.defclr);
+                            cell::unpack_indexed_colors_to(canvas, baked, owner.ctrack.color, owner.defclr);
                             buffer.s11n<true, true, faux>(baked, part_1);
                             buffer.s11n<true, faux, faux>(baked, part_2);
                             buffer.s11n<true, faux, true>(baked, part_3);
@@ -2922,10 +2922,9 @@ namespace netxs::ui
                 }
             }
             // alt_screen: .
-            auto& _fragment_from_current_coord(si32 left_cells)
+            void _fragment_from_current_coord(si32 left_cells)
             {
                 canvas.copy_piece(tail_frag, coord.x + coord.y * panel.x, left_cells);
-                return tail_frag;
             }
             // alt_screen: .
             template<bool Copy, class Span, class Shader>
@@ -2949,7 +2948,7 @@ namespace netxs::ui
                 if (next_x < panel.x)
                 {
                     auto left_cells = panel.x - next_x;
-                    tail_frag = _fragment_from_current_coord(left_cells);
+                    _fragment_from_current_coord(left_cells); // Update tail_frag.
                     _data_direct_fill<faux>(count, proto, fuse);
                     coord.x = next_x;
                     if (tail_frag.size())
@@ -3089,7 +3088,7 @@ namespace netxs::ui
             //    {
             //        auto use_true_color = owner.selmod == mime::richtext || selmod == mime::htmltext;
             //        auto baked = core{};
-            //        if (use_true_color) stripe.unpack_indexed_colors(baked, owner.ctrack.color, owner.defclr);
+            //        if (use_true_color) cell::unpack_indexed_colors_to(stripe, baked, owner.ctrack.color, owner.defclr);
             //        crop.s11n<true, true, faux>(use_true_colors ? baked : stripe, brush_state);
             //    }
             //    return crop;
@@ -3161,8 +3160,8 @@ namespace netxs::ui
             void selection_byword(twod coor) override
             {
                 seltop = selend = coor;
-                seltop.x = canvas.word<feed::rev>(coor);
-                selend.x = canvas.word<feed::fwd>(coor);
+                seltop = canvas.word<feed::rev>(coor);
+                selend = canvas.word<feed::fwd>(coor);
                 selection_locked(faux);
                 selection_selbox(faux);
                 selection_update(faux);
@@ -3232,7 +3231,7 @@ namespace netxs::ui
                 }
                 else
                 {
-                    match = { canvas.core::line(seltop, selend) };
+                    match = canvas.core::subline(seltop, selend);
                     auto p1 = seltop;
                     auto p2 = selend;
                     if (p1.y > p2.y || (p1.y == p2.y && p1.x > p2.x)) std::swap(p1, p2);
@@ -3282,7 +3281,7 @@ namespace netxs::ui
             // alt_screen: Remove all references to the image from the scrollback.
             void wipe_image_index(std::vector<ui16>& removed_image_indexes) override
             {
-                canvas.remove_image_bits(removed_image_indexes);
+                cell::remove_image_bits(canvas, removed_image_indexes);
             }
         };
 
@@ -4505,7 +4504,6 @@ namespace netxs::ui
                     }
 
                     auto curit = block.begin();
-                    auto width = twod{ size.x, 1 };
                     auto curid = start == 0 ? batch.front().index
                                             : batch[start - 1].index + 1;
                     auto style = ansi::def_style;
@@ -4513,8 +4511,8 @@ namespace netxs::ui
                     while (size.y-- > 0)
                     {
                         auto oldsz = batch.size;
-                        auto proto = core::span{ curit, (size_t)size.x };
-                        auto curln = line{ curid++, style, proto, width };
+                        auto proto = std::span{ curit, (size_t)size.x };
+                        auto curln = line{ curid++, style, proto };
                         curln.shrink(block.mark());
                         batch.insert(start, std::move(curln));
                         start += batch.size - oldsz; // Due to circulation in the ring.
@@ -5159,7 +5157,7 @@ namespace netxs::ui
                                 auto  shadow = destln.wrapped() ? destln.substr(mapln.start + coord.x)
                                                                 : destln.substr(mapln.start + coord.x, std::min(panel.x, mapln.width) - coord.x);
 
-                                if constexpr (mixer) curln.resize(batch.caret +shadow.length(), brush.spare.spc());
+                                if constexpr (mixer) curln.resize(batch.caret + (si32)shadow.size(), brush.spare.spc());
                                 else                 curln.splice(batch.caret, shadow, cell::shaders::full, brush.spare.spc());
 
                                 batch.recalc(curln);
@@ -5279,7 +5277,7 @@ namespace netxs::ui
                 }
             }
             // scroll_buf: .
-            auto& _fragment_from_current_coord(si32 left_cells)
+            void _fragment_from_current_coord(si32 left_cells)
             {
                 if (coord.y < y_top)
                 {
@@ -5295,7 +5293,6 @@ namespace netxs::ui
                 {
                     dnbox.copy_piece(tail_frag, coord.x + (coord.y - (y_end + 1)) * panel.x, left_cells);
                 }
-                return tail_frag;
             }
             // scroll_buf: Insert text using the specified cell shader.
             template<class Span, class Shader>
@@ -5305,7 +5302,7 @@ namespace netxs::ui
                 if (next_x < panel.x)
                 {
                     auto left_cells = panel.x - next_x;
-                    tail_frag = _fragment_from_current_coord(left_cells);
+                    _fragment_from_current_coord(left_cells); // Update tail_frag.
                     _data_direct_fill<faux>(count, proto, fuse);
                     coord.x = next_x;
                     sync_coord();
@@ -5538,7 +5535,7 @@ namespace netxs::ui
                     auto& curln = batch[i];
                     if (fresh)
                     {
-                        curln.trimto(start, brush.spc());
+                        curln.trimto(start);
                     }
                     else
                     {
@@ -5548,12 +5545,12 @@ namespace netxs::ui
                             mapln.width = panel.x;
                             auto x = std::min(coor.x, panel.x); // Trim unwrapped lines by viewport.
                             curln.splice<true>(start + x, panel.x - x, blank);
-                            curln.trimto(start + panel.x, brush.spc());
+                            curln.trimto(start + panel.x);
                         }
                         else
                         {
                             mapln.width = coor.x;
-                            curln.trimto(start + coor.x, brush.spc());
+                            curln.trimto(start + coor.x);
                         }
                         assert(mapln.start == 0 || curln.wrapped());
                     }
@@ -5655,7 +5652,7 @@ namespace netxs::ui
                     {
                         auto& curln = *(curit - 1);
                         curln = std::move(tmpln);
-                        curln.trimto(start, brush.spc());
+                        curln.trimto(start);
                         batch.invite(curln);
                     }
 
@@ -5821,7 +5818,7 @@ namespace netxs::ui
             //    {
             //        auto use_true_color = owner.selmod == mime::richtext || selmod == mime::htmltext;
             //        auto baked = core{};
-            //        if (use_true_color) stripe.unpack_indexed_colors(baked, owner.ctrack.color, owner.defclr);
+            //        if (use_true_color) cell::unpack_indexed_colors_to(stripe, baked, owner.ctrack.color, owner.defclr);
             //        crop.s11n<true, true, faux>(use_true_colors ? baked : stripe, brush_state);
             //    }
             //    return crop;
@@ -6289,8 +6286,8 @@ namespace netxs::ui
                     uptop.role = grip::base;
                     uptop.coor = coor;
                     dntop = uptop;
-                    uptop.coor.x = upbox.word<feed::rev>(coor);
-                    dntop.coor.x = upbox.word<feed::fwd>(coor);
+                    uptop.coor = upbox.word<feed::rev>(coor);
+                    dntop.coor = upbox.word<feed::fwd>(coor);
                 }
                 else if (coor.y < scrolling_margin + arena) // Inside the scrolling region.
                 {
@@ -6301,8 +6298,8 @@ namespace netxs::ui
                     dnmid = upmid;
                     auto& cell_run = batch.item_by_id(upmid.link);
                     auto start = screen_to_offset(cell_run, upmid.coor);
-                    auto offup = cell_run.word<feed::rev>({ start, 0 });
-                    auto offdn = cell_run.word<feed::fwd>({ start, 0 });
+                    auto offup = cell_run.word<feed::rev>(start);
+                    auto offdn = cell_run.word<feed::fwd>(start);
                     upmid.coor = offset_to_screen(cell_run, offup);
                     dnmid.coor = offset_to_screen(cell_run, offdn);
                 }
@@ -6315,8 +6312,8 @@ namespace netxs::ui
                     upend.role = grip::base;
                     upend.coor = coor;
                     dnend = upend;
-                    upend.coor.x = dnbox.word<feed::rev>(coor);
-                    dnend.coor.x = dnbox.word<feed::fwd>(coor);
+                    upend.coor = dnbox.word<feed::rev>(coor);
+                    dnend.coor = dnbox.word<feed::fwd>(coor);
                 }
                 selection_locked(faux);
                 selection_selbox(faux);
@@ -6646,7 +6643,7 @@ namespace netxs::ui
                     while (head++ != tail);
                     if (use_true_color)
                     {
-                        dest.unpack_indexed_colors(owner.ctrack.color, owner.defclr);
+                        cell::unpack_indexed_colors(dest, owner.ctrack.color, owner.defclr);
                     }
                     selmod == mime::disabled ||
                     selmod == mime::textonly ||
@@ -6655,7 +6652,7 @@ namespace netxs::ui
                 }
                 else
                 {
-                    auto baked = core{};
+                    auto baked = line{};
                     auto field = rect{ dot_00, dot_01 };
                     auto accum = cell{};
                     auto build = [&](auto print)
@@ -6689,7 +6686,7 @@ namespace netxs::ui
                         build([&](auto& curln)
                         {
                             auto block = escx{};
-                            block.s11n<faux, faux, faux>(curln, field, accum);
+                            block.s11n<faux, faux, faux>(curln.canvas, field, accum);
                             if (block.size() > 0) yield.add(block);
                             else                  yield.eol();
                         });
@@ -6706,8 +6703,8 @@ namespace netxs::ui
                                 s = curln.style;
                             }
                             auto block = escx{};
-                            if (use_true_color) curln.unpack_indexed_colors(baked, owner.ctrack.color, owner.defclr);
-                            block.s11n<true, faux, faux>(use_true_color ? baked : curln, field, accum);
+                            if (use_true_color) cell::unpack_indexed_colors_to(curln, baked, owner.ctrack.color, owner.defclr);
+                            block.s11n<true, faux, faux>((use_true_color ? baked : curln).canvas, field, accum);
                             if (block.size() > 0) yield.add(block);
                             else                  yield.eol();
                         });
@@ -6806,7 +6803,7 @@ namespace netxs::ui
                                 else if (coord.y > curend.y) coor.y = stop;
                                 else
                                 {
-                                    auto block = rect{ coord, { subblock.length(), 1 }};
+                                    auto block = rect{ coord, { (si32)subblock.size(), 1 }};
                                     if (coord.y == curtop.y)
                                     {
                                         auto width = curtop.y == curend.y ? curend.x - curtop.x + 1
@@ -6844,7 +6841,7 @@ namespace netxs::ui
                                         case bias::right:  coord.x += panel.x - 1; break;
                                         case bias::center: coord.x += panel.x / 2; break;
                                     }
-                                    struct { auto length() const { return 1; }} empty;
+                                    struct { auto size() const { return 1; }} empty;
                                     draw(coord, empty, faux);
                                 }
                                 coor.y += height;
@@ -6994,19 +6991,19 @@ namespace netxs::ui
                     if (p1.y > p2.y || (p1.y == p2.y && p1.x > p2.x)) std::swap(p1, p2);
                     auto head = selection_offset(curln, p1, 0);
                     auto tail = selection_offset(curln, p2, 1);
-                    match = { curln.core::line(head, tail) };
+                    match = line{ curln.subline(head, tail) };
                 }
                 else if (uptop.role == grip::base
                       && dntop.role == grip::base
                       && (!selection_selbox() || uptop.coor.y == dntop.coor.y))
                 {
-                    match = { upbox.core::line(uptop.coor, dntop.coor) };
+                    match = line{ upbox.core::subline(uptop.coor, dntop.coor) };
                 }
                 else if (upend.role == grip::base
                       && dnend.role == grip::base
                       && (!selection_selbox() || upend.coor.y == dnend.coor.y))
                 {
-                    match = { dnbox.core::line(upend.coor, dnend.coor) };
+                    match = line{ dnbox.core::subline(upend.coor, dnend.coor) };
                 }
                 else match = {};
 
@@ -7272,19 +7269,19 @@ namespace netxs::ui
             // scroll_buf: Remove all references to the image from the scrollback.
             void wipe_image_index(std::vector<ui16>& removed_image_indexes) override
             {
-                upbox.remove_image_bits(removed_image_indexes);
-                dnbox.remove_image_bits(removed_image_indexes);
+                cell::remove_image_bits(upbox, removed_image_indexes);
+                cell::remove_image_bits(dnbox, removed_image_indexes);
                 #if defined (__ANDROID__)
                     std::for_each(batch.begin(), batch.end(), [&](auto& l)
                     {
-                        l.remove_image_bits(removed_image_indexes);
+                        cell::remove_image_bits(l, removed_image_indexes);
                     });
                 #else
                     auto wipe_batch = [&](auto policy) // Try to parallelize.
                     {
                         std::for_each(policy, batch.begin(), batch.end(), [&](auto& l)
                         {
-                            l.remove_image_bits(removed_image_indexes);
+                            cell::remove_image_bits(l, removed_image_indexes);
                         });
                     };
                     batch.length() > 100000 ? wipe_batch(std::execution::par)
@@ -8861,7 +8858,7 @@ namespace netxs::ui
             auto utf8 = text{};
             if (console.selection_active()) // Paste from selection.
             {
-                utf8 = console.match.utf8();
+                utf8 = cell::to_utf8(console.match);
             }
             else if (selection_passed()) // Paste from clipboard.
             {
@@ -10590,7 +10587,7 @@ namespace netxs::ui
         {
             auto bitmap_lock = stream.bitmap_dtvt.freeze();
             auto& grid = bitmap_lock.thing.image;
-            grid.remove_image_bits(removed_image_indexes);
+            cell::remove_image_bits(grid, removed_image_indexes);
         }
         // dtvt: Drop removed image metadata from canvas.
         void update_image_bits(ui16 updated_image_index)

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -1240,88 +1240,6 @@ namespace netxs::ui
 
             using tabs = std::vector<std::pair<si32, si32>>; // Pairs of forward and reverse tabstops index.
 
-            struct line
-                : public rich
-            {
-                using rich::rich;
-                using type = deco::type;
-
-                line(line&& l)
-                    : rich{ std::move(l) },
-                     index{ l.index      }
-                {
-                    static constexpr auto j = sizeof(core);//112
-                    static constexpr auto i = sizeof(rich);//112
-                    static constexpr auto i2 = sizeof(line);//144
-                    static constexpr auto i3 = sizeof(deco);//
-                    style = l.style;
-                    _size = l._size;
-                    _kind = l._kind;
-                    l._size = {};
-                    l._kind = {};
-                }
-                line(line const& l)
-                    : rich{ l       },
-                     style{ l.style },
-                     index{ l.index }
-                { }
-                line(id_t line_id, deco const& line_style, span dt, twod sz)
-                    : rich{ dt, sz     },
-                     style{ line_style },
-                     index{ line_id    }
-                { }
-                line(id_t line_id, deco const& line_style, cell const& blank)
-                    : rich{ blank      },
-                     style{ line_style },
-                     index{ line_id    }
-                { }
-                line(id_t line_id, deco const& line_style, cell const& blank, si32 length)
-                    : rich{ blank, length },
-                     style{ line_style    },
-                     index{ line_id       }
-                { }
-                line(core&& s)
-                    : rich{ std::move(s) }
-                { }
-                line(netxs::view utf8)
-                    : rich{ para{ utf8 }.content() }
-                { }
-
-                line& operator = (line&&)      = default;
-                line& operator = (line const&) = default;
-
-                deco style{};
-                id_t index{};
-                si32 _size{};
-                si32 _kind{};
-
-                friend void swap(line& lhs, line& rhs)
-                {
-                    std::swap<rich>(lhs, rhs);
-                    std::swap(lhs.index, rhs.index);
-                    std::swap(lhs.style, rhs.style);
-                    std::swap(lhs._size, rhs._size);
-                    std::swap(lhs._kind, rhs._kind);
-                }
-                void wipe()
-                {
-                    rich::kill();
-                    _size = {};
-                    _kind = {};
-                }
-                bool wrapped() const
-                {
-                    assert(_kind == style.get_kind());
-                    return _kind == type::autowrap;
-                }
-                si32 height(si32 panel_x) const
-                {
-                    auto len = length();
-                    assert(_kind == style.get_kind());
-                    return len > panel_x && wrapped() ? (len + panel_x - 1) / panel_x
-                                                      : 1;
-                }
-            };
             struct redo
             {
                 using mark = ansi::mark;
@@ -2736,8 +2654,8 @@ namespace netxs::ui
                     {
                         head += clip.coor.x;
                         auto next = head + clip.size.x;
-                        auto line = std::span(head, next);
-                        print_stripe(line);
+                        auto cell_run = std::span(head, next);
+                        print_stripe(cell_run);
                         head = next + rest;
                         if (head != tail)
                         {
@@ -3559,19 +3477,19 @@ namespace netxs::ui
                     undock(l._kind, l._size);
                 }
                 // buff: Return the item position in the scrollback using its id.
-                auto index_by_id(ui32 item_id) const
+                auto index_by_id(id_t item_id) const
                 {
                     //No need to disturb distant objects, it may already be in the swap.
                     auto total = length();
                     return (si32)(total - 1 - (back().index - item_id)); // ring buffer size is never larger than max_int32.
                 }
                 // buff: Return an iterator pointing to the item with the specified id.
-                auto iter_by_id(ui32 line_id) -> ring::iter<ring> //todo MSVC 17.7.0 requires return type
+                auto iter_by_id(id_t line_id) -> ring::iter<ring> //todo MSVC 17.7.0 requires return type
                 {
                     return begin() + index_by_id(line_id);
                 }
                 // buff: Return the item reference using its id.
-                auto& item_by_id(ui32 line_id)
+                auto& item_by_id(id_t line_id)
                 {
                     return ring::at(index_by_id(line_id));
                 }
@@ -3644,10 +3562,10 @@ namespace netxs::ui
 
             friend auto& operator << (std::ostream& s, scroll_buf& c) // For debug.
             {
-                return s << "{ " << c.batch.max<line::type::leftside>() << ","
-                                 << c.batch.max<line::type::rghtside>() << ","
-                                 << c.batch.max<line::type::centered>() << ","
-                                 << c.batch.max<line::type::autowrap>() << " }";
+                return s << "{ " << c.batch.max<deco::type::leftside>() << ","
+                                 << c.batch.max<deco::type::rghtside>() << ","
+                                 << c.batch.max<deco::type::centered>() << ","
+                                 << c.batch.max<deco::type::autowrap>() << " }";
             }
 
             buff batch; // scroll_buf: Scrollback container.
@@ -4176,11 +4094,11 @@ namespace netxs::ui
                 auto unknown = true;
                 while (head != tail && (index.size < arena || unknown))
                 {
-                    auto& line = *--head;
-                    auto lineid = line.index;
-                    auto length = line.length();
+                    auto& cell_run = *--head;
+                    auto lineid = cell_run.index;
+                    auto length = cell_run.length();
                     auto active = lnid == lineid;
-                    if (line.wrapped())
+                    if (cell_run.wrapped())
                     {
                         auto offset = length;
                         auto remain = length ? (length - 1) % panel.x + 1
@@ -4235,10 +4153,10 @@ namespace netxs::ui
                 {
                     assert(curit != batch.end() - 1);
 
-                    auto& line = *++curit;
-                    width = line.length();
-                    wraps = line.wrapped();
-                    curid = line.index;
+                    auto& cell_run = *++curit;
+                    width = cell_run.length();
+                    wraps = cell_run.wrapped();
+                    curid = cell_run.index;
                     start = 0;
                 }
                 else assert(mapln.width == panel.x);
@@ -4263,10 +4181,10 @@ namespace netxs::ui
                     if (avail == 0) break;
 
                     assert(curit != batch.end() - 1);
-                    auto& line = *++curit;
-                    width = line.length();
-                    wraps = line.wrapped();
-                    curid = line.index;
+                    auto& cell_run = *++curit;
+                    width = cell_run.length();
+                    wraps = cell_run.wrapped();
+                    curid = cell_run.index;
                     start = 0;
                 }
                 assert(test_index());
@@ -4333,9 +4251,9 @@ namespace netxs::ui
             bool recalc_pads(dent& oversz_ref) override
             {
                 auto coor = get_coord();
-                auto rght = std::max({0, batch.max<line::type::leftside>() - panel.x, coor.x - panel.x + 1 }); // Take into account the cursor position.
-                auto left = std::max( 0, batch.max<line::type::rghtside>() - panel.x);
-                auto cntr = std::max( 0, batch.max<line::type::centered>() - panel.x);
+                auto rght = std::max({0, batch.max<deco::type::leftside>() - panel.x, coor.x - panel.x + 1 }); // Take into account the cursor position.
+                auto left = std::max( 0, batch.max<deco::type::rghtside>() - panel.x);
+                auto cntr = std::max( 0, batch.max<deco::type::centered>() - panel.x);
                 auto bttm = std::max( 0, batch.vsize - batch.basis - arena          );
                 auto both = cntr >> 1;
                 left = shore + std::max(left, both + (cntr & 1));
@@ -5079,17 +4997,17 @@ namespace netxs::ui
                 else ctx.block.splice(coord, n, blank);
             }
             // scroll_buf: Merge curln with its neighbors.
-            void _merge(line& curln, si32 oldsz, ui32 curid, si32 count)
+            void _merge(line& curln, si32 oldsz, id_t curid, si32 count)
             {
                 auto coor = oldsz + panel.x - (oldsz - 1) % panel.x - 1;
                 auto iter = batch.iter_by_id(curid);
                 while (count-- > 0)
                 {
-                    auto& line = *++iter;
+                    auto& cell_run = *++iter;
                     //todo respect line alignment
-                    if (line.wrapped()) curln.splice(coor, line                   , cell::shaders::full, brush.spc());
-                    else                curln.splice(coor, line.substr(0, panel.x), cell::shaders::full, brush.spc());
-                    coor += line.height(panel.x) * panel.x;
+                    if (cell_run.wrapped()) curln.splice(coor, cell_run                   , cell::shaders::full, brush.spc());
+                    else                    curln.splice(coor, cell_run.substr(0, panel.x), cell::shaders::full, brush.spc());
+                    coor += cell_run.height(panel.x) * panel.x;
                 }
             }
             // scroll_buf: Proceed new text using specified cell shader.
@@ -5975,11 +5893,11 @@ namespace netxs::ui
                             assert(head != limit);
                             while (true)
                             {
-                                auto& line = *head;
-                                auto line_height = line.height(panel.x);
+                                auto& cell_run = *head;
+                                auto line_height = cell_run.height(panel.x);
                                 if (ypos < line_height || ++head == limit)
                                 {
-                                    grip.link = line.index;
+                                    grip.link = cell_run.index;
                                     grip.coor.y = ypos;
                                     break;
                                 }
@@ -6381,12 +6299,12 @@ namespace netxs::ui
                     upend.role = dnend.role = grip::idle;
                     upmid = selection_coor_to_grip(coor, grip::base);
                     dnmid = upmid;
-                    auto& line = batch.item_by_id(upmid.link);
-                    auto start = screen_to_offset(line, upmid.coor);
-                    auto offup = line.word<feed::rev>({ start, 0 });
-                    auto offdn = line.word<feed::fwd>({ start, 0 });
-                    upmid.coor = offset_to_screen(line, offup);
-                    dnmid.coor = offset_to_screen(line, offdn);
+                    auto& cell_run = batch.item_by_id(upmid.link);
+                    auto start = screen_to_offset(cell_run, upmid.coor);
+                    auto offup = cell_run.word<feed::rev>({ start, 0 });
+                    auto offdn = cell_run.word<feed::fwd>({ start, 0 });
+                    upmid.coor = offset_to_screen(cell_run, offup);
+                    dnmid.coor = offset_to_screen(cell_run, offdn);
                 }
                 else // Inside the bottom margin.
                 {
@@ -6497,9 +6415,9 @@ namespace netxs::ui
                     upmid = selection_coor_to_grip(coor, grip::base);
                     dnmid = upmid;
                     auto curit = batch.iter_by_id(upmid.link);
-                    auto& line = *curit;
-                    auto start = screen_to_offset(line, upmid.coor);
-                    auto group = 0xFF & (line.empty() ? line.link() : line.at(start).link()); // The semantic marker is placed in the low byte of the identifier.
+                    auto& cell_run = *curit;
+                    auto start = screen_to_offset(cell_run, upmid.coor);
+                    auto group = 0xFF & (cell_run.empty() ? cell_run.link() : cell_run.at(start).link()); // The semantic marker is placed in the low byte of the identifier.
                     auto check = [&](auto& c){ return (c.link() & 0xFF) != group; };
                     if (!group) // Semantic markers are not used.
                     {
@@ -6510,12 +6428,12 @@ namespace netxs::ui
                         place = part::mid;
                         auto offup = start;
                         auto offdn = start;
-                        auto up_rc = line.seek<feed::rev>(offup, check);
-                        auto dn_rc = line.seek<feed::fwd>(offdn, check);
+                        auto up_rc = cell_run.seek<feed::rev>(offup, check);
+                        auto dn_rc = cell_run.seek<feed::fwd>(offdn, check);
                         if (up_rc) // We are inside the command line.
                         {
-                            upmid.coor = offset_to_screen(line, offup);
-                            dnmid.coor = offset_to_screen(line, offdn);
+                            upmid.coor = offset_to_screen(cell_run, offup);
+                            dnmid.coor = offset_to_screen(cell_run, offdn);
                         }
                         else // We are inside the output or prompt.
                         {
@@ -6622,9 +6540,9 @@ namespace netxs::ui
                 auto vpos = -upcur.coor.y;
                 while (head != tail)
                 {
-                    auto& line = *head;
-                    vpos += line.height(panel.x);
-                    summ += line.length();
+                    auto& cell_run = *head;
+                    vpos += cell_run.height(panel.x);
+                    summ += cell_run.length();
                     ++head;
                 }
                 summ += std::min(end.length(), 1 + dncur.coor.y * panel.x + std::max(0, dncur.coor.x));
@@ -7202,15 +7120,15 @@ namespace netxs::ui
                                                : si32{0};
                             while (head != tail)
                             {
-                                auto& line = proc(head);
-                                from = ahead ? 0 : line.length();
-                                if (resx(line))
+                                auto& cell_run = proc(head);
+                                from = ahead ? 0 : cell_run.length();
+                                if (resx(cell_run))
                                 {
                                     delta.y += ahead ?-accum
-                                                     : accum + line.height(panel.x);
+                                                     : accum + cell_run.height(panel.x);
                                     return true;
                                 }
-                                accum += line.height(panel.x);
+                                accum += cell_run.height(panel.x);
                             }
                             return faux;
                         };
@@ -7699,8 +7617,8 @@ namespace netxs::ui
             while (true)
             {
                 auto next = head + step;
-                auto line = std::span(head, next);
-                scrollback.template _data<true>(step, line, fuse);
+                auto cell_run = std::span(head, next);
+                scrollback.template _data<true>(step, cell_run, fuse);
                 head = next + rest;
                 if (head != tail)
                 {
@@ -7745,9 +7663,9 @@ namespace netxs::ui
             {
                 head += clip.coor.x;
                 auto next = head + clip.size.x;
-                auto line = std::span(head, next);
+                auto cell_run = std::span(head, next);
                 scrollback.cup2(coor);
-                scrollback.template _data<true>(clip.size.x, line, fuse);
+                scrollback.template _data<true>(clip.size.x, cell_run, fuse);
                 head = next + rest;
                 coor.y++;
             }

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -3477,7 +3477,8 @@ namespace netxs::ui
                 template<class ...Args>
                 auto& invite(Args&&... args)
                 {
-                    auto& l = ring::push_back(std::forward<Args>(args)...);
+                    auto& l = ring::push_back();
+                    l.reinitialize(std::forward<Args>(args)...);
                     invite(l);
                     return l;
                 }
@@ -3485,12 +3486,37 @@ namespace netxs::ui
                 template<class ...Args>
                 auto& insert(si32 at, Args&&... args)
                 {
-                    auto& l = *ring::insert(at, std::forward<Args>(args)...);
+                    auto& l = *ring::insert(at);
+                    l.reinitialize(std::forward<Args>(args)...);
                     invite(l);
                     return l;
                 }
                 // buff: Remove specified line info from accounting and update metrics based on scroll height.
-                void undock_base_front(line& l) override
+                void _clear_line(line& l, bool deallocate)
+                {
+                    if (l.image) 
+                    {
+                        l.image = {};
+                        for (auto& c : l.cells) 
+                        {
+                            if (auto index = c.get_image_index())
+                            {
+                                //todo
+                                //if (--image_ref_counts[index] == 0) 
+                                //{
+                                //    release index
+                                //}
+                            }
+                        }
+                    }
+                    l.cells.clear();
+                    if (deallocate || l.cells.capacity() > 256) // Deallocate long lines (256*sizeof(cell)=10240bytes).
+                    {
+                        l.deallocate();
+                    }
+                }
+                // buff: Remove specified line from accounting and update metrics based on scroll height.
+                void undock_base_front(line& l, bool deallocate = faux) override
                 {
                     auto line_kind = l.get_kind();
                     auto line_size = l.length();
@@ -3508,26 +3534,13 @@ namespace netxs::ui
                         slide = 0;
                     }
                     rolls = true;
+                    _clear_line(l, deallocate);
                 }
                 // buff: Remove information about the specified line from accounting.
-                void undock_base_back(line& l) override
+                void undock_base_back(line& l, bool deallocate = faux) override
                 {
                     undock(l.get_kind(), l.length());
-                    if (l.image) 
-                    {
-                        l.image = {};
-                        for (auto& c : l.cells) 
-                        {
-                            if (auto index = c.get_image_index())
-                            {
-                                //todo
-                                //if (--image_ref_counts[index] == 0) 
-                                //{
-                                //    release id
-                                //}
-                            }
-                        }
-                    }
+                    _clear_line(l, deallocate);
                 }
                 // buff: Return the item position in the scrollback using its id.
                 auto index_by_id(id_t item_id) const
@@ -3597,16 +3610,25 @@ namespace netxs::ui
                 // buff: Clear scrollback keeping current line.
                 void clear_but_current()
                 {
-                    auto backup = current();
+                    auto& curln = current();
+                    auto backup = std::move(curln);
+                    auto old_state = backup.get_state();
+                    recalc(curln, old_state); // Detach current line.
                     backup.index = 0;
                     ring::clear();
-                    auto& curln = ring::push_back(backup); // Keep current line.
+                    auto& newln = ring::push_back();
+                    newln = std::move(backup); // Attach current line.
                     basis = 0;
                     slide = 0;
                     simpl = 0;
+                    if constexpr (debugmode)
+                    {
+                        for (auto& s : sizea) assert(s == std::decay_t<decltype(s)>{});
+                        for (auto& s : sizes) assert(s.empty());
+                    }
                     maxes.fill(0);
-                    invite(curln); // Sync current line state (length, wrap mode).
-                    ancid = curln.index;
+                    invite(newln); // Sync current line state (length, wrap mode).
+                    ancid = newln.index;
                     ancdy = 0;
                     set_width(width);
                 }
@@ -4566,9 +4588,10 @@ namespace netxs::ui
                     {
                         auto oldsz = batch.size;
                         auto proto = std::span{ curit, (size_t)size.x };
-                        auto curln = line{ curid++, new_style, proto };
+                        auto& curln = *batch.ring::insert(start);
+                        curln.reinitialize(curid++, new_style, proto);
                         curln.shrink(block.mark());
-                        batch.insert(start, std::move(curln));
+                        batch.invite(curln);
                         start += batch.size - oldsz; // Due to circulation in the ring.
                         assert(start <= batch.size);
                         curit += size.x;
@@ -5703,22 +5726,24 @@ namespace netxs::ui
                 auto split = [&](id_t curid, si32 start)
                 {
                     auto after = batch.index_by_id(curid);
-                    auto tmpln = std::move(batch[after]);
-                    auto curit = batch.ring::insert(after + 1, tmpln.index, tmpln.get_style(), parser::brush);
-                    auto endit = batch.end();
-
-                    auto& newln = *curit;
-                    newln.splice(0, tmpln.substr(start), cell::shaders::full, brush.spc());
-                    batch.undock_base_back(tmpln);
-                    batch.invite(newln);
-
-                    if (curit != batch.begin())
+                    if (batch.ring_size() == 1)
                     {
-                        auto& curln = *(curit - 1);
-                        curln = std::move(tmpln);
-                        curln.trimto(start);
-                        batch.invite(curln);
+                        auto& tmpln = batch[after];
+                        auto old_state = tmpln.get_state();
+                        tmpln.copy_piece(tmpln, start);
+                        batch.recalc(tmpln, old_state);
+                        return;
                     }
+                    auto curit = batch.ring::insert(after + 1);
+                    auto endit = batch.end();
+                    auto& newln = *curit;
+                    auto& tmpln = *(curit - 1);
+                    newln.reinitialize(tmpln.index, tmpln.get_style(), parser::brush);
+                    newln.splice(0, tmpln.substr(start), cell::shaders::full, brush.spc());
+                    auto old_state = tmpln.get_state();
+                    tmpln.trimto(start);
+                    batch.recalc(tmpln, old_state);
+                    batch.invite(newln);
 
                     do  ++(curit++->index);
                     while (curit != endit);
@@ -7356,6 +7381,7 @@ namespace netxs::ui
                 #endif
             }
         };
+
         // term: Take data until ST. Don't touch q if sequence is broken.
         static qiew read_until_st_or_giveup(qiew& q)
         {
@@ -7586,6 +7612,8 @@ namespace netxs::ui
                 if (ok) // Show image.
                 {
                     auto svg_doc = term::rgba_to_svg(bitmap, size);
+                    //
+                    //
                     static auto i = 0;
                     auto print_via_osc = utf::fprint("id=_sixel%id% %doc% W=%% H=%% fit=stretch", i++, svg_doc, size.x / cellsz.x, size.y / cellsz.y);
                     if constexpr (debugmode) log("svg:", utf::debase(print_via_osc));

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -3497,17 +3497,17 @@ namespace netxs::ui
                     if (l.image) 
                     {
                         l.image = {};
-                        for (auto& c : l.cells) 
-                        {
-                            //if (auto index = c.get_image_index())
-                            {
-                                //todo
-                                //if (--owner.image_ref_count[index] == 0) 
-                                //{
-                                //    release index
-                                //}
-                            }
-                        }
+                        //for (auto& c : l.cells) 
+                        //{
+                        //    if (auto index = c.get_image_index())
+                        //    {
+                        //        //todo
+                        //        //if (--owner.image_ref_count[index] == 0) 
+                        //        //{
+                        //        //    release index
+                        //        //}
+                        //    }
+                        //}
                     }
                     l.cells.clear();
                     if (deallocate || l.cells.capacity() > 256) // Deallocate long lines (256*sizeof(cell)=10240bytes).

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -3407,29 +3407,30 @@ namespace netxs::ui
                     }
                 }
                 // buff: Register a new line.
-                void invite(line& l, si32 new_kind, si32 new_size)
+                void invite(line& l)
                 {
+                    auto new_kind = l.get_kind();
+                    auto new_size = l.length();
                     if (new_kind != type::autowrap) simpl++;
                     if (new_size < sizea_size) sizea[new_kind][new_size]++;
                     else                       sizes[new_kind][new_size]++;
                     if (new_size > maxes[new_kind]) maxes[new_kind] = new_size; // Update max length.
                     add_height(vsize, new_kind, new_size);
-                    l._size = new_size;
-                    l._kind = new_kind;
                 }
-                // buff: Refresh scrollback height.
-                void recalc(line& l, si32 new_kind, si32 new_size)
+                // buff: Update buffer line statistics.
+                void recalc(auto& l, auto old_state)
                 {
-                    if (l._size != new_size || l._kind != new_kind)
+                    auto old_kind = std::get<0>(old_state);
+                    auto old_size = std::get<1>(old_state);
+                    auto [new_kind, new_size] = l.get_state();
+                    if (old_size != new_size || old_kind != new_kind)
                     {
-                        undock(l._kind, l._size);
+                        undock(old_kind, old_size);
                         if (new_kind != type::autowrap) simpl++;
                         if (new_size > maxes[new_kind]) maxes[new_kind] = new_size;
                         if (new_size < sizea_size) sizea[new_kind][new_size]++;
                         else                       sizes[new_kind][new_size]++;
                         add_height(vsize, new_kind, new_size);
-                        l._size = new_size;
-                        l._kind = new_kind;
                     }
                 }
                 // buff: Discard the specified metrics.
@@ -3472,32 +3473,27 @@ namespace netxs::ui
                     }
                     return old_value != vsize;
                 }
-                // buff: Push the specified line back.
-                void invite(line& l)
-                {
-                    invite(l, l.get_kind(), l.length());
-                }
-                // buff: Push a new line back.
+                // buff: Push a new line to the buffer back.
                 template<class ...Args>
                 auto& invite(Args&&... args)
                 {
                     auto& l = ring::push_back(std::forward<Args>(args)...);
-                    invite(l, l.get_kind(), l.length());
+                    invite(l);
                     return l;
                 }
-                // buff: Insert a new line at the specified position.
+                // buff: Insert a new line to the specified position.
                 template<class ...Args>
                 auto& insert(si32 at, Args&&... args)
                 {
                     auto& l = *ring::insert(at, std::forward<Args>(args)...);
-                    invite(l, l.get_kind(), l.length());
+                    invite(l);
                     return l;
                 }
                 // buff: Remove specified line info from accounting and update metrics based on scroll height.
                 void undock_base_front(line& l) override
                 {
-                    auto line_kind = l._kind;
-                    auto line_size = l._size;
+                    auto line_kind = l.get_kind();
+                    auto line_size = l.length();
                     undock(line_kind, line_size);
                     dec_height(basis, line_kind, line_size);
                     dec_height(slide, line_kind, line_size);
@@ -3516,7 +3512,22 @@ namespace netxs::ui
                 // buff: Remove information about the specified line from accounting.
                 void undock_base_back(line& l) override
                 {
-                    undock(l._kind, l._size);
+                    undock(l.get_kind(), l.length());
+                    if (l.image) 
+                    {
+                        l.image = {};
+                        for (auto& c : l.cells) 
+                        {
+                            if (auto index = c.get_image_index())
+                            {
+                                //todo
+                                //if (--image_ref_counts[index] == 0) 
+                                //{
+                                //    release id
+                                //}
+                            }
+                        }
+                    }
                 }
                 // buff: Return the item position in the scrollback using its id.
                 auto index_by_id(id_t item_id) const
@@ -3534,11 +3545,6 @@ namespace netxs::ui
                 auto& item_by_id(id_t line_id)
                 {
                     return ring::at(index_by_id(line_id));
-                }
-                // buff: Refresh metrics due to modified line.
-                void recalc(line& l)
-                {
-                    recalc(l, l.get_kind(), l.length());
                 }
                 // buff: Rewrite the indices from the specified position to the end or to the top (negative from).
                 void reindex(si32 from)
@@ -3597,6 +3603,8 @@ namespace netxs::ui
                     auto& curln = ring::push_back(backup); // Keep current line.
                     basis = 0;
                     slide = 0;
+                    simpl = 0;
+                    maxes.fill(0);
                     invite(curln); // Sync current line state (length, wrap mode).
                     ancid = curln.index;
                     ancdy = 0;
@@ -4107,8 +4115,9 @@ namespace netxs::ui
                 auto& curln = batch.current();
                 if (curln.wrapped() && batch.caret > curln.length()) // Dangling cursor.
                 {
+                    auto old_state = curln.get_state();
                     curln.crop(batch.caret, brush.spare.dry());
-                    batch.recalc(curln);
+                    batch.recalc(curln, old_state);
                 }
 
                 if (!owner.bottom_anchored || in_top > 0 || in_end > 0) // The cursor is outside the scrolling region.
@@ -4679,6 +4688,7 @@ namespace netxs::ui
             // scroll_buf: Update current SGR attributes. (! Check coord.y context)
             void _set_style(line& curln, deco const& new_style)
             {
+                auto old_state = curln.get_state();
                 auto wraps = curln.wrapped();
                 auto width = curln.length();
                 curln.set_style(new_style);
@@ -4700,7 +4710,7 @@ namespace netxs::ui
                     }
                 }
 
-                batch.recalc(curln);
+                batch.recalc(curln, old_state);
 
                 if (wraps != curln.wrapped())
                 {
@@ -4804,6 +4814,7 @@ namespace netxs::ui
                     auto  count = si32{};
                     auto cursor = std::max(0, batch.caret);
                     auto& curln = batch.current();
+                    auto old_state = curln.get_state();
                     auto  width = curln.length();
                     auto  wraps = curln.wrapped();
                     switch (n)
@@ -4834,14 +4845,15 @@ namespace netxs::ui
                     {
                         curln.splice<true>(start, count, blank);
 
-                        batch.recalc(curln);
+                        batch.recalc(curln, old_state);
                         width = curln.length();
                         auto& mapln = index[coord.y];
                         mapln.width = wraps ? std::min(panel.x, width - mapln.start)
                                             : width;
 
+                        //auto old_state2 = curln.get_state();
                         //curln.shrink(blank); //todo revise: It kills wrapped lines and as a result requires the viewport to be rebuilt.
-                        //batch.recalc(curln); //             The cursor may be misplaced when resizing because curln.length is less than batch.caret.
+                        //batch.recalc(curln, old_state2); //  The cursor may be misplaced when resizing because curln.length is less than batch.caret.
                         //index_rebuild();
                         //print_batch(" el");
                     }
@@ -4857,8 +4869,9 @@ namespace netxs::ui
                 {
                     n = std::min(n, panel.x - coord.x);
                     auto& curln = batch.current();
+                    auto old_state = curln.get_state();
                     curln.insert(batch.caret, n, blank, panel.x);
-                    batch.recalc(curln); // Line front is filled by blanks. No wrapping.
+                    batch.recalc(curln, old_state); // Line front is filled by blanks. No wrapping.
                     auto  width = curln.length();
                     auto  wraps = curln.wrapped();
                     auto& mapln = index[coord.y];
@@ -4875,8 +4888,9 @@ namespace netxs::ui
                 if (auto ctx = get_context(coord))
                 {
                     auto& curln = batch.current();
+                    auto old_state = curln.get_state();
                     curln.cutoff(batch.caret, n, blank, panel.x);
-                    batch.recalc(curln);
+                    batch.recalc(curln, old_state);
                 }
                 else ctx.block.cutoff(coord, n, blank);
             }
@@ -5025,11 +5039,12 @@ namespace netxs::ui
                 {
                     n = std::min(n, panel.x - coord.x);
                     auto& curln = batch.current();
+                    auto old_state = curln.get_state();
                     //todo revise (brush != default ? see windows console)
                     //if (c == whitespace) curln.splice<faux>(batch.caret, n, blank);
                     //else                 curln.splice<true>(batch.caret, n, blank);
                     curln.splice<true>(batch.caret, n, blank);
-                    batch.recalc(curln);
+                    batch.recalc(curln, old_state);
                     auto& mapln = index[coord.y];
                     auto  width = curln.length();
                     auto  wraps = curln.wrapped();
@@ -5099,15 +5114,15 @@ namespace netxs::ui
                     coord.x     += count;
                     if (batch.caret <= panel.x || !curln.wrapped()) // case 0.
                     {
+                        auto old_state = curln.get_state();
                         curln.splice<Copy>(start, count, proto, fuse, brush.spare.spc());
                         auto& mapln = index[coord.y];
                         assert(coord.x % panel.x == batch.caret % panel.x && mapln.index == curln.index);
                         if (coord.x > mapln.width)
                         {
                             mapln.width = coord.x;
-                            batch.recalc(curln);
+                            batch.recalc(curln, old_state);
                         }
-                        else assert(curln._size == curln.length());
                     } // case 0 - done.
                     else
                     {
@@ -5127,8 +5142,9 @@ namespace netxs::ui
                         auto curid = curln.index;
                         if (query > 0) // case 3 - complex: Cursor is outside the viewport.
                         {              // cursor overlaps some lines below and placed below the viewport.
+                            auto old_state = curln.get_state();
                             curln.resize(batch.caret, brush.spare.spc());
-                            batch.recalc(curln);
+                            batch.recalc(curln, old_state);
                             if (auto n = (si32)(batch.back().index - curid))
                             {
                                 if constexpr (mixer) _merge(curln, oldsz, curid, n);
@@ -5172,6 +5188,7 @@ namespace netxs::ui
                         } // case 3 done
                         else
                         {
+                            auto old_state = curln.get_state();
                             auto& mapln = index[coord.y];
                             if (curid == mapln.index) // case 1 - plain: cursor is inside the current paragraph.
                             {
@@ -5181,16 +5198,15 @@ namespace netxs::ui
                                     if (coord.x > mapln.width)
                                     {
                                         mapln.width = coord.x;
-                                        batch.recalc(curln);
+                                        batch.recalc(curln, old_state);
                                     }
-                                    else assert(curln._size == curln.length());
                                 }
                                 else // The case when the current line completely fills the viewport (arena == 1).
                                 {
                                     assert(arena == 1);
                                     mapln.start = batch.caret - coord.x;
                                     mapln.width = coord.x;
-                                    batch.recalc(curln);
+                                    batch.recalc(curln, old_state);
                                 }
                                 assert(test_futures());
                             } // case 1 done.
@@ -5204,7 +5220,7 @@ namespace netxs::ui
                                 if constexpr (mixer) curln.resize(batch.caret + (si32)shadow.size(), brush.spare.spc());
                                 else                 curln.splice(batch.caret, shadow, cell::shaders::full, brush.spare.spc());
 
-                                batch.recalc(curln);
+                                batch.recalc(curln, old_state);
                                 auto w = curln.length();
                                 auto spoil = (si32)(mapln.index - curid);
                                 assert(spoil > 0);
@@ -5308,10 +5324,11 @@ namespace netxs::ui
                     auto newlen = batch.caret + count;
                     if (newlen > curln.length())
                     {
+                        auto old_state = curln.get_state();
                         curln.crop(newlen, brush.spare.spc());
                         auto& mapln = index[coord.y - y_top];
                         mapln.width = newlen % panel.x;
-                        batch.recalc(curln);
+                        batch.recalc(curln, old_state);
                     }
                     fill(curln.begin(), start);
                 }
@@ -5577,6 +5594,7 @@ namespace netxs::ui
 
                     i = batch.index_by_id(topid); // The index may be outdated due to the ring.
                     auto& curln = batch[i];
+                    auto old_state = curln.get_state();
                     if (fresh)
                     {
                         curln.trimto(start);
@@ -5598,7 +5616,7 @@ namespace netxs::ui
                         }
                         assert(mapln.start == 0 || curln.wrapped());
                     }
-                    batch.recalc(curln);
+                    batch.recalc(curln, old_state);
 
                     sync_coord();
 
@@ -5639,17 +5657,19 @@ namespace netxs::ui
                     {
                         auto& mapln = *head++;
                         auto& curln = batch.item_by_id(mapln.index);
+                        auto old_state = curln.get_state();
                         mapln.width = panel.x;
                         curln.splice<true>(mapln.start, panel.x, blank);
-                        batch.recalc(curln);
+                        batch.recalc(curln, old_state);
                     }
                     if (from.x > 0)
                     {
                         auto& mapln = *head;
                         auto& curln = batch.item_by_id(mapln.index);
+                        auto old_state = curln.get_state();
                         mapln.width = std::max(mapln.width, from.x);
                         curln.splice<true>(mapln.start, from.x, blank);
-                        batch.recalc(curln);
+                        batch.recalc(curln, old_state);
                     }
                     upbox.wipe(blank);
                 };
@@ -6982,8 +7002,9 @@ namespace netxs::ui
                                                                      : bias::left;
                     selection_foreach([&](auto& curln)
                     {
+                        auto old_state = curln.get_state();
                         curln.jet(align);
-                        batch.recalc(curln);
+                        batch.recalc(curln, old_state);
                     });
                     if (a != bias::none) parser::style.jet(a);
                     resize_viewport(panel, true); // Recalc batch.basis.
@@ -7009,8 +7030,9 @@ namespace netxs::ui
                     upmid.coor.y = dnmid.coor.y = 0;
                     selection_foreach([&](auto& curln)
                     {
+                        auto old_state = curln.get_state();
                         curln.wrp(wraps);
-                        batch.recalc(curln);
+                        batch.recalc(curln, old_state);
                     });
                     if (w != wrap::none) parser::style.wrp(w);
                     resize_viewport(panel, true); // Recalc batch.basis.

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -1842,7 +1842,7 @@ namespace netxs::ui
                 {
                     if (owner.io_log) log("%%Sixel data:\n\tparams: %%\n\tpayload:%%", prompt::term, [&]{ auto t = ansi::escx{}; while (param_count--) { t.add(params[param_count], ';'); } return t; }(), ansi::hi(tmp));
                     q.remove_prefix(SIXEL_str.size());
-                    owner.sixels.start(q, params, this);
+                    owner.sixels.parse(q, params);
                 }
                 else if (auto data = term::read_until_st_or_giveup(q))
                 {
@@ -7422,26 +7422,11 @@ namespace netxs::ui
             static constexpr auto cellsz = twod{ 10, 20 };
 
             term& owner;
-            bool sixel_mode{}; // Sixel input is not complete.
-            si32 aspect_ratio{};
-            si32 transparency{};
-            si32 stride{};
-            si32 cur_map{};
-            si32 coor{};
-            si32 maxx{};
-            si32 maxy{};
-            si32 line{};
-            twod size;
-            pals palette{};
-            cell cur_clr;
-            argb cur_fgc{};
-            argb cur_bgc{};
             std::vector<argb> bitmap; // Sixel bitmap buffer.
 
-            operator bool () { return sixel_mode; }
-
-            void start(qiew& q, auto& params, bufferbase* target_buffer)
+            void parse(qiew& q, auto& params)
             {
+                auto ok = faux;
                 // aspect_ratio:
                 // omitted     2:1
                 // 0 or 1      5:1
@@ -7451,60 +7436,55 @@ namespace netxs::ui
                 // 7,8, or 9   1:1
                 //                                        -1  0  1  2  3  4  5  6  7  8  9
                 static constexpr auto ar = std::to_array({ 2, 5, 5, 3, 2, 2, 2, 2, 1, 1, 1 });
-                aspect_ratio = ar[std::clamp(params[0] + 1, 0, (si32)ar.size() - 1)];
+                auto aspect_ratio = ar[std::clamp(params[0] + 1, 0, (si32)ar.size() - 1)];
                 // transparency:
                 // omitted     opaque  0's are filled with current background color
                 // 0 or 2      opaque
                 // 1           transparent   0's are kept intact
                 //                                        -1  0  1  2
                 static constexpr auto tr = std::to_array({ 0, 0, 1, 0 });
-                transparency = tr[std::clamp(params[1] + 1, 0, (si32)tr.size() - 1)];
+                auto transparency = tr[std::clamp(params[1] + 1, 0, (si32)tr.size() - 1)];
                 // hz_grid_size: We ignore it.
                 // n
                 //auto hz_grid_size = params[2];
-                size = target_buffer->panel * cellsz;
+                auto size = owner.target->panel * cellsz;
                 size.y *= aspect_ratio;
-                stride = size.x * aspect_ratio * 6;
-                palette = owner.ctrack.color; // Copy terminal palette.
-                cur_map = 0;
-                cur_clr = target_buffer->get_effective_brush();
-                cur_fgc = cur_clr.fgc();
-                cur_bgc = cur_clr.bgc();
+                auto stride = size.x * aspect_ratio * 6;
+                auto palette = owner.ctrack.color; // Copy terminal palette.
+                auto cur_map = 0;
+                auto cur_clr = owner.target->get_effective_brush();
+                auto cur_fgc = cur_clr.fgc();
+                auto cur_bgc = cur_clr.bgc();
                 if (cur_clr.inv()) std::swap(cur_fgc, cur_bgc);
                 transparency ? bitmap.assign(size.x * size.y, argb{})
                              : bitmap.assign(size.x * size.y, cur_bgc);
-                coor = 0;
-                maxx = size.x;
-                maxy = size.x * size.y;
-                line = 0;
-                parse(q, target_buffer);
-            }
-            void print_sixel(si32 c)
-            {
-                if (coor < maxx)
+                auto coor = 0;
+                auto maxx = size.x;
+                auto maxy = size.x * size.y;
+                auto line = 0;
+                auto print_sixel = [&](si32 c)
                 {
-                    auto offset = coor++;
-                    while (c)
+                    if (coor < maxx)
                     {
-                        if (c & 1)
+                        auto offset = coor++;
+                        while (c)
                         {
-                            for (auto y = 0; y < aspect_ratio; y++)
+                            if (c & 1)
                             {
-                                if (offset < maxy) bitmap[offset] = cur_fgc;
-                                offset += size.x;
+                                for (auto y = 0; y < aspect_ratio; y++)
+                                {
+                                    if (offset < maxy) bitmap[offset] = cur_fgc;
+                                    offset += size.x;
+                                }
                             }
+                            else
+                            {
+                                offset += size.x * aspect_ratio;
+                            }
+                            c >>= 1;
                         }
-                        else
-                        {
-                            offset += size.x * aspect_ratio;
-                        }
-                        c >>= 1;
                     }
-                }
-            }
-            void parse(qiew& q, bufferbase* target_buffer)
-            {
-                sixel_mode = true;
+                };
                 //auto hash = ui64{};
                 auto head = q.begin();
                 auto tail = q.end();
@@ -7544,18 +7524,18 @@ namespace netxs::ui
                         if (q2 && q2.front() == ';') // Update palette.
                         {
                             q2.pop_front();
-                            auto params = std::to_array({ 0, 0, 0, 0 });
-                            term::read_params(q2, params);
-                            auto color_mode = params[0];
+                            auto params2 = std::to_array({ 0, 0, 0, 0 });
+                            term::read_params(q2, params2);
+                            auto color_mode = params2[0];
                             if (color_mode == 1) // HLS
                             {
-                                palette[cur_map] = netxs::letoh(argb::from_HLS(params[1], params[2], params[3]).token);
+                                palette[cur_map] = netxs::letoh(argb::from_HLS(params2[1], params2[2], params2[3]).token);
                             }
                             else if (color_mode == 2) // RGB
                             {
-                                palette[cur_map] = netxs::letoh(argb{ (byte)(params[1] * 255 / 100),
-                                                                      (byte)(params[2] * 255 / 100),
-                                                                      (byte)(params[3] * 255 / 100) }.token);
+                                palette[cur_map] = netxs::letoh(argb{ (byte)(params2[1] * 255 / 100),
+                                                                      (byte)(params2[2] * 255 / 100),
+                                                                      (byte)(params2[3] * 255 / 100) }.token);
                             }
                         }
                         head = q2.begin();
@@ -7564,15 +7544,15 @@ namespace netxs::ui
                     }
                     else if (c == '"') // Raster Attributes (reset canvas).  "dy;dx;width;height  aspect_ratio=round(dy/dx).
                     {
-                        auto params = std::to_array({ -1, -1, -1, -1 });
+                        auto params2 = std::to_array({ -1, -1, -1, -1 });
                         auto q2 = qiew{ head, tail };
-                        term::read_params(q2, params);
+                        term::read_params(q2, params2);
                         head = q2.begin();
                         tail = q2.end();
-                        auto dy = std::max(1, std::abs(params[0]));
-                        auto dx = std::max(1, std::abs(params[1]));
-                        size.x = std::clamp(std::abs(params[2]), 1, std::max(4096, target_buffer->panel.x * cellsz.x));
-                        size.y = std::clamp(std::abs(params[3]), 1, std::max(4096, target_buffer->panel.y * cellsz.y));
+                        auto dy = std::max(1, std::abs(params2[0]));
+                        auto dx = std::max(1, std::abs(params2[1]));
+                        size.x = std::clamp(std::abs(params2[2]), 1, std::max(4096, owner.target->panel.x * cellsz.x));
+                        size.y = std::clamp(std::abs(params2[3]), 1, std::max(4096, owner.target->panel.y * cellsz.y));
                         aspect_ratio = (si32)std::round((fp32)dy / dx);
                         size.y *= aspect_ratio;
                         coor = 0;
@@ -7595,23 +7575,19 @@ namespace netxs::ui
                     }
                     else if ((c == '\x1b' && head != tail && *head == '\\' && (head++, true)) || c == '\a') // ST
                     {
-                        if constexpr (debugmode) log("sixel end");
-                        sixel_mode = faux;
+                        if constexpr (debugmode) log("sixel complete");
+                        ok = true;
                         break;
                     }
+                    //else if (c == '\x1b') //todo Escape sequence inside sixels. ?Should we parse it?
+                    //{
+                    //    if constexpr (debugmode) log("escape sequence inside sixels");
+                    //    auto data = qiew{ head, tail };
+                    //    ...ansi::parse(data, console_ptr);
+                    //}
                     else if (c == ansi::c0_can || c == ansi::c0_sub) // Abort.
                     {
                         if constexpr (debugmode) log("sixel aborted");
-                        sixel_mode = faux;
-                        auto q2 = qiew{ head, tail };
-                        if (auto data = term::read_until_st_or_giveup(q2)) // Eat all sixels.
-                        {
-                            q = q2;
-                        }
-                        else // Broken sequence.
-                        {
-                            // Keep q intact.
-                        }
                         break;
                     }
                     else
@@ -7619,13 +7595,13 @@ namespace netxs::ui
                         // Silently ignore all unknown characters.
                     }
                 }
-                if (sixel_mode == faux) // Show image.
+                q = qiew{ head, tail };
+                if (ok) // Show image.
                 {
-                    q = qiew{ head, tail };
                     auto svg_doc = term::rgba_to_svg(bitmap, size);
                     static auto i = 0;
                     auto print_via_osc = utf::fprint("id=_sixel%id% %doc% W=%% H=%% fit=stretch", i++, svg_doc, size.x / cellsz.x, size.y / cellsz.y);
-                    log("svg:", utf::debase(print_via_osc));
+                    if constexpr (debugmode) log("svg:", utf::debase(print_via_osc));
                     //todo check decsdm
                     //todo sync original fragments
                     //todo add a bitmap raster bit (introduce payload category: svg, raw, ...) to the imagens::image
@@ -8402,6 +8378,9 @@ namespace netxs::ui
                 case 1007: // Enable alternate scroll mode.
                     altscr = defcfg.def_alt_on;
                     break;
+                case 1070:// Enable Sixel Private Color Registers.
+                    // We always have this mode on (colors are baked in place).
+                    break;
                 case 10060:// Enable mouse reporting outside the viewport (outside+negative coordinates).
                     mtrack.enable(input::mouse::mode::negative_args);
                     break;
@@ -8522,6 +8501,9 @@ namespace netxs::ui
                     break;
                 case 1007: // Disable alternate scroll mode.
                     altscr = 0;
+                    break;
+                case 1070:// Disable Sixel Private Color Registers.
+                    // We always have this mode on (colors are baked in place).
                     break;
                 case 10060:// Disable mouse reporting outside the viewport (allow reporting inside the viewport only).
                     mtrack.disable(input::mouse::mode::negative_args);
@@ -8720,10 +8702,6 @@ namespace netxs::ui
         auto ondata_direct(qiew data = {}, bufferbase* target_buffer = {})
         {
             auto& console_ptr = target_buffer ? target_buffer : target;
-            if (sixels)
-            {
-                sixels.parse(data, console_ptr);
-            }
             if (data.size())
             {
                 if (io_log) log(prompt::cout, "\n\t", utf::replace_all(ansi::hi(utf::debase(data)), "\n", ansi::pushsgr().nil().add("\n\t").popsgr()));

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -3623,8 +3623,8 @@ namespace netxs::ui
                     simpl = 0;
                     if constexpr (debugmode)
                     {
-                        for (auto& s : sizea) assert(s == std::decay_t<decltype(s)>{});
-                        for (auto& s : sizes) assert(s.empty());
+                        for ([[maybe_unused]] auto& s : sizea) assert(s == std::decay_t<decltype(s)>{});
+                        for ([[maybe_unused]] auto& s : sizes) assert(s.empty());
                     }
                     maxes.fill(0);
                     invite(newln); // Sync current line state (length, wrap mode).

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -1825,245 +1825,6 @@ namespace netxs::ui
                     }
                 }
             }
-            // bufferbase: Take data until ST. Don't touch q if sequence is broken.
-            auto read_until_st_or_giveup(qiew& q)
-            {
-                auto data = utf::take_binary_front<true>(q, std::tuple{ "\x1b\\"sv, "\a"sv });
-                if (data)
-                {
-                         if (q.starts_with("\a")    ) q.remove_prefix(1); // Pop '\a'.
-                    else if (q.starts_with("\x1b\\")) q.remove_prefix(2); // Pop '\e\\'.
-                }
-                return data;
-            }
-            auto read_params(qiew& q, auto& params)
-            {
-                auto param_count = 0u;
-                while (param_count < params.size()) // Read params.
-                {
-                    auto c = q.front();
-                    if (c == ';')
-                    {
-                        param_count++;
-                        q.remove_prefix(1);
-                    }
-                    else if (auto v = utf::to_int(q))
-                    {
-                        params[param_count++] = v.value();
-                        if (q.front() == ';') q.remove_prefix(1);
-                    }
-                    else break;
-                }
-                return param_count;
-            }
-            auto rgba_to_svg(std::vector<argb>& pixels, twod size)
-            {
-                for (auto& c : pixels) c.swap_rb();
-                auto file_data = std::vector<byte>{};
-                file_data.reserve(size.x * size.y);
-                auto append_fx = [](void* context, void* data, si32 len)
-                {
-                    auto vec = (std::vector<byte>*)context;
-                    vec->insert(vec->end(), (byte*)data, (byte*)data + len);
-                };
-                auto jpeg_quality = skin::globals().jpeg_quality;
-                ::stbi_write_jpg_to_func(append_fx, &file_data, size.x, size.y, 4, (byte*)pixels.data(), jpeg_quality);
-                //::stbi_write_png_to_func(append_fx, &png_data, size.x, size.y, 4, (byte*)pixels.data(), size.x * 4);
-                auto b64 = utf::base64(view{ (char*)file_data.data(), file_data.size() });
-                return utf::fprint("<svg width='%%' height='%%'><image width='%%' height='%%' href='data:image/jpg;base64,%%' /></svg>", size.x, size.y, size.x, size.y, b64);
-            }
-            auto parse_sixel(qiew& q, auto& params)
-            {
-                auto ok = true;
-                // aspect_ratio:
-                // omitted     2:1
-                // 0 or 1      5:1
-                // 2           3:1
-                // 3 or 4      2:1
-                // 5 or 6      2:1
-                // 7,8, or 9   1:1
-                //                                        -1  0  1  2  3  4  5  6  7  8  9
-                static constexpr auto ar = std::to_array({ 2, 5, 5, 3, 2, 2, 2, 2, 1, 1, 1 });
-                auto aspect_ratio = ar[std::clamp(params[0] + 1, 0, (si32)ar.size() - 1)];
-                // transparency:
-                // omitted     opaque  0's are filled with current background color
-                // 0 or 2      opaque
-                // 1           transparent   0's are kept intact
-                //                                        -1  0  1  2
-                static constexpr auto tr = std::to_array({ 0, 0, 1, 0 });
-                auto transparency = tr[std::clamp(params[1] + 1, 0, (si32)tr.size() - 1)];
-                // hz_grid_size: We ignore it.
-                // n
-                //auto hz_grid_size = params[2];
-                auto cellsz = twod{ 10, 20 };
-                auto size = panel * cellsz;
-                size.y *= aspect_ratio;
-                auto stride = size.x * aspect_ratio * 6;
-                auto& bitmap = owner.sixel_bitmap;
-                auto palette = owner.ctrack.color; // Copy terminal palette.
-                auto cur_map = 0;
-                auto cur_clr = get_effective_brush();
-                auto cur_fgc = cur_clr.fgc();
-                auto cur_bgc = cur_clr.bgc();
-                transparency ? owner.sixel_bitmap.assign(size.x * size.y, argb{})
-                             : owner.sixel_bitmap.assign(size.x * size.y, cur_bgc);
-                auto coor = 0;
-                auto maxx = size.x;
-                auto maxy = size.x * size.y;
-                auto line = 0;
-                //auto hash = ui64{};
-                auto head = q.begin();
-                auto tail = q.end();
-                auto print_sixel = [&](auto c)
-                {
-                    if (coor < maxx)
-                    {
-                        auto offset = coor++;
-                        while (c)
-                        {
-                            if (c & 1)
-                            {
-                                for (auto y = 0; y < aspect_ratio; y++)
-                                {
-                                    if (offset < maxy) bitmap[offset] = cur_fgc;
-                                    offset += size.x;
-                                }
-                            }
-                            else
-                            {
-                                offset += size.x * aspect_ratio;
-                            }
-                            c >>= 1;
-                        }
-                    }
-                };
-                while (head != tail)
-                {
-                    auto c = *head++;
-                    if (c >= '?' && c <= '~') // Print sixels.
-                    {
-                        c -= '?';
-                        print_sixel(c);
-                    }
-                    else if (c == '!') // Repeat sixels.
-                    {
-                        auto q2 = qiew{ head, tail };
-                        if (auto v = utf::to_int(q2))
-                        {
-                            if (q2)
-                            {
-                                auto c2 = q2.front();
-                                if (c2 >= '?' && c <= '~')
-                                {
-                                    q2.pop_front();
-                                    c2 -= '?';
-                                    auto count = std::max(0, v.value());
-                                    while (count--) print_sixel(c2);
-                                }
-                            }
-                        }
-                        head = q2.begin();
-                        tail = q2.end();
-                    }
-                    else if (c == '#') // Select register.
-                    {
-                        auto q2 = qiew{ head, tail };
-                        auto v = utf::to_int(q2);
-                        cur_map = v ? std::clamp(v.value(), 0, 255) : 0;
-                        if (q2 && q2.front() == ';') // Update palette.
-                        {
-                            q2.pop_front();
-                            auto params2 = std::to_array({ 0, 0, 0, 0 });
-                            read_params(q2, params2);
-                            auto color_mode = params2[0];
-                            if (color_mode == 1) // HLS
-                            {
-                                palette[cur_map] = netxs::letoh(argb::from_HLS(params2[1], params2[2], params2[3]).token);
-                            }
-                            else if (color_mode == 2) // RGB
-                            {
-                                palette[cur_map] = netxs::letoh(argb{ (byte)(params2[1] * 255 / 100),
-                                                                      (byte)(params2[2] * 255 / 100),
-                                                                      (byte)(params2[3] * 255 / 100) }.token);
-                            }
-                        }
-                        head = q2.begin();
-                        tail = q2.end();
-                        cur_fgc = palette[cur_map];
-                    }
-                    else if (c == '"') // Raster Attributes (reset canvas).  "dy;dx;width;height  aspect_ratio=round(dy/dx).
-                    {
-                        auto params2 = std::to_array({ -1, -1, -1, -1 });
-                        auto q2 = qiew{ head, tail };
-                        read_params(q2, params2);
-                        head = q2.begin();
-                        tail = q2.end();
-                        auto dy = std::max(1, std::abs(params2[0]));
-                        auto dx = std::max(1, std::abs(params2[1]));
-                        size.x = std::clamp(std::abs(params2[2]), 1, std::max(4096, panel.x * cellsz.x));
-                        size.y = std::clamp(std::abs(params2[3]), 1, std::max(4096, panel.y * cellsz.y));
-                        aspect_ratio = (si32)std::round((fp32)dy / dx);
-                        size.y *= aspect_ratio;
-                        coor = 0;
-                        line = 0;
-                        maxx = size.x;
-                        maxy = size.x * size.y;
-                        stride = size.x * aspect_ratio * 6;
-                        transparency ? bitmap.assign(size.x * size.y, argb{})
-                                     : bitmap.assign(size.x * size.y, parser::brush.bgc());
-                    }
-                    else if (c == '-') // New Line.
-                    {
-                        line++;
-                        coor = line * stride;
-                        maxx = coor + size.x;
-                    }
-                    else if (c == '$') // Carriage Return.
-                    {
-                        coor = line * stride;
-                    }
-                    else if ((c == '\x1b' && head != tail && *head == '\\' && (head++, true)) || c == '\a') // ST
-                    {
-                        break;
-                    }
-                    else if (c == ansi::c0_can || c == ansi::c0_sub) // Abort.
-                    {
-                        ok = faux;
-                        auto q2 = qiew{ head, tail };
-                        if (auto data = read_until_st_or_giveup(q2)) // Eat all sixels.
-                        {
-                            q = q2;
-                        }
-                        else // Broken sequence.
-                        {
-                            // Keep q intact.
-                        }
-                        break;
-                    }
-                    else
-                    {
-                        // Silently ignore all unknown characters.
-                    }
-                }
-                if (ok) // Show image.
-                {
-                    q = qiew{ head, tail };
-                    auto svg_doc = rgba_to_svg(bitmap, size);
-                    static auto i = 0;
-                    auto print_via_osc = utf::fprint("id=_sixel%id% %doc% W=%% H=%% fit=stretch", i++, svg_doc, size.x / cellsz.x, size.y / cellsz.y);
-                    log("svg:", utf::debase(print_via_osc));
-                    //todo check decsdm
-                    //todo sync original fragments
-                    //todo add a bitmap raster bit (introduce payload category: svg, raw, ...) to the imagens::image
-                    //todo store the payload in byts instead of text
-                    //todo implement own bitmap (raw category) rasterization (with interpolation)
-                    //todo hashing by sixel_string
-                    //todo implement scrollback lifetime management for sixel images (destroy it in line dtor if reference_count[id] == 0)
-                    owner.osc_images(print_via_osc);
-                    owner.data_in("\n\r");
-                }
-                return ok;
-            }
             void dcs(qiew& q)
             {
                 parser::flush();
@@ -2076,19 +1837,14 @@ namespace netxs::ui
 
                 auto tmp = q;
                 auto params = std::to_array({ -1, -1, -1, -1, -1, -1 });
-                auto param_count = read_params(q, params);
+                auto param_count = term::read_params(q, params);
                 if (q.starts_with(SIXEL_str))
                 {
                     if (owner.io_log) log("%%Sixel data:\n\tparams: %%\n\tpayload:%%", prompt::term, [&]{ auto t = ansi::escx{}; while (param_count--) { t.add(params[param_count], ';'); } return t; }(), ansi::hi(tmp));
                     q.remove_prefix(SIXEL_str.size());
-                    auto ok = parse_sixel(q, params);
-                    if (!ok)
-                    {
-                        if (owner.io_log) log("%%Broken sixel sequence", prompt::term);
-                        q = tmp;
-                    }
+                    owner.sixels.start(q, params, this);
                 }
-                else if (auto data = read_until_st_or_giveup(q))
+                else if (auto data = term::read_until_st_or_giveup(q))
                 {
                     auto reply = flux{};
                     if (data.starts_with(XTGETTCAP_str))
@@ -2207,7 +1963,7 @@ namespace netxs::ui
             }
             void sos(qiew& q)
             {
-                if (auto data = read_until_st_or_giveup(q))
+                if (auto data = term::read_until_st_or_giveup(q))
                 {
                     //todo
                     if (owner.io_log) log("%%SOS sequences are not supported: %%", prompt::term, ansi::hi(utf::debase<faux>(data)));
@@ -2215,7 +1971,7 @@ namespace netxs::ui
             }
             void _pm(qiew& q)
             {
-                if (auto data = read_until_st_or_giveup(q))
+                if (auto data = term::read_until_st_or_giveup(q))
                 {
                     //todo
                     if (owner.io_log) log("%%PM sequences are not supported: ", prompt::term, ansi::hi(utf::debase<faux>(data)));
@@ -7613,6 +7369,280 @@ namespace netxs::ui
                 #endif
             }
         };
+        // term: Take data until ST. Don't touch q if sequence is broken.
+        static qiew read_until_st_or_giveup(qiew& q)
+        {
+            auto data = utf::take_binary_front<true>(q, std::tuple{ "\x1b\\"sv, "\a"sv });
+            if (data)
+            {
+                        if (q.starts_with("\a")    ) q.remove_prefix(1); // Pop '\a'.
+                else if (q.starts_with("\x1b\\")) q.remove_prefix(2); // Pop '\e\\'.
+            }
+            return data;
+        }
+        // term: Read semicolon separated integers from qiew.
+        static si32 read_params(qiew& q, auto& params)
+        {
+            auto param_count = 0u;
+            while (param_count < params.size()) // Read params.
+            {
+                auto c = q.front();
+                if (c == ';')
+                {
+                    param_count++;
+                    q.remove_prefix(1);
+                }
+                else if (auto v = utf::to_int(q))
+                {
+                    params[param_count++] = v.value();
+                    if (q.front() == ';') q.remove_prefix(1);
+                }
+                else break;
+            }
+            return param_count;
+        }
+        static text rgba_to_svg(std::vector<argb>& pixels, twod size)
+        {
+            for (auto& c : pixels) c.swap_rb();
+            auto file_data = std::vector<byte>{};
+            file_data.reserve(size.x * size.y);
+            auto append_fx = [](void* context, void* data, si32 len)
+            {
+                auto vec = (std::vector<byte>*)context;
+                vec->insert(vec->end(), (byte*)data, (byte*)data + len);
+            };
+            auto jpeg_quality = skin::globals().jpeg_quality;
+            ::stbi_write_jpg_to_func(append_fx, &file_data, size.x, size.y, 4, (byte*)pixels.data(), jpeg_quality);
+            //::stbi_write_png_to_func(append_fx, &png_data, size.x, size.y, 4, (byte*)pixels.data(), size.x * 4);
+            auto b64 = utf::base64(view{ (char*)file_data.data(), file_data.size() });
+            return utf::fprint("<svg width='%%' height='%%'><image width='%%' height='%%' href='data:image/jpg;base64,%%' /></svg>", size.x, size.y, size.x, size.y, b64);
+        }
+        struct sixel_t
+        {
+            static constexpr auto cellsz = twod{ 10, 20 };
+
+            term& owner;
+            bool sixel_mode{}; // Sixel input is not complete.
+            si32 aspect_ratio{};
+            si32 transparency{};
+            si32 stride{};
+            si32 cur_map{};
+            si32 coor{};
+            si32 maxx{};
+            si32 maxy{};
+            si32 line{};
+            twod size;
+            pals palette{};
+            cell cur_clr;
+            argb cur_fgc{};
+            argb cur_bgc{};
+            std::vector<argb> bitmap; // Sixel bitmap buffer.
+
+            operator bool () { return sixel_mode; }
+
+            void start(qiew& q, auto& params, bufferbase* target_buffer)
+            {
+                // aspect_ratio:
+                // omitted     2:1
+                // 0 or 1      5:1
+                // 2           3:1
+                // 3 or 4      2:1
+                // 5 or 6      2:1
+                // 7,8, or 9   1:1
+                //                                        -1  0  1  2  3  4  5  6  7  8  9
+                static constexpr auto ar = std::to_array({ 2, 5, 5, 3, 2, 2, 2, 2, 1, 1, 1 });
+                aspect_ratio = ar[std::clamp(params[0] + 1, 0, (si32)ar.size() - 1)];
+                // transparency:
+                // omitted     opaque  0's are filled with current background color
+                // 0 or 2      opaque
+                // 1           transparent   0's are kept intact
+                //                                        -1  0  1  2
+                static constexpr auto tr = std::to_array({ 0, 0, 1, 0 });
+                transparency = tr[std::clamp(params[1] + 1, 0, (si32)tr.size() - 1)];
+                // hz_grid_size: We ignore it.
+                // n
+                //auto hz_grid_size = params[2];
+                size = target_buffer->panel * cellsz;
+                size.y *= aspect_ratio;
+                stride = size.x * aspect_ratio * 6;
+                palette = owner.ctrack.color; // Copy terminal palette.
+                cur_map = 0;
+                cur_clr = target_buffer->get_effective_brush();
+                cur_fgc = cur_clr.fgc();
+                cur_bgc = cur_clr.bgc();
+                if (cur_clr.inv()) std::swap(cur_fgc, cur_bgc);
+                transparency ? bitmap.assign(size.x * size.y, argb{})
+                             : bitmap.assign(size.x * size.y, cur_bgc);
+                coor = 0;
+                maxx = size.x;
+                maxy = size.x * size.y;
+                line = 0;
+                parse(q, target_buffer);
+            }
+            void print_sixel(si32 c)
+            {
+                if (coor < maxx)
+                {
+                    auto offset = coor++;
+                    while (c)
+                    {
+                        if (c & 1)
+                        {
+                            for (auto y = 0; y < aspect_ratio; y++)
+                            {
+                                if (offset < maxy) bitmap[offset] = cur_fgc;
+                                offset += size.x;
+                            }
+                        }
+                        else
+                        {
+                            offset += size.x * aspect_ratio;
+                        }
+                        c >>= 1;
+                    }
+                }
+            }
+            void parse(qiew& q, bufferbase* target_buffer)
+            {
+                sixel_mode = true;
+                //auto hash = ui64{};
+                auto head = q.begin();
+                auto tail = q.end();
+                while (head != tail)
+                {
+                    auto c = *head++;
+                    if (c >= '?' && c <= '~') // Print sixels.
+                    {
+                        c -= '?';
+                        print_sixel(c);
+                    }
+                    else if (c == '!') // Repeat sixels.
+                    {
+                        auto q2 = qiew{ head, tail };
+                        if (auto v = utf::to_int(q2))
+                        {
+                            if (q2)
+                            {
+                                auto c2 = q2.front();
+                                if (c2 >= '?' && c <= '~')
+                                {
+                                    q2.pop_front();
+                                    c2 -= '?';
+                                    auto count = std::max(0, v.value());
+                                    while (count--) print_sixel(c2);
+                                }
+                            }
+                        }
+                        head = q2.begin();
+                        tail = q2.end();
+                    }
+                    else if (c == '#') // Select register.
+                    {
+                        auto q2 = qiew{ head, tail };
+                        auto v = utf::to_int(q2);
+                        cur_map = v ? std::clamp(v.value(), 0, 255) : 0;
+                        if (q2 && q2.front() == ';') // Update palette.
+                        {
+                            q2.pop_front();
+                            auto params = std::to_array({ 0, 0, 0, 0 });
+                            term::read_params(q2, params);
+                            auto color_mode = params[0];
+                            if (color_mode == 1) // HLS
+                            {
+                                palette[cur_map] = netxs::letoh(argb::from_HLS(params[1], params[2], params[3]).token);
+                            }
+                            else if (color_mode == 2) // RGB
+                            {
+                                palette[cur_map] = netxs::letoh(argb{ (byte)(params[1] * 255 / 100),
+                                                                      (byte)(params[2] * 255 / 100),
+                                                                      (byte)(params[3] * 255 / 100) }.token);
+                            }
+                        }
+                        head = q2.begin();
+                        tail = q2.end();
+                        cur_fgc = palette[cur_map];
+                    }
+                    else if (c == '"') // Raster Attributes (reset canvas).  "dy;dx;width;height  aspect_ratio=round(dy/dx).
+                    {
+                        auto params = std::to_array({ -1, -1, -1, -1 });
+                        auto q2 = qiew{ head, tail };
+                        term::read_params(q2, params);
+                        head = q2.begin();
+                        tail = q2.end();
+                        auto dy = std::max(1, std::abs(params[0]));
+                        auto dx = std::max(1, std::abs(params[1]));
+                        size.x = std::clamp(std::abs(params[2]), 1, std::max(4096, target_buffer->panel.x * cellsz.x));
+                        size.y = std::clamp(std::abs(params[3]), 1, std::max(4096, target_buffer->panel.y * cellsz.y));
+                        aspect_ratio = (si32)std::round((fp32)dy / dx);
+                        size.y *= aspect_ratio;
+                        coor = 0;
+                        line = 0;
+                        maxx = size.x;
+                        maxy = size.x * size.y;
+                        stride = size.x * aspect_ratio * 6;
+                        transparency ? bitmap.assign(size.x * size.y, argb{})
+                                     : bitmap.assign(size.x * size.y, cur_bgc);
+                    }
+                    else if (c == '-') // New Line.
+                    {
+                        line++;
+                        coor = line * stride;
+                        maxx = coor + size.x;
+                    }
+                    else if (c == '$') // Carriage Return.
+                    {
+                        coor = line * stride;
+                    }
+                    else if ((c == '\x1b' && head != tail && *head == '\\' && (head++, true)) || c == '\a') // ST
+                    {
+                        if constexpr (debugmode) log("sixel end");
+                        sixel_mode = faux;
+                        break;
+                    }
+                    else if (c == ansi::c0_can || c == ansi::c0_sub) // Abort.
+                    {
+                        if constexpr (debugmode) log("sixel aborted");
+                        sixel_mode = faux;
+                        auto q2 = qiew{ head, tail };
+                        if (auto data = term::read_until_st_or_giveup(q2)) // Eat all sixels.
+                        {
+                            q = q2;
+                        }
+                        else // Broken sequence.
+                        {
+                            // Keep q intact.
+                        }
+                        break;
+                    }
+                    else
+                    {
+                        // Silently ignore all unknown characters.
+                    }
+                }
+                if (sixel_mode == faux) // Show image.
+                {
+                    q = qiew{ head, tail };
+                    auto svg_doc = term::rgba_to_svg(bitmap, size);
+                    static auto i = 0;
+                    auto print_via_osc = utf::fprint("id=_sixel%id% %doc% W=%% H=%% fit=stretch", i++, svg_doc, size.x / cellsz.x, size.y / cellsz.y);
+                    log("svg:", utf::debase(print_via_osc));
+                    //todo check decsdm
+                    //todo sync original fragments
+                    //todo add a bitmap raster bit (introduce payload category: svg, raw, ...) to the imagens::image
+                    //todo store the payload in byts instead of text
+                    //todo implement own bitmap (raw category) rasterization (with interpolation)
+                    //todo hashing by sixel_string
+                    //todo implement scrollback lifetime management for sixel images (destroy it in line dtor if reference_count[id] == 0)
+                    //todo print to target_buffer
+                    owner.osc_images(print_via_osc);
+                    owner.data_in("\n\r");
+                }
+                else
+                {
+                    if constexpr (debugmode) log("sixel incomplete");
+                }
+            }
+        };
 
         using prot = input::keybd::prot;
         using buffer_ptr = bufferbase*;
@@ -7665,7 +7695,7 @@ namespace netxs::ui
         utf::unordered_map<text, netxs::sptr<imagens::image>> image_cache; // term: Image cache.
         face                                                  image_buffer; // term: Image temporary buffer.
         bool                                                  image_alive{ true }; // term: Indicator for whether to clear images in the scrollback.
-        std::vector<argb> sixel_bitmap; // term: Sixel bitmap buffer.
+        sixel_t    sixels; // term: Sixel mode state.
         vtty       ipccon; // term: IPC connector. Should be destroyed first.
 
         // term: Print the block to the scrollback buffer with scroll.
@@ -8687,9 +8717,13 @@ namespace netxs::ui
         }
         // term: Proceed terminal input.
         template<bool Forced = faux>
-        auto ondata_direct(view data = {}, bufferbase* target_buffer = {})
+        auto ondata_direct(qiew data = {}, bufferbase* target_buffer = {})
         {
             auto& console_ptr = target_buffer ? target_buffer : target;
+            if (sixels)
+            {
+                sixels.parse(data, console_ptr);
+            }
             if (data.size())
             {
                 if (io_log) log(prompt::cout, "\n\t", utf::replace_all(ansi::hi(utf::debase(data)), "\n", ansi::pushsgr().nil().add("\n\t").popsgr()));
@@ -9528,7 +9562,8 @@ namespace netxs::ui
               rawkbd{ faux },
               bottom_anchored{ true },
               event_sources{},
-              session_token{ netxs::get_random() }
+              session_token{ netxs::get_random() },
+              sixels{ *this }
         {
             set_fg_color(defcfg.def_fcolor);
             set_bg_color(defcfg.def_bcolor);

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -2117,7 +2117,7 @@ namespace netxs::ui
             void rep(si32 n)
             {
                 if constexpr (Flush) parser::flush();
-                n = std::clamp<si32>(n, 0, si16max);
+                n = std::clamp<si32>(n, 0, netxs::si16max);
                 if (n)
                 {
                     auto c = cell{ parser::brush };
@@ -3333,7 +3333,7 @@ namespace netxs::ui
             {
                 using ring::ring;
                 using type = deco::type;
-                using maps = std::map<si32, si32>[type::count];
+                using maps = std::map<si32, si32>[type::count]; //todo ?use std::array<si32, 65536>[type::count]
 
                 si32 caret{}; // buff: Current line cursor horizontal position.
                 si32 vsize{}; // buff: Scrollback vertical size (height).
@@ -3388,24 +3388,23 @@ namespace netxs::ui
                     }
                 }
                 // buff: Register a new line.
-                void invite(si32& line_kind, si32& line_size, si32 new_kind, si32 new_size)
+                void invite(line& l, si32 new_kind, si32 new_size)
                 {
                     ++sizes[new_kind][new_size];
                     add_height(vsize, new_kind, new_size);
-                    line_size = new_size;
-                    line_kind = new_kind;
+                    l._size = new_size;
+                    l._kind = new_kind;
                 }
                 // buff: Refresh scrollback height.
-                void recalc(si32& line_kind, si32& line_size, si32 new_kind, si32 new_size)
+                void recalc(line& l, si32 new_kind, si32 new_size)
                 {
-                    if (line_size != new_size
-                     || line_kind != new_kind)
+                    if (l._size != new_size || l._kind != new_kind)
                     {
-                        undock(line_kind, line_size);
+                        undock(l._kind, l._size);
                         ++sizes[new_kind][new_size];
                         add_height(vsize, new_kind, new_size);
-                        line_size = new_size;
-                        line_kind = new_kind;
+                        l._size = new_size;
+                        l._kind = new_kind;
                     }
                 }
                 // buff: Discard the specified metrics.
@@ -3432,14 +3431,14 @@ namespace netxs::ui
                 // buff: Push the specified line back.
                 void invite(line& l)
                 {
-                    invite(l._kind, l._size, l.get_kind(), l.length());
+                    invite(l, l.get_kind(), l.length());
                 }
                 // buff: Push a new line back.
                 template<class ...Args>
                 auto& invite(Args&&... args)
                 {
                     auto& l = ring::push_back(std::forward<Args>(args)...);
-                    invite(l._kind, l._size, l.get_kind(), l.length());
+                    invite(l, l.get_kind(), l.length());
                     return l;
                 }
                 // buff: Insert a new line at the specified position.
@@ -3447,7 +3446,7 @@ namespace netxs::ui
                 auto& insert(si32 at, Args&&... args)
                 {
                     auto& l = *ring::insert(at, std::forward<Args>(args)...);
-                    invite(l._kind, l._size, l.get_kind(), l.length());
+                    invite(l, l.get_kind(), l.length());
                     return l;
                 }
                 // buff: Remove specified line info from accounting and update metrics based on scroll height.
@@ -3495,7 +3494,7 @@ namespace netxs::ui
                 // buff: Refresh metrics due to modified line.
                 void recalc(line& l)
                 {
-                    recalc(l._kind, l._size, l.get_kind(), l.length());
+                    recalc(l, l.get_kind(), l.length());
                 }
                 // buff: Rewrite the indices from the specified position to the end or to the top (negative from).
                 void reindex(si32 from)

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -2605,7 +2605,7 @@ namespace netxs::ui
                 {
                     auto length = std::max(1, canvas.size().x);
                     auto offset = from + a;
-                    if (canvas.find(match, offset, direction))
+                    if (canvas.find(match.cells, offset, direction))
                     {
                         seltop = { offset % length,
                                    offset / length };
@@ -2613,7 +2613,7 @@ namespace netxs::ui
                         selend = { offset % length,
                                    offset / length };
                         offset += a;
-                        uinext = canvas.find(match, offset, direction); // Try to find next next.
+                        uinext = canvas.find(match.cells, offset, direction); // Try to find next next.
                         uiprev = true;
                         return true;
                     }
@@ -6686,7 +6686,7 @@ namespace netxs::ui
                         build([&](auto& curln)
                         {
                             auto block = escx{};
-                            block.s11n<faux, faux, faux>(curln.canvas, field, accum);
+                            block.s11n<faux, faux, faux>(curln.cells, field, accum);
                             if (block.size() > 0) yield.add(block);
                             else                  yield.eol();
                         });
@@ -6704,7 +6704,7 @@ namespace netxs::ui
                             }
                             auto block = escx{};
                             if (use_true_color) cell::unpack_indexed_colors_to(curln, baked, owner.ctrack.color, owner.defclr);
-                            block.s11n<true, faux, faux>((use_true_color ? baked : curln).canvas, field, accum);
+                            block.s11n<true, faux, faux>((use_true_color ? baked : curln).cells, field, accum);
                             if (block.size() > 0) yield.add(block);
                             else                  yield.eol();
                         });

--- a/src/vtm.hpp
+++ b/src/vtm.hpp
@@ -2165,7 +2165,7 @@ namespace netxs::app::vtm
             };
             usergate.LISTEN(tier::request, e2::form::prop::name, user_name_utf8)
             {
-                user_name_utf8 = uname.lyric->utf8();
+                user_name_utf8 = cell::to_utf8(uname.content());
             };
             usergate.LISTEN(tier::release, e2::form::layout::shift, newpos)
             {

--- a/src/vtm.xml
+++ b/src/vtm.xml
@@ -265,7 +265,7 @@ R"==(
         </gate>
         <desktop script*>  <!-- Desktop-level bindings. -->
 )=="
-#if defined (WIN32)
+#if defined(_WIN32)
 R"==(
             <script=FocusTaskbar    on="Esc+F1"       />
 )=="
@@ -347,7 +347,7 @@ R"==(
         </tile>
         <terminal script*>  <!-- Terminal-specific bindings. -->
 )=="
-#if defined (WIN32)
+#if defined(_WIN32)
 R"==(
             <script=ExclusiveKeyboardMode on="preview: Ctrl-Alt | Alt-Ctrl"/>
 )=="


### PR DESCRIPTION
### Changes

- Fix issues with building on non-win32 platforms (std::execution). #919
- Terminal:
  - Revise scrollback buffer mechanics.
  - Free up memory when clearing the scrollback.
  - Update existing sixel-images when printing over (for sixel streaming). #917

Note: There is still no automatic cleaning of sixel images. Please avoid heavy use of it.
