### PR TITLE
Implement Sixel cell accounting

### DIFF
--- a/src/netxs/desktopio/ansivt.hpp
+++ b/src/netxs/desktopio/ansivt.hpp
@@ -1312,7 +1312,7 @@ namespace netxs::ansi
             * Unicode:
             * - void task(ansi::rule const& cmd);          // Proceed curses command.
             * - void meta(deco& old, deco& new);           // Proceed new style.
-            * - void data(si32 width, si32 height, core::body const& proto);  // Proceed new cells.
+            * - void data(si32 width, si32 height, std::span<cell const> proto);  // Proceed new cells.
             * SGR:
             * - void nil();                          // Reset all SGR to default.
             * - void sav();                          // Set current SGR as default.
@@ -2019,7 +2019,7 @@ namespace netxs::ansi
             flush_data();
         }
         virtual void meta(deco const& /*old_style*/) { };
-        virtual void data(si32 /*width*/, si32 /*height*/, core::body const& /*proto*/) { };
+        virtual void data(si32 /*width*/, si32 /*height*/, std::span<cell const> /*proto*/) { };
         virtual void pop_cluster(si32 /*cmatrix*/) { };
     };
 

--- a/src/netxs/desktopio/ansivt.hpp
+++ b/src/netxs/desktopio/ansivt.hpp
@@ -648,8 +648,8 @@ namespace netxs::ansi
             if (legacy_color)
             {
                 save_palette();
-                argb::set_vtm16_palette([&](auto ...Args){ escx::old_palette(Args...); });
-                argb::set_vtm16_palette([&](auto ...Args){ escx::osc_palette(Args...); });
+                argb::set_vtm16_palette([&](auto... args){ escx::old_palette(args...); });
+                argb::set_vtm16_palette([&](auto... args){ escx::osc_palette(args...); });
             }
             return *this;
         }

--- a/src/netxs/desktopio/application.hpp
+++ b/src/netxs/desktopio/application.hpp
@@ -22,7 +22,7 @@ namespace netxs::app
 
 namespace netxs::app::shared
 {
-    static const auto version = "v2026.05.08";
+    static const auto version = "v2026.05.12";
     static const auto repository = "https://github.com/directvt/vtm";
     static const auto usr_config = "~/.config/vtm/settings.xml"s;
     static const auto sys_config = "/etc/vtm/settings.xml"s;

--- a/src/netxs/desktopio/canvas.hpp
+++ b/src/netxs/desktopio/canvas.hpp
@@ -4062,6 +4062,24 @@ namespace netxs
             digest++;
         }
         template<bool BottomAnchored = faux>
+        void crop(twod new_size, cell const& c, auto dec_accounting) // core: Resize preserving bitmap.
+        {
+            auto old_size = size();
+            if (new_size.y < old_size.y) // Check bottom field.
+            {
+                auto r = rect{{ 0, BottomAnchored ? 0 : new_size.y }, { old_size.x, old_size.y - new_size.y }};
+                r.coor += coor();
+                netxs::onrect(*this, r, dec_accounting);
+            }
+            if (new_size.x < old_size.x) // Check right field.
+            {
+                auto r = rect{{ new_size.x, BottomAnchored ? std::max(0, old_size.y - new_size.y) : 0 }, { old_size.x - new_size.x, std::min(old_size.y, new_size.y) }};
+                r.coor += coor();
+                netxs::onrect(*this, r, dec_accounting);
+            }
+            crop<BottomAnchored>(new_size, c);
+        }
+        template<bool BottomAnchored = faux>
         void crop(twod new_size) // core: Resize preserving bitmap.
         {
             crop<BottomAnchored>(new_size, marker);

--- a/src/netxs/desktopio/canvas.hpp
+++ b/src/netxs/desktopio/canvas.hpp
@@ -2362,6 +2362,7 @@ namespace netxs
         }
         auto& set_image_index(si32 n) { netxs::set_field<p2_index16_mask>(n, p2); return *this; }
         auto& set_image_sixel(si32 n) { netxs::set_field<p2_sixel_1_mask>(n, p2); return *this; }
+        auto&  or_image_sixel(si32 n) { netxs::set_field<p2_sixel_1_mask>(n | netxs::get_field<p2_sixel_1_mask>(p2), p2); return *this; }
         auto& set_image_ontop(si32 n) { netxs::set_field<p2_ontop_1_mask>(n, p2); return *this; }
         auto& set_image_stamp(si32 n) { netxs::set_field<p2_stamp_8_mask>(n, p2); return *this; }
         auto& inc_image_stamp(si32 n) { netxs::set_field<p2_stamp_8_mask>(get_image_stamp() + n, p2); return *this; }
@@ -3934,6 +3935,7 @@ namespace netxs
         body canvas; // core: Cell data.
         cell marker; // core: Current brush.
         si32 digest = 0; // core: Resize stamp.
+        si32 hasimg{}; // core: Canvas contains Sixel cells.
 
     public:
         core()                         = default;
@@ -3959,6 +3961,9 @@ namespace netxs
               marker{ fill }
         { }
 
+        auto get_image_sixel()       { return hasimg; }
+        auto set_image_sixel(si32 n) { hasimg = n; }
+        auto  or_image_sixel(si32 n) { hasimg |= n; }
         template<class P>
         auto same(core const& c, P compare) const // core: Compare content.
         {

--- a/src/netxs/desktopio/canvas.hpp
+++ b/src/netxs/desktopio/canvas.hpp
@@ -1717,7 +1717,7 @@ namespace netxs
             using sync = std::lock_guard<lock>;
             using depo = std::array<netxs::sptr<T>, 65536>; // ~1MB
             using uset = std::vector<ui16>;//std::unordered_set<ui16>;
-            using pool = generics::indexer<ui16>;
+            using pool = generics::indexer_fifo<ui16>;
 
             lock mutex; // Object map mutex.
             depo store; // Object map.

--- a/src/netxs/desktopio/canvas.hpp
+++ b/src/netxs/desktopio/canvas.hpp
@@ -2309,6 +2309,7 @@ namespace netxs
         // ------|------
         //  16   | Image index. ui16
         //  1    | o ontop. 0/1
+        //  1    | is sixel (destructible). 0/1
         //  16   | c fragment (column). ui16
         //  16   | r fragment (row). ui16
         //  16   | W cell canvas width. ui16
@@ -2318,7 +2319,8 @@ namespace netxs
         static constexpr auto p2_index16_mask = (ui32)0b00000000'00000000'11111111'11111111;
         static constexpr auto p2_stamp_8_mask = (ui32)0b00000000'11111111'00000000'00000000;
         static constexpr auto p2_ontop_1_mask = (ui32)0b00000001'00000000'00000000'00000000;
-      //static constexpr auto p2_reserv7_mask = (ui32)0b11111110'00000000'00000000'00000000;
+        static constexpr auto p2_sixel_1_mask = (ui32)0b00000010'00000000'00000000'00000000;
+      //static constexpr auto p2_reserv7_mask = (ui32)0b11111100'00000000'00000000'00000000;
 
         static constexpr auto px_imgX_16_mask = (ui64)0b00000000'00000000'00000000'00000000'00000000'00000000'11111111'11111111;
         static constexpr auto px_imgY_16_mask = (ui64)0b00000000'00000000'00000000'00000000'11111111'11111111'00000000'00000000;
@@ -2350,6 +2352,7 @@ namespace netxs
             return *this;
         }
         auto get_image_index() const { return (ui16)netxs::get_field<p2_index16_mask>(p2); }
+        auto get_image_sixel() const { return       netxs::get_field<p2_sixel_1_mask>(p2); }
         auto get_image_stamp() const { return       netxs::get_field<p2_stamp_8_mask>(p2); }
         auto get_image_ontop() const
         {
@@ -2358,6 +2361,7 @@ namespace netxs
             return std::pair{ index, ontop };
         }
         auto& set_image_index(si32 n) { netxs::set_field<p2_index16_mask>(n, p2); return *this; }
+        auto& set_image_sixel(si32 n) { netxs::set_field<p2_sixel_1_mask>(n, p2); return *this; }
         auto& set_image_ontop(si32 n) { netxs::set_field<p2_ontop_1_mask>(n, p2); return *this; }
         auto& set_image_stamp(si32 n) { netxs::set_field<p2_stamp_8_mask>(n, p2); return *this; }
         auto& inc_image_stamp(si32 n) { netxs::set_field<p2_stamp_8_mask>(get_image_stamp() + n, p2); return *this; }
@@ -2578,7 +2582,7 @@ namespace netxs
                 {
                     st.xy(c.st.xy());
                 }
-                if (c.raw()) // Terminal output is non-destructive for images.
+                if (get_image_sixel() || c.raw()) // Terminal output is non-destructive for images but sixels.
                 {
                     px = c.px;
                     p2 = c.p2;

--- a/src/netxs/desktopio/canvas.hpp
+++ b/src/netxs/desktopio/canvas.hpp
@@ -2362,7 +2362,7 @@ namespace netxs
         }
         auto& set_image_index(si32 n) { netxs::set_field<p2_index16_mask>(n, p2); return *this; }
         auto& set_image_sixel(si32 n) { netxs::set_field<p2_sixel_1_mask>(n, p2); return *this; }
-        auto&  or_image_sixel(si32 n) { netxs::set_field<p2_sixel_1_mask>(n | netxs::get_field<p2_sixel_1_mask>(p2), p2); return *this; }
+        auto&  or_image_sixel(si32 n) { netxs::set_field<p2_sixel_1_mask>(n || netxs::get_field<p2_sixel_1_mask>(p2), p2); return *this; }
         auto& set_image_ontop(si32 n) { netxs::set_field<p2_ontop_1_mask>(n, p2); return *this; }
         auto& set_image_stamp(si32 n) { netxs::set_field<p2_stamp_8_mask>(n, p2); return *this; }
         auto& inc_image_stamp(si32 n) { netxs::set_field<p2_stamp_8_mask>(get_image_stamp() + n, p2); return *this; }
@@ -3963,7 +3963,7 @@ namespace netxs
 
         auto get_image_sixel()       { return hasimg; }
         auto set_image_sixel(si32 n) { hasimg = n; }
-        auto  or_image_sixel(si32 n) { hasimg |= n; }
+        auto  or_image_sixel(si32 n) { hasimg = hasimg || n; }
         template<class P>
         auto same(core const& c, P compare) const // core: Compare content.
         {

--- a/src/netxs/desktopio/canvas.hpp
+++ b/src/netxs/desktopio/canvas.hpp
@@ -4277,6 +4277,14 @@ namespace netxs
             auto size = upto - from;
             return std::span{ canvas.begin() + from, (size_t)size };
         }
+        auto subline2(si32 start, si32 count) const // core: Get stripe.
+        {
+            assert(canvas.size() <= netxs::si32max);
+            auto limit = (si32)canvas.size();
+            start = std::clamp(start, 0, limit);
+            count = std::clamp(count, 0, limit - start);
+            return std::span{ canvas.begin() + start, (size_t)count };
+        }
         auto subline(twod p1, twod p2) const // core: Get stripe.
         {
             if (p1.y > p2.y || (p1.y == p2.y && p1.x > p2.x)) std::swap(p1, p2);

--- a/src/netxs/desktopio/canvas.hpp
+++ b/src/netxs/desktopio/canvas.hpp
@@ -4073,13 +4073,13 @@ namespace netxs
             canvas.resize(0);
             digest++;
         }
-        void wipe(cell const& c) { std::fill(canvas.begin(), canvas.end(), c); } // core: Fill canvas with specified marker.
-        void wipe()              { wipe(marker); } // core: Fill canvas with default color.
-        void wipe(id_t id)                         // core: Fill canvas with specified id.
+        void wipe2(cell const& c) { std::fill(canvas.begin(), canvas.end(), c); } // core: Fill canvas with specified marker.
+        void wipe2()              { wipe2(marker); } // core: Fill canvas with default color.
+        void wipe2(id_t id)                         // core: Fill canvas with specified id.
         {
             auto my_id = marker.link();
             marker.link(id);
-            wipe(marker);
+            wipe2(marker);
             marker.link(my_id);
         }
         auto each(auto proc) // core: Exec a proc for each cell.

--- a/src/netxs/desktopio/consrv.hpp
+++ b/src/netxs/desktopio/consrv.hpp
@@ -4251,11 +4251,10 @@ struct impl : consrv
         direct(packet.target, [&](auto& scrollback)
         {
             scrollback.flush_data();
-            auto has_sixels = faux;
-            mirror.each(uiterm.sixel_inc_accounting([&](auto& c){ has_sixels = has_sixels || c.get_image_sixel(); }));
+            auto has_sixels = uiterm.sixels_inc(mirror.pick());
             uiterm.write_block(scrollback, filler, scrl.coor, clip, cell::shaders::full, faux);
             uiterm.write_block(scrollback, mirror, dest,      clip, cell::shaders::full, has_sixels);
-            if (has_sixels) mirror.each(uiterm.sixel_dec_accounting());
+            if (has_sixels) uiterm.sixels_dec(mirror.pick());
             return true;
         });
     }

--- a/src/netxs/desktopio/consrv.hpp
+++ b/src/netxs/desktopio/consrv.hpp
@@ -3436,7 +3436,7 @@ struct impl : consrv
             auto success = direct(packet.target, [&](auto& scrollback)
             {
                 scrollback.flush_data();
-                uiterm.write_block(scrollback, dest, crop.coor, rect{ dot_00, window_inst.panel }, cell::shaders::full); // cell::shaders::skipnulls for transparency?
+                uiterm.write_block(scrollback, dest, crop.coor, rect{ dot_00, window_inst.panel }, cell::shaders::full, faux); // cell::shaders::skipnulls for transparency?
                 return true;
             });
             if (!success) crop = {};
@@ -4251,8 +4251,11 @@ struct impl : consrv
         direct(packet.target, [&](auto& scrollback)
         {
             scrollback.flush_data();
-            uiterm.write_block(scrollback, filler, scrl.coor, clip, cell::shaders::full);
-            uiterm.write_block(scrollback, mirror, dest,      clip, cell::shaders::full);
+            auto has_sixels = faux;
+            mirror.each(uiterm.sixel_inc_accounting([&](auto& c){ has_sixels = has_sixels || c.get_image_sixel(); }));
+            uiterm.write_block(scrollback, filler, scrl.coor, clip, cell::shaders::full, faux);
+            uiterm.write_block(scrollback, mirror, dest,      clip, cell::shaders::full, has_sixels);
+            if (has_sixels) mirror.each(uiterm.sixel_dec_accounting());
             return true;
         });
     }

--- a/src/netxs/desktopio/events.hpp
+++ b/src/netxs/desktopio/events.hpp
@@ -291,7 +291,7 @@ namespace netxs::events
             static constexpr auto not_handled = __COUNTER__ - _counter;
         };
 
-        generics::indexer<id_t>                   id_pool;
+        generics::indexer_fifo<id_t>              id_pool;
         std::recursive_mutex                      mutex;
         std::unordered_map<id_t, std::reference_wrapper<ui::base>>  objects; // auth: Map of objects by object id.
         clasess_umap                              classes; // auth: Map of classes by classname.

--- a/src/netxs/desktopio/generics.hpp
+++ b/src/netxs/desktopio/generics.hpp
@@ -1320,14 +1320,46 @@ namespace netxs::generics
         }
     };
 
-    // generics: Index manager.
+    // generics: Index manager (FIFO).
     template<class T>
-    struct indexer
+    struct indexer_fifo
+    {
+        T             next_index{};
+        std::deque<T> free_indices;
+
+        // indexer: Return the new index. Returns 0 if there are no indices available.
+        auto get_new()
+        {
+            if (!free_indices.empty())
+            {
+                auto id = free_indices.front();
+                free_indices.pop_front();
+                return id;
+            }
+            if (next_index == std::numeric_limits<T>::max() - 1) [[unlikely]]
+            {
+                return T{}; 
+            }
+            return ++next_index;
+        }
+        // indexer: Make index available.
+        void release(T id)
+        {
+            if (id)
+            {
+                free_indices.push_back(id);
+            }
+        }
+    };
+
+    // generics: Index manager (LIFO).
+    template<class T>
+    struct indexer_lifo
     {
         T              next_index{};
         std::vector<T> free_indices;
 
-        indexer(size_t expected_max_free = 2048)
+        indexer_lifo(size_t expected_max_free = 2048)
         {
             free_indices.reserve(expected_max_free);
         }
@@ -1349,7 +1381,10 @@ namespace netxs::generics
         // indexer: Make index available.
         void release(T id)
         {
-            free_indices.push_back(id);
+            if (id)
+            {
+                free_indices.push_back(id);
+            }
         }
     };
 }

--- a/src/netxs/desktopio/geometry.hpp
+++ b/src/netxs/desktopio/geometry.hpp
@@ -835,43 +835,13 @@ namespace netxs
         template<class irgb>
         auto get_minimal_non_transparent_area_for_pma()
         {
-            auto crop = rect{};
-            auto w = area.size.x;
-            auto h = area.size.y;
             auto image_raster = raster<irgb>();
             auto data = image_raster._data;
             assert((size_t)area.length() <= data.size()); // Invalid sprite element type.
+            auto w = area.size.x;
             auto get_row = [&](si32 y){ return data.subspan(y * w, w); };
-            auto y0 = 0;
             auto is_visible = [](irgb p){ return p.a != 0; };
-            while (y0 < h && std::none_of(get_row(y0).begin(), get_row(y0).end(), is_visible)) // Top bound.
-            {
-                y0++;
-            }
-            if (y0 != h)
-            {
-                auto y1 = h - 1;
-                while (y1 > y0 && std::none_of(get_row(y1).begin(), get_row(y1).end(), is_visible)) // Bottom bound.
-                {
-                    y1--;
-                }
-                auto x0 = w;
-                auto x1 = -1;
-                for (auto y = y0; y <= y1; ++y) // Look inside [y0, y1].
-                {
-                    auto row = get_row(y);
-                    auto first = std::find_if(row.begin(), row.end(), is_visible);
-                    if (first != row.end())
-                    {
-                        x0 = std::min(x0, (si32)std::distance(row.begin(), first)); // Left.
-                        auto last = std::find_if(row.rbegin(), row.rend(), is_visible);
-                        x1 = std::max(x1, (si32)(w - 1 - std::distance(row.rbegin(), last))); // Right.
-                    }
-                    if (x0 == 0 && x1 == w - 1) break; // Maximum possible found.
-                }
-                crop = {{ x0, y0 }, { x1 - x0 + 1, y1 - y0 + 1 }};
-            }
-            return crop;
+            return netxs::get_minimal_area_if<rect>(area.size, get_row, is_visible);
         }
         // sprite: Perform Dihedral group (D4) transformations on the image raster ("push-based" iterate over source) (8 combinations of rotations and reflections).
         template<class irgb>

--- a/src/netxs/desktopio/intmath.hpp
+++ b/src/netxs/desktopio/intmath.hpp
@@ -763,7 +763,7 @@ namespace netxs
         }
     };
 
-    // intmath: Forward/Reverse (bool template arg) copy the specified
+    // intmath: Forward/Reverse (RtoL) copy the specified
     //          sequence of cells onto the canvas at the specified offset
     //          and return count of copied cells.
     template<bool RtoL>

--- a/src/netxs/desktopio/intmath.hpp
+++ b/src/netxs/desktopio/intmath.hpp
@@ -131,10 +131,13 @@ namespace netxs
     template<bool PredicateReturn>
     struct base_noop
     {
+        constexpr auto operator () (auto&&...) const
+        {
+            return PredicateReturn;
+        }
         constexpr auto operator () (auto&&...)
         {
             return PredicateReturn;
-            //return *this;
         }
         constexpr operator bool () const { return faux; }
         constexpr base_noop(auto&&...) { }

--- a/src/netxs/desktopio/intmath.hpp
+++ b/src/netxs/desktopio/intmath.hpp
@@ -1178,6 +1178,43 @@ namespace netxs
             iter += stride;
         }
     }
+    // intmath: Get minimal rectangular area if 'is_visible(...)'.
+    template<class Rect>
+    auto get_minimal_area_if(auto size, auto get_row, auto is_visible)
+    {
+        auto crop = Rect{};
+        auto w = size.x;
+        auto h = size.y;
+        auto y0 = 0;
+        while (y0 < h && std::none_of(get_row(y0).begin(), get_row(y0).end(), is_visible)) // Top bound.
+        {
+            y0++;
+        }
+        if (y0 != h)
+        {
+            auto y1 = h - 1;
+            while (y1 > y0 && std::none_of(get_row(y1).begin(), get_row(y1).end(), is_visible)) // Bottom bound.
+            {
+                y1--;
+            }
+            auto x0 = w;
+            auto x1 = -1;
+            for (auto y = y0; y <= y1; ++y) // Look inside [y0, y1].
+            {
+                auto row = get_row(y);
+                auto first = std::find_if(row.begin(), row.end(), is_visible);
+                if (first != row.end())
+                {
+                    x0 = std::min(x0, (si32)std::distance(row.begin(), first)); // Left.
+                    auto last = std::find_if(row.rbegin(), row.rend(), is_visible);
+                    x1 = std::max(x1, (si32)(w - 1 - std::distance(row.rbegin(), last))); // Right.
+                }
+                if (x0 == 0 && x1 == w - 1) break; // Maximum possible found.
+            }
+            crop = {{ x0, y0 }, { x1 - x0 + 1, y1 - y0 + 1 }};
+        }
+        return crop;
+    }
 
     static inline
     bool liang_barsky(fp32 xmin, fp32 ymin, fp32 xmax, fp32 ymax,

--- a/src/netxs/desktopio/richtext.hpp
+++ b/src/netxs/desktopio/richtext.hpp
@@ -862,7 +862,7 @@ namespace netxs::ui
             reverse_fill_proc<Copy>(src, dst, end, fuse);
         }
         // rich: Scroll by gap the 2D-block of lines between top and end (exclusive); down: gap > 0; up: gap < 0.
-        void scroll(si32 top, si32 end, si32 gap, cell const& clr)
+        void scroll(si32 top, si32 end, si32 gap, auto fuse, cell const& clr)
         {
             auto data = core::begin();
             auto size = core::size();
@@ -879,12 +879,12 @@ namespace netxs::ui
                     auto head = data + size.x * cut;
                     auto dest = head + step;
                     auto tail = src;
-                    while (head != tail) *--dest = *--head;
+                    while (head != tail) fuse(*--dest, *--head);
                 }
                 else step *= end - top;
 
                 auto dst = src + step;
-                while (dst != src) *src++ = clr;
+                while (dst != src) fuse(*src++, clr);
             }
             else
             {
@@ -896,12 +896,12 @@ namespace netxs::ui
                     auto head = data + size.x * cut;
                     auto dest = head + step;
                     auto tail = src;
-                    while (head != tail) *dest++ = *head++;
+                    while (head != tail) fuse(*dest++, *head++);
                 }
                 else step *= top - end;
 
                 auto dst = src + step;
-                while (dst != src) *--src = clr;
+                while (dst != src) fuse(*--src, clr);
             }
         }
         // rich: Shift 1D substring inside the line.
@@ -1609,7 +1609,7 @@ namespace netxs::ui
         }
         auto get_image_sixel()       { return image; }
         auto set_image_sixel(si32 n) { image = n; }
-        auto  or_image_sixel(si32 n) { image |= n; }
+        auto  or_image_sixel(si32 n) { image = image || n; }
         void deallocate()
         {
             body().swap(cells);

--- a/src/netxs/desktopio/richtext.hpp
+++ b/src/netxs/desktopio/richtext.hpp
@@ -575,8 +575,7 @@ namespace netxs::ui
         auto length() const                                     { return size().x;                            }
         auto shadow() const                                     { return shot{ *this };                       }
         auto substr(si32 at, si32 width = netxs::si32max) const { return shadow().substr(at, width);          }
-        void trimto(si32 max_size)                              { if (length() > max_size) crop(max_size);    }
-        void resize(si32 oversize, cell const& c = {})          { if (oversize > length()) crop(oversize, c); }
+        void resize_if_need(si32 oversize, cell const& c = {})  { if (oversize > length()) crop(oversize, c); }
         auto take_piece(si32 at, si32 width = netxs::si32max) const
         {
             if (width == netxs::si32max) width = length() - at;
@@ -836,7 +835,7 @@ namespace netxs::ui
         void splice4(si32 at, si32 count, auto const& proto, auto fuse, cell const& c = {})
         {
             if (count <= 0) return;
-            rich::resize(at + count, c);
+            rich::resize_if_need(at + count, c);
             auto end = begin() + at;
             auto dst = end + count;
             auto src = proto.end();
@@ -929,7 +928,7 @@ namespace netxs::ui
             auto pos = at % margin;
             auto vol = std::min(count, margin - pos);
             auto max = std::min(len + vol, at + margin - pos);
-            rich::resize(max);
+            rich::resize_if_need(max);
             auto ptr = begin();
             auto dst = ptr + max;
             auto src = dst - vol;
@@ -961,7 +960,7 @@ namespace netxs::ui
             auto len = length();
             auto max = len + add;
             if (at > len) max += at - len;
-            rich::resize(max);
+            rich::resize_if_need(max);
             auto pos = max - add;
             auto dst = begin() + pos;
             auto src = fragment.begin();
@@ -1053,7 +1052,7 @@ namespace netxs::ui
                 }
                 else
                 {
-                    rich::resize(margin + at);
+                    rich::resize_if_need(margin + at);
                     auto ptr = begin();
                     auto dst = ptr + at;
                     auto src = dst + count;
@@ -1697,12 +1696,6 @@ namespace netxs::ui
             return len > panel_x && wrapped() ? (len + panel_x - 1) / panel_x
                                               : 1;
         }
-        // line: Resize preserving content.
-        //todo sixel accounting
-        void crop(si32 new_length, cell const& c = {})
-        {
-            cells.resize(new_length, c);
-        }
         // line: Trim line if it exeeds max_size.
         //todo sixel accounting
         void trimto(si32 max_size)
@@ -1712,12 +1705,17 @@ namespace netxs::ui
                 cells.resize(max_size);
             }
         }
-        // line: Resize if needed (preserving content).
+        // line: Grow preserving content.
+        void grow_to(si32 oversize, cell const& c = {})
+        {
+            cells.resize(oversize, c);
+        }
+        // line: Resize (grow) if needed (preserving content).
         void resize_if_need(si32 oversize, cell const& c = {})
         {
             if (oversize > size())
             {
-                crop(oversize, c);
+                grow_to(oversize, c);
             }
         }
         // line: Trim all blank cells from the line end.
@@ -1732,7 +1730,10 @@ namespace netxs::ui
                 tail = next;
             }
             auto new_size = (si32)(tail - head);
-            if (new_size != size()) crop(new_size);
+            if (length() > new_size)
+            {
+                cells.resize(new_size);
+            }
         }
         // line: Place a number of blank cells at specified position.
         template<bool AutoGrow = faux>

--- a/src/netxs/desktopio/richtext.hpp
+++ b/src/netxs/desktopio/richtext.hpp
@@ -974,7 +974,7 @@ namespace netxs::ui
             while (src != end) fuse(*--dst, *--src);
             while (dst != end) fuse(*--dst, blank);
         }
-        // rich: Insert fragment with shifting chars to the right.
+        // rich: Insert fragment with shifting chars to the right (ui::para).
         void insert3(si32 at, rich const& fragment)
         {
             auto add = fragment.length();
@@ -991,7 +991,7 @@ namespace netxs::ui
             while (src != end) *dst++ = *src++;
             if (at < len) scroll3(at, len - at, add);
         }
-        // rich: (whole line) Insert n blanks at the specified position. Autogrow.
+        // rich: (whole line) Insert n blanks at the specified position (ui::para). Autogrow.
         void insert_full(si32 at, si32 count, cell const& blank)
         {
             if (count <= 0) return;
@@ -1026,7 +1026,7 @@ namespace netxs::ui
                 while (dst != end) *dst++ = blank;
             }
         }
-        // rich: (current segment) Delete n chars.
+        // rich: (current segment) Delete n chars (ui::para).
         void cutoff2(si32 at, si32 count)
         {
             if (count <= 0) return;
@@ -1043,7 +1043,7 @@ namespace netxs::ui
             }
         }
         // rich: Delete n chars and add blanks at the right. Same as insert(twod), but shifts from right to left.
-        void cutoff3(twod at, si32 count, cell const& blank)
+        void cutoff3(twod at, si32 count, cell const& blank, auto fuse)
         {
             if (count <= 0) return;
             auto len = size();
@@ -1054,8 +1054,8 @@ namespace netxs::ui
             auto dst = pos + at.x;
             auto end = pos + len.x;
             auto src = dst + vol;
-            while (src != end) *dst++ = *src++;
-            while (dst != end) *dst++ = blank;
+            while (src != end) fuse(*dst++, *src++);
+            while (dst != end) fuse(*dst++, blank);
         }
         // rich: (whole line) Delete n chars and add blanks at the right margin.
         void cutoff_full_not_used(si32 at, si32 count, cell const& blank, si32 margin)

--- a/src/netxs/desktopio/richtext.hpp
+++ b/src/netxs/desktopio/richtext.hpp
@@ -575,7 +575,7 @@ namespace netxs::ui
         auto length() const                                     { return size().x;                            }
         auto shadow() const                                     { return shot{ *this };                       }
         auto substr(si32 at, si32 width = netxs::si32max) const { return shadow().substr(at, width);          }
-        void resize_if_need(si32 oversize, cell const& c = {})  { if (oversize > length()) crop(oversize, c); }
+        void resize_if_needed(si32 oversize, cell const& c = {}){ if (oversize > length()) crop(oversize, c); }
         auto take_piece(si32 at, si32 width = netxs::si32max) const
         {
             if (width == netxs::si32max) width = length() - at;
@@ -835,7 +835,7 @@ namespace netxs::ui
         void splice4(si32 at, si32 count, std::span<cell const> proto, auto fuse, cell const& c = {})
         {
             if (count <= 0) return;
-            rich::resize_if_need(at + count, c);
+            rich::resize_if_needed(at + count, c);
             auto end = begin() + at;
             auto dst = end + count;
             auto src = proto.end();
@@ -928,7 +928,7 @@ namespace netxs::ui
             auto pos = at % margin;
             auto vol = std::min(count, margin - pos);
             auto max = std::min(len + vol, at + margin - pos);
-            rich::resize_if_need(max);
+            rich::resize_if_needed(max);
             auto ptr = begin();
             auto dst = ptr + max;
             auto src = dst - vol;
@@ -960,7 +960,7 @@ namespace netxs::ui
             auto len = length();
             auto max = len + add;
             if (at > len) max += at - len;
-            rich::resize_if_need(max);
+            rich::resize_if_needed(max);
             auto pos = max - add;
             auto dst = begin() + pos;
             auto src = fragment.begin();
@@ -1052,7 +1052,7 @@ namespace netxs::ui
                 }
                 else
                 {
-                    rich::resize_if_need(margin + at);
+                    rich::resize_if_needed(margin + at);
                     auto ptr = begin();
                     auto dst = ptr + at;
                     auto src = dst + count;
@@ -1710,7 +1710,7 @@ namespace netxs::ui
             cells.resize(oversize, c);
         }
         // line: Resize (grow) if needed (preserving content).
-        void resize_if_need(si32 oversize, cell const& c = {})
+        void resize_if_needed(si32 oversize, cell const& c = {})
         {
             if (oversize > size())
             {
@@ -1742,7 +1742,7 @@ namespace netxs::ui
             auto len = size();
             if constexpr (AutoGrow)
             {
-                resize_if_need(at + count);
+                resize_if_needed(at + count);
             }
             else
             {
@@ -1758,7 +1758,7 @@ namespace netxs::ui
         void splice1(si32 at, std::span<cell const> fragment, auto fuse, cell const& c = {})
         {
             auto len = (si32)fragment.size();
-            resize_if_need(len + at, c);
+            resize_if_needed(len + at, c);
             auto ptr = cells.begin();
             auto dst = ptr + at;
             auto end = dst + len;
@@ -1773,7 +1773,7 @@ namespace netxs::ui
         void splice6(si32 at, si32 count, std::span<cell const> proto, auto fuse, cell const& c = {})
         {
             if (count <= 0) return;
-            resize_if_need(at + count, c);
+            resize_if_needed(at + count, c);
             auto end = cells.begin() + at;
             auto dst = end + count;
             auto src = proto.end();
@@ -1787,7 +1787,7 @@ namespace netxs::ui
             auto pos = at % margin;
             auto vol = std::min(count, margin - pos);
             auto max = std::min(len + vol, at + margin - pos);
-            resize_if_need(max);
+            resize_if_needed(max);
             auto ptr = cells.begin();
             auto dst = ptr + max;
             auto src = dst - vol;

--- a/src/netxs/desktopio/richtext.hpp
+++ b/src/netxs/desktopio/richtext.hpp
@@ -1718,7 +1718,7 @@ namespace netxs::ui
             }
         }
         // line: Trim all blank cells from the line end.
-        void shrink(cell const& blank)
+        void trim_blank_cells(cell const& blank)
         {
             auto head = cells.begin();
             auto tail = cells.end();
@@ -1780,7 +1780,7 @@ namespace netxs::ui
             rich::reverse_fill_proc<Copy>(src, dst, end, fuse);
         }
         // line: Insert n blanks at the specified position. Autogrow within segment only.
-        void insert4(si32 at, si32 count, cell const& blank, si32 margin)
+        void insert_blanks(si32 at, si32 count, cell const& blank, si32 margin)
         {
             if (count <= 0 || margin == 0) return;
             auto len = size();
@@ -1796,21 +1796,18 @@ namespace netxs::ui
             while (dst != end) *--dst = blank;
         }
         // line: Delete n chars and add blanks at the right margin.
-        void cutoff4(si32 at, si32 count, cell const& blank, si32 margin)
+        void cutoff4(si32 at, si32 count, cell const& blank, si32 margin, auto fuse)
         {
-            if (count <= 0 || margin == 0) return;
             auto len = size();
-            if (at < len)
-            {
-                auto pos = at % margin;
-                auto rem = std::min(margin - pos, len - at);
-                auto vol = std::min(count, rem);
-                auto dst = cells.begin() + at;
-                auto end = dst + rem;
-                auto src = dst + vol;
-                while (src != end) *dst++ = *src++;
-                while (dst != end) *dst++ = blank;
-            }
+            if (count <= 0 || margin == 0 || at >= len) return;
+            auto pos = at % margin;
+            auto rem = std::min(margin - pos, len - at);
+            auto vol = std::min(count, rem);
+            auto dst = cells.begin() + at;
+            auto end = dst + rem;
+            auto src = dst + vol;
+            while (src != end) fuse(*dst++, *src++);
+            while (dst != end) fuse(*dst++, blank);
         }
         // line: Find the substring and place its offset in &from.
         auto find(line const& what, auto&& from, feed dir = feed::fwd) const

--- a/src/netxs/desktopio/richtext.hpp
+++ b/src/netxs/desktopio/richtext.hpp
@@ -960,7 +960,7 @@ namespace netxs::ui
             while (dst != end) *--dst = blank;
         }
         // rich: Insert n blanks by shifting chars to the right. Same as delete(twod), but shifts from left to right.
-        void insert2(twod at, si32 count, cell const& blank)
+        void insert2(twod at, si32 count, cell const& blank, auto fuse)
         {
             if (count <= 0) return;
             auto len = size();
@@ -971,8 +971,8 @@ namespace netxs::ui
             auto dst = pos + len.x;
             auto end = pos + at.x;
             auto src = dst - vol;
-            while (src != end) *--dst = *--src;
-            while (dst != end) *--dst = blank;
+            while (src != end) fuse(*--dst, *--src);
+            while (dst != end) fuse(*--dst, blank);
         }
         // rich: Insert fragment with shifting chars to the right.
         void insert3(si32 at, rich const& fragment)

--- a/src/netxs/desktopio/richtext.hpp
+++ b/src/netxs/desktopio/richtext.hpp
@@ -608,8 +608,8 @@ namespace netxs::ui
         {
             return canvas.empty();
         }
-        template<bool Copy = faux, class SrcIt, class DstIt, class Shader>
-        static void forward_fill_proc(SrcIt data, DstIt dest, DstIt tail, Shader fuse)
+        template<bool Copy = faux, class SrcIt, class DstIt>
+        static void forward_fill_proc(SrcIt data, DstIt dest, DstIt tail, auto fuse)
         {
             if constexpr (Copy)
             {
@@ -674,8 +674,8 @@ namespace netxs::ui
                 }
             }
         }
-        template<bool Copy = faux, class SrcIt, class DstIt, class Shader>
-        static void unlimit_fill_proc(SrcIt data, si32 size, DstIt dest, DstIt tail, si32 back, Shader fuse)
+        template<bool Copy = faux, class SrcIt, class DstIt>
+        static void unlimit_fill_proc(SrcIt data, si32 size, DstIt dest, DstIt tail, si32 back, auto fuse)
         {
             if constexpr (Copy)
             {
@@ -746,8 +746,8 @@ namespace netxs::ui
                 }
             }
         }
-        template<bool Copy = faux, class SrcIt, class DstIt, class Shader>
-        static void reverse_fill_proc(SrcIt data, DstIt dest, DstIt tail, Shader fuse)
+        template<bool Copy = faux, class SrcIt, class DstIt>
+        static void reverse_fill_proc(SrcIt data, DstIt dest, DstIt tail, auto fuse)
         {
             if constexpr (Copy)
             {
@@ -842,8 +842,8 @@ namespace netxs::ui
             }
         }
         // rich: Splice proto with auto grow.
-        template<bool Copy = faux, class Span, class Shader>
-        void splice(si32 at, si32 count, Span const& proto, Shader fuse, cell const& c = {})
+        template<bool Copy = faux, class Span>
+        void splice(si32 at, si32 count, Span const& proto, auto fuse, cell const& c = {})
         {
             if (count <= 0) return;
             rich::resize(at + count, c);
@@ -852,8 +852,8 @@ namespace netxs::ui
             auto src = proto.end();
             reverse_fill_proc<Copy>(src, dst, end, fuse);
         }
-        template<bool Copy = faux, class Span, class Shader>
-        void splice(twod at, si32 count, Span const& proto, Shader fuse)
+        template<bool Copy = faux, class Span>
+        void splice(twod at, si32 count, Span const& proto, auto fuse)
         {
             if (count <= 0) return;
             auto end = begin() + at.x + at.y * size().x;

--- a/src/netxs/desktopio/richtext.hpp
+++ b/src/netxs/desktopio/richtext.hpp
@@ -1660,13 +1660,13 @@ namespace netxs::ui
             auto size = upto - from;
             return std::span{ cells.begin() + from, (size_t)size };
         }
-        // line: Return sub-line view.
-        auto substr(si32 at, si32 width = netxs::si32max) const
+        // line: Return subspan.
+        auto substr(si32 start, si32 count = netxs::si32max) const
         {
-            auto w = size();
-            auto a = std::max(0, at);
-            return a < w ? std::span{ cells.begin() + a, (size_t)std::min(std::max(0, width), w - a) }
-                         : std::span{ cells.begin() + 0, (size_t)0 };
+            auto limit = (si32)cells.size();
+            start = std::clamp(start, 0, limit);
+            count = std::clamp(count, 0, limit - start);
+            return std::span{ cells.begin() + start, (size_t)count };
         }
         auto  jet() const { return align;                                    } // line: Return line alignment.
         auto  wrp() const { return wraps;                                    } // line: Return line auto wrapping.

--- a/src/netxs/desktopio/richtext.hpp
+++ b/src/netxs/desktopio/richtext.hpp
@@ -1698,11 +1698,13 @@ namespace netxs::ui
                                               : 1;
         }
         // line: Resize preserving content.
+        //todo sixel accounting
         void crop(si32 new_length, cell const& c = {})
         {
             cells.resize(new_length, c);
         }
         // line: Trim line if it exeeds max_size.
+        //todo sixel accounting
         void trimto(si32 max_size)
         {
             if (length() > max_size)
@@ -1711,7 +1713,7 @@ namespace netxs::ui
             }
         }
         // line: Resize if needed (preserving content).
-        void resize(si32 oversize, cell const& c = {})
+        void resize_if_need(si32 oversize, cell const& c = {})
         {
             if (oversize > size())
             {
@@ -1740,7 +1742,7 @@ namespace netxs::ui
             auto len = size();
             if constexpr (AutoGrow)
             {
-                resize(at + count);
+                resize_if_need(at + count);
             }
             else
             {
@@ -1753,10 +1755,10 @@ namespace netxs::ui
             while (dst != end) fx(*dst++);
         }
         // line: Place the specified fragment to the specified position.
-        void splice(si32 at, std::span<cell const> fragment, auto fuse, cell const& c = {})
+        void splice1(si32 at, std::span<cell const> fragment, auto fuse, cell const& c = {})
         {
             auto len = (si32)fragment.size();
-            resize(len + at, c);
+            resize_if_need(len + at, c);
             auto ptr = cells.begin();
             auto dst = ptr + at;
             auto end = dst + len;
@@ -1768,24 +1770,24 @@ namespace netxs::ui
         }
         // line: Splice proto with auto grow.
         template<bool Copy = faux>
-        void splice(si32 at, si32 count, std::span<cell const> proto, auto fuse, cell const& c = {})
+        void splice6(si32 at, si32 count, std::span<cell const> proto, auto fuse, cell const& c = {})
         {
             if (count <= 0) return;
-            resize(at + count, c);
+            resize_if_need(at + count, c);
             auto end = cells.begin() + at;
             auto dst = end + count;
             auto src = proto.end();
             rich::reverse_fill_proc<Copy>(src, dst, end, fuse);
         }
         // line: Insert n blanks at the specified position. Autogrow within segment only.
-        void insert(si32 at, si32 count, cell const& blank, si32 margin)
+        void insert4(si32 at, si32 count, cell const& blank, si32 margin)
         {
             if (count <= 0 || margin == 0) return;
             auto len = size();
             auto pos = at % margin;
             auto vol = std::min(count, margin - pos);
             auto max = std::min(len + vol, at + margin - pos);
-            resize(max);
+            resize_if_need(max);
             auto ptr = cells.begin();
             auto dst = ptr + max;
             auto src = dst - vol;
@@ -1794,7 +1796,7 @@ namespace netxs::ui
             while (dst != end) *--dst = blank;
         }
         // line: Delete n chars and add blanks at the right margin.
-        void cutoff(si32 at, si32 count, cell const& blank, si32 margin)
+        void cutoff4(si32 at, si32 count, cell const& blank, si32 margin)
         {
             if (count <= 0 || margin == 0) return;
             auto len = size();

--- a/src/netxs/desktopio/richtext.hpp
+++ b/src/netxs/desktopio/richtext.hpp
@@ -2773,7 +2773,7 @@ namespace netxs::ui
         template<class ...Args>
         void wipe(Args&&... args) // Optional args.
         {
-            core::wipe(args...);
+            core::wipe2(args...);
             flow::reset();
         }
         // face: Change current 2D context. Return old 2D context.

--- a/src/netxs/desktopio/richtext.hpp
+++ b/src/netxs/desktopio/richtext.hpp
@@ -1104,23 +1104,23 @@ namespace netxs::ui
             while (dst != end) blank_fx(*dst++);
         }
         // rich: Clear from the specified coor to the bottom.
-        void del_below2(twod pos, cell const& blank)
+        void del_below2(twod pos, auto blank_fx)
         {
             auto len = size();
             auto ptr = begin();
             auto dst = ptr + std::min<si32>(pos.x + pos.y * len.x,
                                                     len.y * len.x);
             auto end = core::end();
-            while (dst != end) *dst++ = blank;
+            while (dst != end) blank_fx(*dst++);
         }
         // rich: Clear from the top to the specified coor.
-        void del_above2(twod pos, cell const& blank)
+        void del_above2(twod pos, auto blank_fx)
         {
             auto len = size();
             auto dst = begin();
             auto end = dst + std::min<si32>(pos.x + pos.y * len.x,
                                                     len.y * len.x);
-            while (dst != end) *dst++ = blank;
+            while (dst != end) blank_fx(*dst++);
         }
         //todo make it 2D
         // rich: Pop glyph matrix.

--- a/src/netxs/desktopio/richtext.hpp
+++ b/src/netxs/desktopio/richtext.hpp
@@ -1028,7 +1028,7 @@ namespace netxs::ui
             }
         }
         // rich: Put n blanks on top of the chars and cut them off with the right edge.
-        void splice(twod at, si32 count, cell const& blank)
+        void splice3(twod at, si32 count, auto fx)
         {
             if (count <= 0) return;
             auto len = size();
@@ -1037,7 +1037,7 @@ namespace netxs::ui
             auto ptr = begin();
             auto dst = ptr + at.x + at.y * len.x;
             auto end = dst + vol;
-            while (dst != end) *dst++ = blank;
+            while (dst != end) fx(*dst++);
         }
         // rich: Put n blanks on top of the chars and wrap them at the right edge.
         void backsp(twod at, si32 count, cell const& blank)
@@ -1756,7 +1756,7 @@ namespace netxs::ui
         }
         // line: Place a number of blank cells at specified position.
         template<bool AutoGrow = faux>
-        void splice(si32 at, si32 count, cell const& blank)
+        void splice2(si32 at, si32 count, auto fx)
         {
             if (count <= 0) return;
             auto len = size();
@@ -1772,7 +1772,7 @@ namespace netxs::ui
             auto ptr = cells.begin();
             auto dst = ptr + at;
             auto end = dst + count;
-            while (dst != end) *dst++ = blank;
+            while (dst != end) fx(*dst++);
         }
         // line: Place the specified fragment to the specified position.
         void splice(si32 at, std::span<cell const> fragment, auto fuse, cell const& c = {})

--- a/src/netxs/desktopio/richtext.hpp
+++ b/src/netxs/desktopio/richtext.hpp
@@ -2916,15 +2916,9 @@ namespace netxs::ui
             return core::size();
         }
         template<bool BottomAnchored = faux>
-        void crop(twod new_size, cell const& c) // face: Resize while saving the bitmap.
+        void crop(twod new_size, auto... args) // face: Resize while saving the bitmap.
         {
-            core::crop<BottomAnchored>(new_size, c);
-            flow::size(new_size);
-        }
-        template<bool BottomAnchored = faux>
-        void crop(twod new_size) // face: Resize while saving the bitmap.
-        {
-            core::crop<BottomAnchored>(new_size, core::mark());
+            core::crop<BottomAnchored>(new_size, args...);
             flow::size(new_size);
         }
         // face: Double boxblur the face background.

--- a/src/netxs/desktopio/richtext.hpp
+++ b/src/netxs/desktopio/richtext.hpp
@@ -789,7 +789,7 @@ namespace netxs::ui
                 }
             }
         }
-        void unpack2d(auto const& proto, twod block_size)
+        void unpack2d(std::span<cell const> proto, twod block_size)
         {
             core::size(block_size);
             //todo simplify (use netxs::onrect)
@@ -832,7 +832,7 @@ namespace netxs::ui
         }
         // rich: Splice proto with auto grow.
         template<bool Copy = faux>
-        void splice4(si32 at, si32 count, auto const& proto, auto fuse, cell const& c = {})
+        void splice4(si32 at, si32 count, std::span<cell const> proto, auto fuse, cell const& c = {})
         {
             if (count <= 0) return;
             rich::resize_if_need(at + count, c);
@@ -842,7 +842,7 @@ namespace netxs::ui
             reverse_fill_proc<Copy>(src, dst, end, fuse);
         }
         template<bool Copy = faux>
-        void splice5(twod at, si32 count, auto const& proto, auto fuse)
+        void splice5(twod at, si32 count, std::span<cell const> proto, auto fuse)
         {
             if (count <= 0) return;
             auto end = begin() + at.x + at.y * size().x;
@@ -1226,7 +1226,7 @@ namespace netxs::ui
             else if (!busy()) locus.push(cmd);
         }
         // para: Convert into the screen-adapted sequence (unfold, remove zerospace chars, etc.).
-        void data(si32 width, si32 /*height*/, core::body const& proto) override
+        void data(si32 width, si32 /*height*/, std::span<cell const> proto) override
         {
             lyric->splice4(caret, width, proto, cell::shaders::full);
             caret += width;
@@ -2181,7 +2181,7 @@ namespace netxs::ui
             item.style = parser::style;
         }
         // page: .
-        void data(si32 width, si32 /*height*/, core::body const& proto) override
+        void data(si32 width, si32 /*height*/, std::span<cell const> proto) override
         {
             auto& item = **layer;
             item.content().splice4(item.caret, width, proto, cell::shaders::full);

--- a/src/netxs/desktopio/richtext.hpp
+++ b/src/netxs/desktopio/richtext.hpp
@@ -1696,8 +1696,7 @@ namespace netxs::ui
             return len > panel_x && wrapped() ? (len + panel_x - 1) / panel_x
                                               : 1;
         }
-        // line: Trim line if it exeeds max_size.
-        //todo sixel accounting
+        // line: Trim line if it exeeds max_size (without sixel accounting).
         void trimto(si32 max_size)
         {
             if (length() > max_size)

--- a/src/netxs/desktopio/richtext.hpp
+++ b/src/netxs/desktopio/richtext.hpp
@@ -841,9 +841,21 @@ namespace netxs::ui
                 iter += w;
             }
         }
+        // rich: Put n blanks on top of the chars and cut them off with the right edge.
+        void splice3(twod at, si32 count, auto fx)
+        {
+            if (count <= 0) return;
+            auto len = size();
+            auto vol = std::min(count, len.x - at.x);
+            assert(at.x + at.y * len.x + vol <= len.y * len.x);
+            auto ptr = begin();
+            auto dst = ptr + at.x + at.y * len.x;
+            auto end = dst + vol;
+            while (dst != end) fx(*dst++);
+        }
         // rich: Splice proto with auto grow.
-        template<bool Copy = faux, class Span>
-        void splice4(si32 at, si32 count, Span const& proto, auto fuse, cell const& c = {})
+        template<bool Copy = faux>
+        void splice4(si32 at, si32 count, auto const& proto, auto fuse, cell const& c = {})
         {
             if (count <= 0) return;
             rich::resize(at + count, c);
@@ -852,8 +864,8 @@ namespace netxs::ui
             auto src = proto.end();
             reverse_fill_proc<Copy>(src, dst, end, fuse);
         }
-        template<bool Copy = faux, class Span>
-        void splice5(twod at, si32 count, Span const& proto, auto fuse)
+        template<bool Copy = faux>
+        void splice5(twod at, si32 count, auto const& proto, auto fuse)
         {
             if (count <= 0) return;
             auto end = begin() + at.x + at.y * size().x;
@@ -932,7 +944,7 @@ namespace netxs::ui
             }
         }
         // rich: (current segment) Insert n blanks at the specified position. Autogrow within segment only.
-        void insert(si32 at, si32 count, cell const& blank, si32 margin)
+        void insert1_not_used(si32 at, si32 count, cell const& blank, si32 margin)
         {
             if (count <= 0 || margin == 0) return;
             auto len = length();
@@ -948,7 +960,7 @@ namespace netxs::ui
             while (dst != end) *--dst = blank;
         }
         // rich: Insert n blanks by shifting chars to the right. Same as delete(twod), but shifts from left to right.
-        void insert(twod at, si32 count, cell const& blank)
+        void insert2(twod at, si32 count, cell const& blank)
         {
             if (count <= 0) return;
             auto len = size();
@@ -998,7 +1010,7 @@ namespace netxs::ui
             while (src != end) *src++ = blank;
         }
         // rich: (current segment) Delete n chars and add blanks at the right margin.
-        void cutoff(si32 at, si32 count, cell const& blank, si32 margin)
+        void cutoff1_not_used(si32 at, si32 count, cell const& blank, si32 margin)
         {
             if (count <= 0 || margin == 0) return;
             auto len = length();
@@ -1015,7 +1027,7 @@ namespace netxs::ui
             }
         }
         // rich: (current segment) Delete n chars.
-        void cutoff(si32 at, si32 count)
+        void cutoff2(si32 at, si32 count)
         {
             if (count <= 0) return;
             auto len = length();
@@ -1030,8 +1042,23 @@ namespace netxs::ui
                 crop(len - vol);
             }
         }
+        // rich: Delete n chars and add blanks at the right. Same as insert(twod), but shifts from right to left.
+        void cutoff3(twod at, si32 count, cell const& blank)
+        {
+            if (count <= 0) return;
+            auto len = size();
+            auto vol = std::min(count, len.x - at.x);
+            assert(at.x + at.y * len.x + vol <= len.y * len.x);
+            auto ptr = begin();
+            auto pos = ptr + at.y * len.x;
+            auto dst = pos + at.x;
+            auto end = pos + len.x;
+            auto src = dst + vol;
+            while (src != end) *dst++ = *src++;
+            while (dst != end) *dst++ = blank;
+        }
         // rich: (whole line) Delete n chars and add blanks at the right margin.
-        void cutoff_full(si32 at, si32 count, cell const& blank, si32 margin)
+        void cutoff_full_not_used(si32 at, si32 count, cell const& blank, si32 margin)
         {
             if (count <= 0 || margin == 0) return;
             auto len = length();
@@ -1059,18 +1086,6 @@ namespace netxs::ui
                 }
             }
         }
-        // rich: Put n blanks on top of the chars and cut them off with the right edge.
-        void splice3(twod at, si32 count, auto fx)
-        {
-            if (count <= 0) return;
-            auto len = size();
-            auto vol = std::min(count, len.x - at.x);
-            assert(at.x + at.y * len.x + vol <= len.y * len.x);
-            auto ptr = begin();
-            auto dst = ptr + at.x + at.y * len.x;
-            auto end = dst + vol;
-            while (dst != end) fx(*dst++);
-        }
         // rich: Put n blanks on top of the chars and wrap them at the right edge.
         void backsp(twod at, si32 count, cell const& blank)
         {
@@ -1088,23 +1103,8 @@ namespace netxs::ui
             auto end = dst + vol;
             while (dst != end) *dst++ = blank;
         }
-        // rich: Delete n chars and add blanks at the right. Same as insert(twod), but shifts from right to left.
-        void cutoff(twod at, si32 count, cell const& blank)
-        {
-            if (count <= 0) return;
-            auto len = size();
-            auto vol = std::min(count, len.x - at.x);
-            assert(at.x + at.y * len.x + vol <= len.y * len.x);
-            auto ptr = begin();
-            auto pos = ptr + at.y * len.x;
-            auto dst = pos + at.x;
-            auto end = pos + len.x;
-            auto src = dst + vol;
-            while (src != end) *dst++ = *src++;
-            while (dst != end) *dst++ = blank;
-        }
         // rich: Clear from the specified coor to the bottom.
-        void del_below(twod pos, cell const& blank)
+        void del_below2(twod pos, cell const& blank)
         {
             auto len = size();
             auto ptr = begin();
@@ -1114,7 +1114,7 @@ namespace netxs::ui
             while (dst != end) *dst++ = blank;
         }
         // rich: Clear from the top to the specified coor.
-        void del_above(twod pos, cell const& blank)
+        void del_above2(twod pos, cell const& blank)
         {
             auto len = size();
             auto dst = begin();
@@ -1275,7 +1275,7 @@ namespace netxs::ui
                 caret_check();
                 auto oldpos = caret;
                 auto& line = content();
-                line.cutoff(0, oldpos);
+                line.cutoff2(0, oldpos);
             }
             caret = 0;
         }
@@ -1347,7 +1347,7 @@ namespace netxs::ui
             {
                 auto newpos = caret;
                 auto& line = content();
-                line.cutoff(newpos, oldpos - newpos);
+                line.cutoff2(newpos, oldpos - newpos);
                 return true;
             }
             else return faux;
@@ -1387,7 +1387,7 @@ namespace netxs::ui
             {
                 auto newpos = caret;
                 auto& line = content();
-                line.cutoff(oldpos, newpos - oldpos);
+                line.cutoff2(oldpos, newpos - oldpos);
                 caret = oldpos;
                 return true;
             }
@@ -1467,7 +1467,7 @@ namespace netxs::ui
             {
                 auto newpos = caret;
                 auto& line = content();
-                line.cutoff(newpos, oldpos - newpos);
+                line.cutoff2(newpos, oldpos - newpos);
                 return true;
             }
             else return faux;
@@ -1494,7 +1494,7 @@ namespace netxs::ui
             {
                 auto newpos = caret;
                 auto& line = content();
-                line.cutoff(oldpos, newpos - oldpos);
+                line.cutoff2(oldpos, newpos - oldpos);
                 caret = oldpos;
                 return true;
             }

--- a/src/netxs/desktopio/richtext.hpp
+++ b/src/netxs/desktopio/richtext.hpp
@@ -1087,7 +1087,7 @@ namespace netxs::ui
             }
         }
         // rich: Put n blanks on top of the chars and wrap them at the right edge.
-        void backsp(twod at, si32 count, cell const& blank)
+        void backsp(twod at, si32 count, auto blank_fx)
         {
             auto len = size();
             if (at.y >= len.y || (at.y == len.y - 1 && at.x >= len.x)) return;
@@ -1101,7 +1101,7 @@ namespace netxs::ui
             auto ptr = begin();
             auto dst = ptr + d2;
             auto end = dst + vol;
-            while (dst != end) *dst++ = blank;
+            while (dst != end) blank_fx(*dst++);
         }
         // rich: Clear from the specified coor to the bottom.
         void del_below2(twod pos, cell const& blank)

--- a/src/netxs/desktopio/richtext.hpp
+++ b/src/netxs/desktopio/richtext.hpp
@@ -2609,6 +2609,12 @@ namespace netxs::ui
         }
 
     public:
+        void reset_face()
+        {
+            auto tmp = core{};
+            core::swap(tmp);
+            flow::reset();
+        }
         //todo revise
         bool caret = faux; // face: Cursor visibility.
         bool moved = faux; // face: Is reflow required.

--- a/src/netxs/desktopio/richtext.hpp
+++ b/src/netxs/desktopio/richtext.hpp
@@ -582,28 +582,6 @@ namespace netxs::ui
             if (width == netxs::si32max) width = length() - at;
             return rich{ core::crop(at, width) };
         }
-        auto copy_piece(auto& dest, si32 from, si32 width) const
-        {
-            auto my_size = size();
-            if (from >= my_size.x * my_size.y)
-            {
-                dest.crop(0);
-                return;
-            }
-            auto new_width = from % my_size.x + width;
-            if (new_width > my_size.x)
-            {
-                width = my_size.x - from;
-            }
-            dest.crop(width);
-            auto src = begin() + from;
-            auto dst = dest.begin();
-            auto end = dest.end();
-            while (dst != end)
-            {
-                *dst++ = *src++;
-            }
-        }
         auto empty()
         {
             return canvas.empty();
@@ -1123,7 +1101,7 @@ namespace netxs::ui
             while (dst != end) blank_fx(*dst++);
         }
         //todo make it 2D
-        // rich: Pop glyph matrix.
+        // rich: Pop glyph matrix (ui::para).
         auto pop_cluster(bool peek = faux)
         {
             auto cluster = netxs::text{};
@@ -1831,12 +1809,6 @@ namespace netxs::ui
                 while (src != end) *dst++ = *src++;
                 while (dst != end) *dst++ = blank;
             }
-        }
-        // line: Copy the specified sub-line to the dest.
-        auto copy_piece(line& dest, si32 from, si32 width = netxs::si32max) const
-        {
-            auto s = substr(from, width);
-            dest.cells.assign(s.begin(), s.end());
         }
         // line: Find the substring and place its offset in &from.
         auto find(line const& what, auto&& from, feed dir = feed::fwd) const

--- a/src/netxs/desktopio/richtext.hpp
+++ b/src/netxs/desktopio/richtext.hpp
@@ -843,7 +843,7 @@ namespace netxs::ui
         }
         // rich: Splice proto with auto grow.
         template<bool Copy = faux, class Span>
-        void splice(si32 at, si32 count, Span const& proto, auto fuse, cell const& c = {})
+        void splice4(si32 at, si32 count, Span const& proto, auto fuse, cell const& c = {})
         {
             if (count <= 0) return;
             rich::resize(at + count, c);
@@ -853,7 +853,7 @@ namespace netxs::ui
             reverse_fill_proc<Copy>(src, dst, end, fuse);
         }
         template<bool Copy = faux, class Span>
-        void splice(twod at, si32 count, Span const& proto, auto fuse)
+        void splice5(twod at, si32 count, Span const& proto, auto fuse)
         {
             if (count <= 0) return;
             auto end = begin() + at.x + at.y * size().x;
@@ -862,7 +862,7 @@ namespace netxs::ui
             reverse_fill_proc<Copy>(src, dst, end, fuse);
         }
         // rich: Scroll by gap the 2D-block of lines between top and end (exclusive); down: gap > 0; up: gap < 0.
-        void scroll(si32 top, si32 end, si32 gap, auto fuse, cell const& clr)
+        void scroll2(si32 top, si32 end, si32 gap, auto fuse, cell const& clr)
         {
             auto data = core::begin();
             auto size = core::size();
@@ -905,7 +905,7 @@ namespace netxs::ui
             }
         }
         // rich: Shift 1D substring inside the line.
-        void scroll(si32 from, si32 size, si32 step)
+        void scroll3(si32 from, si32 size, si32 step)
         {
             if (step == 0 || size == 0) return;
             if (step < 0)
@@ -946,6 +946,38 @@ namespace netxs::ui
             auto end = ptr + at;
             while (src != end) *--dst = *--src;
             while (dst != end) *--dst = blank;
+        }
+        // rich: Insert n blanks by shifting chars to the right. Same as delete(twod), but shifts from left to right.
+        void insert(twod at, si32 count, cell const& blank)
+        {
+            if (count <= 0) return;
+            auto len = size();
+            auto vol = std::min(count, len.x - at.x);
+            assert(at.x + at.y * len.x + vol <= len.y * len.x);
+            auto ptr = begin();
+            auto pos = ptr + at.y * len.x;
+            auto dst = pos + len.x;
+            auto end = pos + at.x;
+            auto src = dst - vol;
+            while (src != end) *--dst = *--src;
+            while (dst != end) *--dst = blank;
+        }
+        // rich: Insert fragment with shifting chars to the right.
+        void insert3(si32 at, rich const& fragment)
+        {
+            auto add = fragment.length();
+            if (add == 0) return;
+            if (at < 0) at = 0;
+            auto len = length();
+            auto max = len + add;
+            if (at > len) max += at - len;
+            rich::resize(max);
+            auto pos = max - add;
+            auto dst = begin() + pos;
+            auto src = fragment.begin();
+            auto end = fragment.end();
+            while (src != end) *dst++ = *src++;
+            if (at < len) scroll3(at, len - at, add);
         }
         // rich: (whole line) Insert n blanks at the specified position. Autogrow.
         void insert_full(si32 at, si32 count, cell const& blank)
@@ -1055,38 +1087,6 @@ namespace netxs::ui
             auto dst = ptr + d2;
             auto end = dst + vol;
             while (dst != end) *dst++ = blank;
-        }
-        // rich: Insert n blanks by shifting chars to the right. Same as delete(twod), but shifts from left to right.
-        void insert(twod at, si32 count, cell const& blank)
-        {
-            if (count <= 0) return;
-            auto len = size();
-            auto vol = std::min(count, len.x - at.x);
-            assert(at.x + at.y * len.x + vol <= len.y * len.x);
-            auto ptr = begin();
-            auto pos = ptr + at.y * len.x;
-            auto dst = pos + len.x;
-            auto end = pos + at.x;
-            auto src = dst - vol;
-            while (src != end) *--dst = *--src;
-            while (dst != end) *--dst = blank;
-        }
-        // rich: Insert fragment with shifting chars to the right.
-        void insert(si32 at, rich const& fragment)
-        {
-            auto add = fragment.length();
-            if (add == 0) return;
-            if (at < 0) at = 0;
-            auto len = length();
-            auto max = len + add;
-            if (at > len) max += at - len;
-            rich::resize(max);
-            auto pos = max - add;
-            auto dst = begin() + pos;
-            auto src = fragment.begin();
-            auto end = fragment.end();
-            while (src != end) *dst++ = *src++;
-            if (at < len) scroll(at, len - at, add);
         }
         // rich: Delete n chars and add blanks at the right. Same as insert(twod), but shifts from right to left.
         void cutoff(twod at, si32 count, cell const& blank)
@@ -1251,7 +1251,7 @@ namespace netxs::ui
         // para: Convert into the screen-adapted sequence (unfold, remove zerospace chars, etc.).
         void data(si32 width, si32 /*height*/, core::body const& proto) override
         {
-            lyric->splice(caret, width, proto, cell::shaders::full);
+            lyric->splice4(caret, width, proto, cell::shaders::full);
             caret += width;
         }
         void id(ui32 newid) { index = newid; }
@@ -1425,7 +1425,7 @@ namespace netxs::ui
                 caret = line.length();
                 if (inserting)
                 {
-                    line.rich::insert(caret, right);
+                    line.rich::insert3(caret, right);
                 }
                 else
                 {
@@ -1439,7 +1439,7 @@ namespace netxs::ui
                         }
                         if (delta < right.length())
                         {
-                            line.rich::insert(caret, right.take_piece(delta));
+                            line.rich::insert3(caret, right.take_piece(delta));
                         }
                     }
                 }
@@ -2213,7 +2213,7 @@ namespace netxs::ui
         void data(si32 width, si32 /*height*/, core::body const& proto) override
         {
             auto& item = **layer;
-            item.content().splice(item.caret, width, proto, cell::shaders::full);
+            item.content().splice4(item.caret, width, proto, cell::shaders::full);
             item.caret += width;
         }
         auto& current()       { return **layer; } // page: Access to the current paragraph.

--- a/src/netxs/desktopio/richtext.hpp
+++ b/src/netxs/desktopio/richtext.hpp
@@ -1607,6 +1607,9 @@ namespace netxs::ui
             r_2_l = line_style.rtl();
             image = {};
         }
+        auto get_image_sixel()       { return image; }
+        auto set_image_sixel(si32 n) { image = n; }
+        auto  or_image_sixel(si32 n) { image |= n; }
         void deallocate()
         {
             body().swap(cells);

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -1300,12 +1300,9 @@ namespace netxs::ui
                   alive{ 0      }
             {
                 parser::style = ansi::def_style;
-                owner.LISTEN(tier::general, e2::data::image::remove, image_indexes, image_update_token)
+                owner.LISTEN(tier::release, e2::data::image::remove, image_indexes, image_update_token)
                 {
-                    if (owner.image_alive)
-                    {
-                        wipe_image_index(image_indexes);
-                    }
+                    wipe_image_index(image_indexes);
                 };
             }
 
@@ -2863,6 +2860,8 @@ namespace netxs::ui
             {
                 assert(coord.y >= 0 && coord.y < panel.y);
 
+                auto has_sixel = proto.front().get_image_sixel();
+                canvas.or_image_sixel(has_sixel);
                 auto start = coord;
                 coord.x += count;
                 //todo apply line adjusting (necessity is not clear)
@@ -3332,12 +3331,12 @@ namespace netxs::ui
             struct buff : public ring
             {
                 static constexpr auto sizea_size = 65536;
-                using ring::ring;
                 using type = deco::type;
                 using mapa = std::array<si32, sizea_size>[type::count];
                 using maps = std::map<si32, si32>[type::count];
                 using maxl = std::array<si32, type::count>;
 
+                term& owner;
                 si32 caret{}; // buff: Current line cursor horizontal position.
                 si32 vsize{}; // buff: Scrollback vertical size (height).
                 si32 width{}; // buff: Viewport width.
@@ -3352,6 +3351,10 @@ namespace netxs::ui
                 bool round{}; // buff: Is the slide position approximate.
                 bool rolls{}; // buff: The scrollback buffer ring was scrolled.
 
+                buff(term& boss)
+                    : ring{ boss.defcfg.def_length, boss.defcfg.def_growdt, boss.defcfg.def_growmx },
+                      owner{ boss }
+                { }
                 // buff: Decrease height.
                 void dec_height(si32& block_vsize, si32 line_kind, si32 line_size)
                 {
@@ -3494,20 +3497,35 @@ namespace netxs::ui
                 // buff: Remove specified line info from accounting and update metrics based on scroll height.
                 void _clear_line(line& l, bool deallocate)
                 {
-                    if (l.image) 
+                    if (l.get_image_sixel())
                     {
-                        l.image = {};
-                        //for (auto& c : l.cells) 
-                        //{
-                        //    if (auto index = c.get_image_index())
-                        //    {
-                        //        //todo
-                        //        //if (--owner.image_ref_count[index] == 0) 
-                        //        //{
-                        //        //    release index
-                        //        //}
-                        //    }
-                        //}
+                        auto removed_image_indexes = e2::data::image::remove.param();
+                        l.set_image_sixel(faux);
+                        if constexpr (debugmode) log("line with sixels");
+                        for (auto& c : l.cells) 
+                        {
+                            if (auto index = c.get_image_index())
+                            {
+                                if constexpr (debugmode)
+                                {
+                                    if (owner.image_ref_count[index] == 0) 
+                                    {
+                                        log("%%Sixel image ref accounting is broken. Image index=%%", prompt::term, index);
+                                        removed_image_indexes.push_back(index);
+                                        continue;
+                                    }
+                                }
+                                if (--owner.image_ref_count[index] == 0) 
+                                {
+                                    if constexpr (debugmode) log("\trelease sixel image index: ", index);
+                                    removed_image_indexes.push_back(index);
+                                }
+                            }
+                        }
+                        if (removed_image_indexes.size())
+                        {
+                            owner.remove_sixel_images(removed_image_indexes);
+                        }
                     }
                     l.cells.clear();
                     if (deallocate || l.cells.capacity() > 256) // Deallocate long lines (256*sizeof(cell)=10240bytes).
@@ -3661,7 +3679,7 @@ namespace netxs::ui
 
             scroll_buf(term& boss)
                 : bufferbase{ boss },
-                       batch{ boss.defcfg.def_length, boss.defcfg.def_growdt, boss.defcfg.def_growmx },
+                       batch{ boss },
                        index{ 1    },
                        place{      },
                        shore{ boss.defcfg.def_margin }
@@ -5100,6 +5118,7 @@ namespace netxs::ui
                 assert(test_futures());
                 assert(test_coord());
 
+                auto has_sixel = proto.front().get_image_sixel();
                 if (coord.y < y_top)
                 {
                     auto start = coord;
@@ -5126,6 +5145,7 @@ namespace netxs::ui
                         auto tail = dest + count;
                         rich::forward_fill_proc<Copy>(data, dest, tail, fuse);
                     }
+                    upbox.or_image_sixel(has_sixel);
                     // Note: coord can be unsync due to scroll regions.
                 }
                 else if (coord.y <= y_end)
@@ -5135,9 +5155,9 @@ namespace netxs::ui
                     auto  start = batch.caret;
                     batch.caret += count;
                     coord.x     += count;
+                    auto old_state = curln.get_state();
                     if (batch.caret <= panel.x || !curln.wrapped()) // case 0.
                     {
-                        auto old_state = curln.get_state();
                         curln.splice<Copy>(start, count, proto, fuse, brush.spare.spc());
                         auto& mapln = index[coord.y];
                         assert(coord.x % panel.x == batch.caret % panel.x && mapln.index == curln.index);
@@ -5146,6 +5166,7 @@ namespace netxs::ui
                             mapln.width = coord.x;
                             batch.recalc(curln, old_state);
                         }
+                        curln.or_image_sixel(has_sixel);
                     } // case 0 - done.
                     else
                     {
@@ -5165,7 +5186,6 @@ namespace netxs::ui
                         auto curid = curln.index;
                         if (query > 0) // case 3 - complex: Cursor is outside the viewport.
                         {              // cursor overlaps some lines below and placed below the viewport.
-                            auto old_state = curln.get_state();
                             curln.resize(batch.caret, brush.spare.spc());
                             batch.recalc(curln, old_state);
                             if (auto n = (si32)(batch.back().index - curid))
@@ -5211,7 +5231,6 @@ namespace netxs::ui
                         } // case 3 done
                         else
                         {
-                            auto old_state = curln.get_state();
                             auto& mapln = index[coord.y];
                             if (curid == mapln.index) // case 1 - plain: cursor is inside the current paragraph.
                             {
@@ -5292,7 +5311,9 @@ namespace netxs::ui
                                 assert(test_futures());
                             } // case 2 done.
                         }
-                        batch.current().splice<Copy>(start, count, proto, fuse, brush.spare.spc());
+                        auto& final_run = batch.current();
+                        final_run.splice<Copy>(start, count, proto, fuse, brush.spare.spc());
+                        final_run.or_image_sixel(has_sixel);
                     }
                     assert(coord.y >= 0 && coord.y < arena);
                     coord.y += y_top;
@@ -5320,6 +5341,7 @@ namespace netxs::ui
                         rich::unlimit_fill_proc<Copy>(data, size, dest, tail, back, cell::shaders::full);
                     }
                     coord.y = std::min(coord.y + y_end + 1, panel.y - 1);
+                    dnbox.or_image_sixel(has_sixel);
                     // Note: coord can be unsync due to scroll regions.
                 }
                 assert(test_coord());
@@ -7371,6 +7393,24 @@ namespace netxs::ui
             }
         };
 
+        void remove_sixel_image(ui16 removed_image_index, bool notify)
+        {
+            auto images = cell::images(); // Lock.
+            images.remove(removed_image_index);
+            if (notify)
+            {
+                base::signal(tier::general, e2::data::image::remove, { removed_image_index }); // Signal to outside.
+            }
+        }
+        void remove_sixel_images(std::vector<ui16>& removed_image_indexes)
+        {
+            auto images = cell::images(); // Lock.
+            for (auto index : removed_image_indexes)
+            {
+                images.remove(index);
+            }
+            base::signal(tier::general, e2::data::image::remove, removed_image_indexes); // Signal to outside.
+        }
         // term: Take data until ST. Don't touch q if sequence is broken.
         static qiew read_until_st_or_giveup(qiew& q)
         {
@@ -7713,7 +7753,6 @@ namespace netxs::ui
         utf::unordered_map<text, netxs::sptr<imagens::image>> image_cache; // term: Image cache.
         //utf::unordered_map<text, netxs::sptr<imagens::image>> sixel_cache; // term: Sixel cache.
         face                                                  image_buffer; // term: Image temporary buffer.
-        bool                                                  image_alive{ true }; // term: Indicator for whether to clear images in the scrollback.
         std::array<ui64, 65536>                               image_ref_count{}; // term: Each slot contains a count of the number of cells containing an id corresponding to the slot index.
         sixel_t    sixels; // term: Sixel mode state.
         vtty       ipccon; // term: IPC connector. Should be destroyed first.
@@ -7722,6 +7761,7 @@ namespace netxs::ui
         template<class S, class P>
         auto print_block(S& scrollback, core const& block, twod trim_by_viewport, P fuse)
         {
+            auto cells_printed = ui64{};
             auto size = block.size();
             auto head = block.begin();
             auto tail = block.end();
@@ -7730,7 +7770,7 @@ namespace netxs::ui
             if (trim_by_viewport)
             {
                 auto crop = std::min(trim_by_viewport, coor + size) - coor;
-                if (crop.x <= 0 || crop.y <= 0) return;
+                if (crop.x <= 0 || crop.y <= 0) return cells_printed;
                 step = crop.x;
                 tail = head + size.x * crop.y;
             }
@@ -7740,6 +7780,7 @@ namespace netxs::ui
                 auto next = head + step;
                 auto cell_run = std::span(head, next);
                 scrollback.template _data<true>(step, cell_run, fuse);
+                cells_printed += step;
                 head = next + rest;
                 if (head != tail)
                 {
@@ -7751,21 +7792,24 @@ namespace netxs::ui
                     break;
                 }
             }
+            return cells_printed;
         }
         // term: Print specified block (scroll/wrap in normal; crop by the altbuf viewport).
         auto draw_block(core const& image_buffer, auto fx, bool trim_hz = faux, bool trim_vt = faux)
         {
+            auto cells_printed = ui64{};
             if (target == &normal)
             {
                 auto trim_by_viewport = twod{ trim_hz ? target->panel.x : dot_mx.x,
                                               trim_vt ? target->panel.y : dot_mx.y };
-                print_block(normal, image_buffer, trim_by_viewport, fx);
+                cells_printed = print_block(normal, image_buffer, trim_by_viewport, fx);
             }
             else
             {
                 auto& target_buffer = *(alt_screen*)target;
-                print_block(target_buffer, image_buffer, target->panel, fx);
+                cells_printed = print_block(target_buffer, image_buffer, target->panel, fx);
             }
+            return cells_printed;
         }
         // term: Place rectangle block to the scrollback buffer.
         template<class S, class P>
@@ -7813,9 +7857,15 @@ namespace netxs::ui
                     (*head++).set_image_cr(col, row);
                 }
             }
-            //todo image cell accounting
+            auto cells_expected = image_buffer.volume();
+            image_ref_count[image.index] += cells_expected;
+            auto cells_printed = draw_block(image_buffer, cell::shaders::full, true, !decsdm);
+            image_ref_count[image.index] -= cells_expected - cells_printed;
+            if (image_ref_count[image.index] == 0) // A case where nothing is printed.
+            {
+                remove_sixel_image(image.index, faux);
+            }
             //todo respect decsdm (trim image + don't move cursor)
-            draw_block(image_buffer, cell::shaders::full, true, !decsdm);
             data_in("\n\r");
         }
         // term: CSI srcTop ; srcLeft ; srcBottom ; srcRight ; srcBuffIndex ; dstTop ; dstLeft ; dstBuffIndex $ v  — Copy rectangular area (DECCRA). BuffIndex: 1..6, 1 is default index. All coords are 1-based (inclusive).
@@ -8084,7 +8134,8 @@ namespace netxs::ui
                         images.remove(image.index);
                     }
                     image_cache.clear();
-                    base::signal(tier::general, e2::data::image::remove, removed_image_indexes);
+                    base::signal(tier::release, e2::data::image::remove, removed_image_indexes); // Remove image cells from the local scrollback.
+                    base::signal(tier::general, e2::data::image::remove, removed_image_indexes); // Signal to outside.
                     if (io_log) log("%%All registered objects are successfully unregistered (count=%%)", prompt::term, removed_image_indexes.size());
                 }
                 else if (auto iter = image_cache.find(id_str); iter != image_cache.end())
@@ -8094,7 +8145,8 @@ namespace netxs::ui
                     auto removed_image_indexes = e2::data::image::remove.param({ image.index });
                     image_cache.erase(iter);
                     images.remove(image.index);
-                    base::signal(tier::general, e2::data::image::remove, removed_image_indexes);
+                    base::signal(tier::release, e2::data::image::remove, removed_image_indexes); // Remove image cells from the local scrollback.
+                    base::signal(tier::general, e2::data::image::remove, removed_image_indexes); // Signal to outside.
                     if (io_log) log("%%Embedded object '%%' successfully unregistered", prompt::term, image.id);
                 }
             }
@@ -9558,7 +9610,6 @@ namespace netxs::ui
     public:
         ~term()
         {
-            image_alive = faux;
             //if (image_cache.size() || sixel_cache.size()) // Signal to wipe all image references.
             if (image_cache.size()) // Signal to wipe all image references.
             {

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -7581,8 +7581,22 @@ namespace netxs::ui
             }
             return param_count;
         }
-        static text rgba_to_svg(std::vector<argb>& pixels, twod size)
+        static text rgba_to_svg(std::vector<argb>& pixels, twod& size, bool implicit_size, argb transparent_pixel)
         {
+            if (implicit_size) // Trim transparent borders (get minimal non transparent area - dropping right+bottom).
+            {
+                auto data = std::span{ pixels };
+                auto w = size.x;
+                auto get_row = [&](si32 y){ return data.subspan(y * w, w); };
+                auto is_visible = [=](argb p){ return p != transparent_pixel; };
+                auto crop = netxs::get_minimal_area_if<rect>(size, get_row, is_visible);
+                auto raster = netxs::raster{ data, rect{ dot_00, size }};
+                crop.size += std::exchange(crop.coor, dot_00); // Keep Top+Left.
+                auto iter = pixels.begin();
+                netxs::onrect(raster, crop, [&](auto p){ *iter++ = p; }); // Copy crop to the pixels itself (dropping Right+Bottom borders).
+                size = crop.size;
+                pixels.resize(size.x * size.y);
+            }
             for (auto& c : pixels) c.swap_rb();
             auto file_data = std::vector<byte>{};
             file_data.reserve(size.x * size.y);
@@ -7628,7 +7642,8 @@ namespace netxs::ui
                 // n
                 //auto hz_grid_size = params[2];
                 auto size = owner.target->panel * cellsz;
-                size.y *= aspect_ratio;
+                auto implicit_size = true;
+                //size.y *= aspect_ratio; // Don't scale max image size.
                 auto stride = size.x * aspect_ratio * 6;
                 auto palette = owner.ctrack.color; // Copy terminal palette.
                 auto cur_map = 0;
@@ -7731,10 +7746,10 @@ namespace netxs::ui
                         tail = q2.end();
                         auto dy = std::max(1, std::abs(params2[0]));
                         auto dx = std::max(1, std::abs(params2[1]));
-                        size.x = std::clamp(std::abs(params2[2]), 1, std::max(4096, owner.target->panel.x * cellsz.x));
-                        size.y = std::clamp(std::abs(params2[3]), 1, std::max(4096, owner.target->panel.y * cellsz.y));
                         aspect_ratio = (si32)std::round((fp32)dy / dx);
-                        size.y *= aspect_ratio;
+                        size.x = std::clamp(std::abs(params2[2]), 1, std::max(4096, owner.target->panel.x * cellsz.x));
+                        size.y = std::clamp(std::abs(params2[3]) * aspect_ratio, 1, std::max(4096, owner.target->panel.y * cellsz.y));
+                        implicit_size = faux;
                         coor = 0;
                         line = 0;
                         maxx = size.x;
@@ -7778,7 +7793,7 @@ namespace netxs::ui
                 q = qiew{ head, tail };
                 if (ok) // Show image.
                 {
-                    auto doc_str = term::rgba_to_svg(bitmap, size);
+                    auto doc_str = term::rgba_to_svg(bitmap, size, implicit_size, transparency ? argb{} : cur_bgc);
                     auto fp_wh = fp2d{ size } / fp2d{ cellsz };
                     auto wh = twod{ std::ceil(fp_wh) };
                     auto c = owner.target->cell_under_cursor();
@@ -8110,7 +8125,7 @@ namespace netxs::ui
             //       " [attrs] + doc "                Register empty id.
             //       " [id] "                         Find by id and print.
             //       " [id] + attrs "                 Find by id and print applying new attrs.
-            //       " [id] + explicite-empty-doc "   Find by id and unregister. (doc=<tag></tag>)
+            //       " [id] + explicit-empty-doc "    Find by id and unregister. (doc=<tag></tag>)
             while (attrs_str)
             {
                 if (attrs_str.front() == '<') // Extract document body <tag1 ...> ... </tag2>

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -3161,14 +3161,18 @@ namespace netxs::ui
             // alt_screen: Clear all lines below except the current by the current brush . "ED2 Erase viewport" keeps empty lines.
             void del_below() override
             {
-                canvas.del_below2(coord, brush.dry());
+                auto has_sixels = canvas.get_image_sixel();
+                has_sixels ? canvas.del_below2(coord, owner.sixel_decrement_accounting(cell::shaders::full(brush.dry())))
+                           : canvas.del_below2(coord,                                  cell::shaders::full(brush.dry()));
             }
             // alt_screen: Clear all lines from the viewport top line to the current line by the current brush.
             void del_above() override
             {
                 auto coorx = coord.x;
                 if (coorx < panel.x) ++coord.x; // Clear the cell at the current position. See ED1 description.
-                canvas.del_above2(coord, brush.dry());
+                auto has_sixels = canvas.get_image_sixel();
+                has_sixels ? canvas.del_above2(coord, owner.sixel_decrement_accounting(cell::shaders::full(brush.dry())))
+                           : canvas.del_above2(coord,                                  cell::shaders::full(brush.dry()));
                 coord.x = coorx;
             }
             // alt_screen: Shift by n the scroll region.
@@ -3208,7 +3212,9 @@ namespace netxs::ui
                 {
                     scroll_region(0, panel.y - 1, -coord.y);
                 }
-                canvas.del_below2({ 0, 1 }, brush.spare.dry());
+                auto has_sixels = canvas.get_image_sixel();
+                has_sixels ? canvas.del_below2({ 0, 1 }, owner.sixel_decrement_accounting(cell::shaders::full(brush.spare.dry())))
+                           : canvas.del_below2({ 0, 1 },                                  cell::shaders::full(brush.spare.dry()));
                 set_coord({ coord.x, 0 });
             }
             //text get_current_line() override
@@ -5847,7 +5853,9 @@ namespace netxs::ui
                 if (coor.y < y_top)
                 {
                     assert(coor.x + coor.y * upbox.size().x < sctop * upbox.size().x);
-                    upbox.del_below2(coor, blank);
+                    auto has_sixels = upbox.get_image_sixel();
+                    has_sixels ? upbox.del_below2(coor, owner.sixel_decrement_accounting(cell::shaders::full(blank)))
+                               : upbox.del_below2(coor,                                  cell::shaders::full(blank));
                     clear(dot_00);
                 }
                 else if (coor.y <= y_end)
@@ -5860,7 +5868,9 @@ namespace netxs::ui
                 {
                     coor.y -= y_end + 1;
                     assert(coor.x + coor.y * dnbox.size().x < scend * dnbox.size().x);
-                    dnbox.del_below2(coor, blank);
+                    auto has_sixels = dnbox.get_image_sixel();
+                    has_sixels ? dnbox.del_below2(coor, owner.sixel_decrement_accounting(cell::shaders::full(blank)))
+                               : dnbox.del_below2(coor,                                  cell::shaders::full(blank));
                 }
             }
             // scroll_buf: Clear all lines from the viewport top line to the current line.
@@ -5901,7 +5911,9 @@ namespace netxs::ui
                 if (coor.y < y_top)
                 {
                     assert(coor.x + coor.y * upbox.size().x < sctop * upbox.size().x);
-                    upbox.del_above2(coor, blank);
+                    auto has_sixels = upbox.get_image_sixel();
+                    has_sixels ? upbox.del_above2(coor, owner.sixel_decrement_accounting(cell::shaders::full(blank)))
+                               : upbox.del_above2(coor,                                  cell::shaders::full(blank));
                 }
                 else if (coor.y <= y_end)
                 {
@@ -5913,7 +5925,9 @@ namespace netxs::ui
                 {
                     coor.y -= y_end + 1;
                     assert(coor.x + coor.y * dnbox.size().x < scend * dnbox.size().x);
-                    dnbox.del_above2(coor, blank);
+                    auto has_sixels = dnbox.get_image_sixel();
+                    has_sixels ? dnbox.del_above2(coor, owner.sixel_decrement_accounting(cell::shaders::full(blank)))
+                               : dnbox.del_above2(coor,                                  cell::shaders::full(blank));
                     clear(twod{ panel.x , arena - 1 });
                 }
             }

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -2954,7 +2954,9 @@ namespace netxs::ui
                 {
                     wrapup();
                 }
-                canvas.backsp(coord, n, brush.spare.spc());
+                auto has_sixels = canvas.get_image_sixel();
+                has_sixels ? canvas.backsp(coord, n, owner.sixel_decrement_accounting(cell::shaders::full(brush.spare.spc())))
+                           : canvas.backsp(coord, n,                                  cell::shaders::full(brush.spare.spc()));
                 if (coord.y < 0) coord = dot_00;
             }
             void del(si32 n) override

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -2766,7 +2766,17 @@ namespace netxs::ui
                 remove_sixel_images(removed_image_indexes);
             }
         }
-        auto _sixel_decrement_accounting(cell const& dst)
+        void _sixel_inc_accounting(cell const& src)
+        {
+            if (src.get_image_sixel())
+            if (auto index = src.get_image_index())
+            {
+                auto& count = image_ref_count[index];
+                if constexpr (debugmode) log("\tinc image index: %% cell_count: %% -> %%", index, count, count + 1);
+                count++;
+            }
+        }
+        void _sixel_dec_accounting(cell const& dst)
         {
             if (dst.get_image_sixel())
             if (auto index = dst.get_image_index())
@@ -2794,11 +2804,20 @@ namespace netxs::ui
             }
         }
         template<class P = netxs::noop>
-        auto sixel_decrement_accounting(P fx = {})
+        auto sixel_inc_accounting(P fx = {})
+        {
+            return [&, fx](auto& src)
+            {
+                _sixel_inc_accounting(src);
+                fx(src);
+            };
+        }
+        template<class P = netxs::noop>
+        auto sixel_dec_accounting(P fx = {})
         {
             return [&, fx](auto& dst)
             {
-                _sixel_decrement_accounting(dst);
+                _sixel_dec_accounting(dst);
                 fx(dst);
             };
         }
@@ -2806,14 +2825,8 @@ namespace netxs::ui
         {
             return [&, fx](cell& dst, cell const& src)
             {
-                if (src.get_image_sixel())
-                if (auto index = src.get_image_index())
-                {
-                    auto& count = image_ref_count[index];
-                    if constexpr (debugmode) log("\tinc image index: %% cell_count: %% -> %%", index, count, count + 1);
-                    count++;
-                }
-                _sixel_decrement_accounting(dst);
+                _sixel_inc_accounting(src);
+                _sixel_dec_accounting(dst);
                 fx(dst, src);
             };
         }
@@ -2838,27 +2851,11 @@ namespace netxs::ui
             // alt_screen: Resize viewport.
             void resize_viewport(twod new_sz, bool /*forced*/ = faux) override
             {
-                auto old_panel = panel;
                 bufferbase::resize_viewport(new_sz);
-                auto new_panel = panel;
-                auto has_sixels = canvas.get_image_sixel();
-                if (has_sixels)
-                {
-                    if (new_panel.y < old_panel.y) // Check bottom field.
-                    {
-                        auto area = rect{{ 0, new_panel.y }, { old_panel.x, old_panel.y - new_panel.y }};
-                        area.coor += canvas.coor();
-                        netxs::onrect(canvas, area, owner.sixel_decrement_accounting());
-                    }
-                    if (new_panel.x < old_panel.x) // Check right field.
-                    {
-                        auto area = rect{{ new_panel.x, 0 }, { old_panel.x - new_panel.x, std::min(old_panel.y, new_panel.y) }};
-                        area.coor += canvas.coor();
-                        netxs::onrect(canvas, area, owner.sixel_decrement_accounting());
-                    }
-                }
                 coord = std::clamp(coord, dot_00, panel - dot_11);
-                canvas.crop(panel, brush.spare.dry());
+                auto has_sixels = canvas.get_image_sixel();
+                has_sixels ? canvas.crop(panel, brush.spare.dry(), owner.sixel_dec_accounting())
+                           : canvas.crop(panel, brush.spare.dry());
                 if (has_sixels)
                 {
                     has_sixels = faux;
@@ -2923,8 +2920,8 @@ namespace netxs::ui
             {
                 bufferbase::flush();
                 auto has_sixels = canvas.get_image_sixel();
-                has_sixels ? _el(n, canvas, coord, panel, owner.sixel_decrement_accounting(cell::shaders::full(brush.spc()))) // ok
-                           : _el(n, canvas, coord, panel,                                  cell::shaders::full(brush.spc()));
+                has_sixels ? _el(n, canvas, coord, panel, owner.sixel_dec_accounting(cell::shaders::full(brush.spc()))) // ok
+                           : _el(n, canvas, coord, panel,                            cell::shaders::full(brush.spc()));
             }
             // alt_screen: CSI n @  ICH. Insert n colored blanks after cursor. No wrap. Existing chars after cursor shifts to the right. Don't change cursor pos.
             void ins(si32 n) override
@@ -2955,8 +2952,8 @@ namespace netxs::ui
                     wrapup();
                 }
                 auto has_sixels = canvas.get_image_sixel();
-                has_sixels ? canvas.backsp(coord, n, owner.sixel_decrement_accounting(cell::shaders::full(brush.spare.spc())))
-                           : canvas.backsp(coord, n,                                  cell::shaders::full(brush.spare.spc()));
+                has_sixels ? canvas.backsp(coord, n, owner.sixel_dec_accounting(cell::shaders::full(brush.spare.spc())))
+                           : canvas.backsp(coord, n,                            cell::shaders::full(brush.spare.spc()));
                 if (coord.y < 0) coord = dot_00;
             }
             void del(si32 n) override
@@ -2981,16 +2978,17 @@ namespace netxs::ui
                 auto blank = brush;
                 blank.txt(c);
                 auto has_sixels = canvas.get_image_sixel();
-                has_sixels ? canvas.splice3(coord, n, owner.sixel_decrement_accounting(cell::shaders::full(blank)))
-                           : canvas.splice3(coord, n,                                  cell::shaders::full(blank));
+                has_sixels ? canvas.splice3(coord, n, owner.sixel_dec_accounting(cell::shaders::full(blank)))
+                           : canvas.splice3(coord, n,                            cell::shaders::full(blank));
             }
             // alt_screen: Proceed new text using specified cell shader.
-            template<bool Copy = faux, class Span, class Shader>
-            void _data(si32 count, Span const& proto, Shader fuse)
+            template<bool Copy = faux>
+            void _data(si32 count, auto const& proto, auto fuse, bool forceSixelAccounting = faux)
             {
                 assert(coord.y >= 0 && coord.y < panel.y);
 
-                auto add_sixels = proto.front().get_image_sixel();
+                auto add_sixels = forceSixelAccounting ? std::ranges::any_of(proto, [](auto& c){ return c.get_image_sixel(); })
+                                                       : proto.front().get_image_sixel();
                 auto has_sixels = add_sixels || canvas.get_image_sixel();
                 canvas.set_image_sixel(has_sixels);
                 auto start = coord;
@@ -3162,8 +3160,8 @@ namespace netxs::ui
             void del_below() override
             {
                 auto has_sixels = canvas.get_image_sixel();
-                has_sixels ? canvas.del_below2(coord, owner.sixel_decrement_accounting(cell::shaders::full(brush.dry())))
-                           : canvas.del_below2(coord,                                  cell::shaders::full(brush.dry()));
+                has_sixels ? canvas.del_below2(coord, owner.sixel_dec_accounting(cell::shaders::full(brush.dry())))
+                           : canvas.del_below2(coord,                            cell::shaders::full(brush.dry()));
             }
             // alt_screen: Clear all lines from the viewport top line to the current line by the current brush.
             void del_above() override
@@ -3171,8 +3169,8 @@ namespace netxs::ui
                 auto coorx = coord.x;
                 if (coorx < panel.x) ++coord.x; // Clear the cell at the current position. See ED1 description.
                 auto has_sixels = canvas.get_image_sixel();
-                has_sixels ? canvas.del_above2(coord, owner.sixel_decrement_accounting(cell::shaders::full(brush.dry())))
-                           : canvas.del_above2(coord,                                  cell::shaders::full(brush.dry()));
+                has_sixels ? canvas.del_above2(coord, owner.sixel_dec_accounting(cell::shaders::full(brush.dry())))
+                           : canvas.del_above2(coord,                            cell::shaders::full(brush.dry()));
                 coord.x = coorx;
             }
             // alt_screen: Shift by n the scroll region.
@@ -3213,8 +3211,8 @@ namespace netxs::ui
                     scroll_region(0, panel.y - 1, -coord.y);
                 }
                 auto has_sixels = canvas.get_image_sixel();
-                has_sixels ? canvas.del_below2({ 0, 1 }, owner.sixel_decrement_accounting(cell::shaders::full(brush.spare.dry())))
-                           : canvas.del_below2({ 0, 1 },                                  cell::shaders::full(brush.spare.dry()));
+                has_sixels ? canvas.del_below2({ 0, 1 }, owner.sixel_dec_accounting(cell::shaders::full(brush.spare.dry())))
+                           : canvas.del_below2({ 0, 1 },                            cell::shaders::full(brush.spare.dry()));
                 set_coord({ coord.x, 0 });
             }
             //text get_current_line() override
@@ -5005,8 +5003,8 @@ namespace netxs::ui
                     if (count)
                     {
                         auto has_sixels = curln.get_image_sixel();
-                        has_sixels ? curln.splice2<true>(start, count, owner.sixel_decrement_accounting(cell::shaders::full(blank)))
-                                   : curln.splice2<true>(start, count,                                  cell::shaders::full(blank));
+                        has_sixels ? curln.splice2<true>(start, count, owner.sixel_dec_accounting(cell::shaders::full(blank)))
+                                   : curln.splice2<true>(start, count,                            cell::shaders::full(blank));
                         batch.recalc(curln, old_state);
                         width = curln.length();
                         auto& mapln = index[coord.y];
@@ -5023,8 +5021,8 @@ namespace netxs::ui
                 else
                 {
                     auto has_sixels = ctx.block.get_image_sixel();
-                    has_sixels ? alt_screen::_el(n, ctx.block, coord, panel, owner.sixel_decrement_accounting(cell::shaders::full(blank)))
-                               : alt_screen::_el(n, ctx.block, coord, panel,                                  cell::shaders::full(blank));
+                    has_sixels ? alt_screen::_el(n, ctx.block, coord, panel, owner.sixel_dec_accounting(cell::shaders::full(blank)))
+                               : alt_screen::_el(n, ctx.block, coord, panel,                            cell::shaders::full(blank));
                 }
             }
             // scroll_buf: CSI n @  ICH. Insert n colored blanks after cursor. Existing chars after cursor shifts to the right. Don't change cursor pos.
@@ -5195,8 +5193,8 @@ namespace netxs::ui
                     _fwd(-n);
                     auto& curln = batch.current();
                     auto has_sixels = curln.get_image_sixel();
-                    has_sixels ? curln.splice2<faux>(batch.caret, n, owner.sixel_decrement_accounting(cell::shaders::full(brush.spare.spc())))
-                               : curln.splice2<faux>(batch.caret, n,                                  cell::shaders::full(brush.spare.spc()));
+                    has_sixels ? curln.splice2<faux>(batch.caret, n, owner.sixel_dec_accounting(cell::shaders::full(brush.spare.spc())))
+                               : curln.splice2<faux>(batch.caret, n,                            cell::shaders::full(brush.spare.spc()));
                 }
             }
             void del(si32 n) override
@@ -5225,8 +5223,8 @@ namespace netxs::ui
                     //if (c == whitespace) curln.splice2<faux>(batch.caret, n, blank);
                     //else                 curln.splice2<true>(batch.caret, n, blank);
                     auto has_sixels = curln.get_image_sixel();
-                    has_sixels ? curln.splice2<true>(batch.caret, n, owner.sixel_decrement_accounting(cell::shaders::full(blank)))
-                               : curln.splice2<true>(batch.caret, n,                                  cell::shaders::full(blank));
+                    has_sixels ? curln.splice2<true>(batch.caret, n, owner.sixel_dec_accounting(cell::shaders::full(blank)))
+                               : curln.splice2<true>(batch.caret, n,                            cell::shaders::full(blank));
                     batch.recalc(curln, old_state);
                     auto& mapln = index[coord.y];
                     auto  width = curln.length();
@@ -5237,8 +5235,8 @@ namespace netxs::ui
                 else
                 {
                     auto has_sixels = ctx.block.get_image_sixel();
-                    has_sixels ? ctx.block.splice3(coord, n, owner.sixel_decrement_accounting(cell::shaders::full(blank)))
-                               : ctx.block.splice3(coord, n,                                  cell::shaders::full(blank));
+                    has_sixels ? ctx.block.splice3(coord, n, owner.sixel_dec_accounting(cell::shaders::full(blank)))
+                               : ctx.block.splice3(coord, n,                            cell::shaders::full(blank));
                 }
             }
             // scroll_buf: Merge curln with its neighbors.
@@ -5273,16 +5271,17 @@ namespace netxs::ui
                 }
             }
             // scroll_buf: Proceed new text using specified cell shader.
-            template<bool Copy = faux, class Span, class Shader>
-            void _data(si32 count, Span const& proto, Shader fuse)
+            template<bool Copy = faux>
+            void _data(si32 count, auto const& proto, auto fuse, bool forceSixelAccounting = faux)
             {
-                static constexpr auto mixer = !std::is_same_v<Shader, decltype(cell::shaders::full)>;
+                static constexpr auto mixer = !std::is_same_v<decltype(fuse), decltype(cell::shaders::full)>;
 
                 assert(coord.y >= 0 && coord.y < panel.y);
                 assert(test_futures());
                 assert(test_coord());
 
-                auto add_sixels = proto.front().get_image_sixel();
+                auto add_sixels = forceSixelAccounting ? std::ranges::any_of(proto, [](auto& c){ return c.get_image_sixel(); })
+                                                       : proto.front().get_image_sixel();
                 if (coord.y < y_top)
                 {
                     auto has_sixels = add_sixels || upbox.get_image_sixel();
@@ -5834,8 +5833,8 @@ namespace netxs::ui
                         {
                             mapln.width = panel.x;
                             auto x = std::min(coor.x, panel.x); // Trim unwrapped lines by viewport.
-                            has_sixels ? curln.splice2<true>(start + x, panel.x - x, owner.sixel_decrement_accounting(cell::shaders::full(blank)))
-                                       : curln.splice2<true>(start + x, panel.x - x,                                  cell::shaders::full(blank));
+                            has_sixels ? curln.splice2<true>(start + x, panel.x - x, owner.sixel_dec_accounting(cell::shaders::full(blank)))
+                                       : curln.splice2<true>(start + x, panel.x - x,                            cell::shaders::full(blank));
                             new_size = start + panel.x;
                         }
                         else
@@ -5850,7 +5849,7 @@ namespace netxs::ui
                         if (has_sixels)
                         {
                             auto cut = curln.substr(new_size);
-                            std::ranges::for_each(cut, owner.sixel_decrement_accounting());
+                            std::ranges::for_each(cut, owner.sixel_dec_accounting());
                         }
                         curln.trimto(new_size);
                         batch.recalc(curln, old_state);
@@ -5868,8 +5867,8 @@ namespace netxs::ui
                 {
                     assert(coor.x + coor.y * upbox.size().x < sctop * upbox.size().x);
                     auto has_sixels = upbox.get_image_sixel();
-                    has_sixels ? upbox.del_below2(coor, owner.sixel_decrement_accounting(cell::shaders::full(blank)))
-                               : upbox.del_below2(coor,                                  cell::shaders::full(blank));
+                    has_sixels ? upbox.del_below2(coor, owner.sixel_dec_accounting(cell::shaders::full(blank)))
+                               : upbox.del_below2(coor,                            cell::shaders::full(blank));
                     clear(dot_00);
                 }
                 else if (coor.y <= y_end)
@@ -5883,8 +5882,8 @@ namespace netxs::ui
                     coor.y -= y_end + 1;
                     assert(coor.x + coor.y * dnbox.size().x < scend * dnbox.size().x);
                     auto has_sixels = dnbox.get_image_sixel();
-                    has_sixels ? dnbox.del_below2(coor, owner.sixel_decrement_accounting(cell::shaders::full(blank)))
-                               : dnbox.del_below2(coor,                                  cell::shaders::full(blank));
+                    has_sixels ? dnbox.del_below2(coor, owner.sixel_dec_accounting(cell::shaders::full(blank)))
+                               : dnbox.del_below2(coor,                            cell::shaders::full(blank));
                 }
             }
             // scroll_buf: Clear all lines from the viewport top line to the current line.
@@ -5902,8 +5901,8 @@ namespace netxs::ui
                         auto old_state = curln.get_state();
                         mapln.width = panel.x;
                         auto has_sixels = curln.get_image_sixel();
-                        has_sixels ? curln.splice2<true>(mapln.start, panel.x, owner.sixel_decrement_accounting(cell::shaders::full(blank)))
-                                   : curln.splice2<true>(mapln.start, panel.x,                                  cell::shaders::full(blank));
+                        has_sixels ? curln.splice2<true>(mapln.start, panel.x, owner.sixel_dec_accounting(cell::shaders::full(blank)))
+                                   : curln.splice2<true>(mapln.start, panel.x,                            cell::shaders::full(blank));
                         batch.recalc(curln, old_state);
                     }
                     if (from.x > 0)
@@ -5913,8 +5912,8 @@ namespace netxs::ui
                         auto old_state = curln.get_state();
                         mapln.width = std::max(mapln.width, from.x);
                         auto has_sixels = curln.get_image_sixel();
-                        has_sixels ? curln.splice2<true>(mapln.start, from.x, owner.sixel_decrement_accounting(cell::shaders::full(blank)))
-                                   : curln.splice2<true>(mapln.start, from.x,                                  cell::shaders::full(blank));
+                        has_sixels ? curln.splice2<true>(mapln.start, from.x, owner.sixel_dec_accounting(cell::shaders::full(blank)))
+                                   : curln.splice2<true>(mapln.start, from.x,                            cell::shaders::full(blank));
                         batch.recalc(curln, old_state);
                     }
                     upbox.wipe(blank);
@@ -5926,8 +5925,8 @@ namespace netxs::ui
                 {
                     assert(coor.x + coor.y * upbox.size().x < sctop * upbox.size().x);
                     auto has_sixels = upbox.get_image_sixel();
-                    has_sixels ? upbox.del_above2(coor, owner.sixel_decrement_accounting(cell::shaders::full(blank)))
-                               : upbox.del_above2(coor,                                  cell::shaders::full(blank));
+                    has_sixels ? upbox.del_above2(coor, owner.sixel_dec_accounting(cell::shaders::full(blank)))
+                               : upbox.del_above2(coor,                            cell::shaders::full(blank));
                 }
                 else if (coor.y <= y_end)
                 {
@@ -5940,8 +5939,8 @@ namespace netxs::ui
                     coor.y -= y_end + 1;
                     assert(coor.x + coor.y * dnbox.size().x < scend * dnbox.size().x);
                     auto has_sixels = dnbox.get_image_sixel();
-                    has_sixels ? dnbox.del_above2(coor, owner.sixel_decrement_accounting(cell::shaders::full(blank)))
-                               : dnbox.del_above2(coor,                                  cell::shaders::full(blank));
+                    has_sixels ? dnbox.del_above2(coor, owner.sixel_dec_accounting(cell::shaders::full(blank)))
+                               : dnbox.del_above2(coor,                            cell::shaders::full(blank));
                     clear(twod{ panel.x , arena - 1 });
                 }
             }
@@ -5961,7 +5960,7 @@ namespace netxs::ui
                         auto tail = head + start;
                         if (tmpln.get_image_sixel())
                         {
-                            std::ranges::for_each(head, tail, owner.sixel_decrement_accounting());
+                            std::ranges::for_each(head, tail, owner.sixel_dec_accounting());
                         }
                         tmpln.cells.erase(head, tail);
                         batch.recalc(tmpln, old_state);
@@ -8034,9 +8033,8 @@ namespace netxs::ui
                 print_block(target_buffer, image_buffer, target->panel, fx);
             }
         }
-        // term: Place rectangle block to the scrollback buffer.
-        template<class S, class P>
-        auto write_block(S& scrollback, core const& block, twod coor, rect trim, P fuse)
+        // term: Place rectangle block to the scrollback buffer (forced sixel accounting).
+        auto write_block(auto& scrollback, core const& block, twod coor, rect trim, auto fuse, bool forceSixelAccounting)
         {
             auto size = block.size();
             auto clip = block.clip();
@@ -8055,7 +8053,7 @@ namespace netxs::ui
                 auto next = head + clip.size.x;
                 auto cell_run = std::span(head, next);
                 scrollback.cup2(coor);
-                scrollback.template _data<true>(clip.size.x, cell_run, fuse);
+                scrollback.template _data<true>(clip.size.x, cell_run, fuse, forceSixelAccounting);
                 head = next + rest;
                 coor.y++;
             }
@@ -8119,23 +8117,28 @@ namespace netxs::ui
             auto src_area = rect{ dot_00, size };
             area.trimby(src_area);
             fragment.full(src_area);
-            auto empty_cells = cell{}.link(defclr.link());
-            fragment.core::crop(area.size, empty_cells);
+            auto empty_cell = cell{}.link(defclr.link());
+            fragment.core::crop(area.size, empty_cell);
             fragment.core::area(area);
             // Take fragment.
             if (srcBuffIndex == -1) console.do_viewport_copy(fragment);
             else                    netxs::onbody(fragment, pocket[srcBuffIndex], cell::shaders::full);
+            auto has_sixels = faux;
+            fragment.each(sixel_inc_accounting([&](auto& c){ has_sixels = has_sixels || c.get_image_sixel(); }));
             // Put fragment.
             auto coor = twod{ dstLeft, dstTop };
             if (dstBuffIndex == -1) // Dst is real buffer.
             {
                 area.coor = {};
                 fragment.area(area);
-                if (target == &normal) write_block(normal, fragment, coor, src_area, cell::shaders::full);
+                if (target == &normal)
+                {
+                    write_block(normal, fragment, coor, src_area, cell::shaders::full, has_sixels);
+                }
                 else
                 {
                     auto& target_buffer = *(alt_screen*)target;
-                    write_block(target_buffer, fragment, coor, src_area, cell::shaders::full);
+                    write_block(target_buffer, fragment, coor, src_area, cell::shaders::full, has_sixels);
                 }
             }
             else
@@ -8143,9 +8146,10 @@ namespace netxs::ui
                 area.coor = coor;
                 fragment.area(area);
                 auto& dst = pocket[dstBuffIndex];
-                dst.crop(console.panel, empty_cells);
-                dst.plot(fragment, cell::shaders::full);
+                dst.crop(console.panel, empty_cell, sixel_dec_accounting());
+                dst.plot(fragment, sixel_accounting(cell::shaders::full));
             }
+            if (has_sixels) fragment.each(sixel_dec_accounting());
         }
         // term: Set semantic marker (OSC 133).
         void osc_marker(view data)

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -4278,8 +4278,8 @@ namespace netxs::ui
                 // Preserve original content. The app that changed the margins is responsible for updating the content.
                 auto upnew = std::max(upmin, twod{ panel.x, sctop });
                 auto dnnew = std::max(dnmin, twod{ panel.x, scend });
-                upbox.crop(upnew, brush.spare.dry());
-                dnbox.crop(dnnew, brush.spare.dry());
+                upbox.crop(upnew, brush.spare.dry(), owner.sixel_dec_accounting());
+                dnbox.crop(dnnew, brush.spare.dry(), owner.sixel_dec_accounting());
 
                 index.resize(arena); // Use a fixed ring because new lines are added much more often than a futures feed.
                 auto away = batch.basis != batch.slide;
@@ -4647,8 +4647,8 @@ namespace netxs::ui
                 parser::flush();
                 upmin = dot_00;
                 dnmin = dot_00;
-                upbox.crop(upmin);
-                dnbox.crop(dnmin);
+                upbox.crop(upmin, upbox.mark(), owner.sixel_dec_accounting());
+                dnbox.crop(dnmin, dnbox.mark(), owner.sixel_dec_accounting());
                 arena = panel.y;
                 index.resize(arena);
                 index_rebuild();
@@ -4688,19 +4688,22 @@ namespace netxs::ui
                     auto size = (si32)(upto - from);
                     auto tail = head + size;
                     auto area = block.area();
+                    auto has_sixels = faux;
                     block.full(area);
                     block.clip(area);
                     block.ac(origin);
                     do
                     {
                         auto& curln = *head;
-                        block.output(curln, cell::shaders::full);
+                        block.output(curln, owner.sixel_accounting(cell::shaders::full));
+                        has_sixels = has_sixels || curln.get_image_sixel();
                         block.nl(1);
                     }
                     while (++head != tail);
+                    block.or_image_sixel(has_sixels);
                     batch.remove(base, size);
                 };
-                // Return lines to the scrollback iif margin is disabled.
+                // Return lines to the scrollback iif margin is disabled. There is no need to count Sixel cells here, since their number does not change.
                 auto push = [&](face& block, bool at_bottom)
                 {
                     auto size = block.size();

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -3125,7 +3125,7 @@ namespace netxs::ui
                 auto dry_brush = brush.dry(); // ok
                 auto has_sixels = canvas.get_image_sixel();
                 has_sixels ? owner.sixel_run_accounting(canvas, cell::shaders::full(dry_brush))
-                           : canvas.wipe(dry_brush);
+                           : std::fill(canvas.begin(), canvas.end(), dry_brush);
                 canvas.set_image_sixel(faux);
                 set_scroll_region(0, 0);
                 bufferbase::clear_all();

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -2932,7 +2932,9 @@ namespace netxs::ui
                 bufferbase::flush();
                 assert(coord.y < panel.y);
                 assert(coord.x >= 0);
-                canvas.insert2(coord, n, brush.spc());
+                auto has_sixels = canvas.get_image_sixel();
+                has_sixels ? canvas.insert2(coord, n, brush.spc(), owner.sixel_accounting(cell::shaders::full))
+                           : canvas.insert2(coord, n, brush.spc(),                        cell::shaders::full);
             }
             // alt_screen: CSI n P  Delete (not Erase) letters under the cursor by defclr.
             void dch(si32 n) override
@@ -5036,7 +5038,9 @@ namespace netxs::ui
                 }
                 else
                 {
-                    ctx.block.insert2(coord, n, blank);
+                    auto has_sixels = ctx.block.get_image_sixel();
+                    has_sixels ? ctx.block.insert2(coord, n, blank, owner.sixel_accounting(cell::shaders::full))
+                               : ctx.block.insert2(coord, n, blank,                        cell::shaders::full);
                 }
             }
             // scroll_buf: CSI n P  Delete (not Erase) letters under the cursor. Line end is filled by defclr. Length is preserved. No wrapping.

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -3654,7 +3654,7 @@ namespace netxs::ui
                 // buff: Remove specified line info from accounting and update metrics based on scroll height.
                 void _clear_line(line& l, bool deallocate)
                 {
-                    if (auto has_sixels = l.get_image_sixel())
+                    if (l.get_image_sixel())
                     {
                         l.set_image_sixel(faux);
                         owner.sixel_run_accounting(l.cells);
@@ -5368,7 +5368,7 @@ namespace netxs::ui
                         auto curid = curln.index;
                         if (query > 0) // case 3 - complex: Cursor is outside the viewport.
                         {              // cursor overlaps some lines below and placed below the viewport.
-                            curln.resize_if_need(batch.caret, brush.spare.spc());
+                            curln.resize_if_needed(batch.caret, brush.spare.spc());
                             batch.recalc(curln, old_state);
                             if (auto n = (si32)(batch.back().index - curid))
                             {
@@ -5416,7 +5416,7 @@ namespace netxs::ui
                             auto& mapln = index[coord.y];
                             if (curid == mapln.index) // case 1 - plain: cursor is inside the current paragraph.
                             {
-                                curln.resize_if_need(batch.caret, brush.spare.spc());
+                                curln.resize_if_needed(batch.caret, brush.spare.spc());
                                 if (batch.caret - coord.x == mapln.start)
                                 {
                                     if (coord.x > mapln.width)
@@ -5444,12 +5444,12 @@ namespace netxs::ui
 
                                 if constexpr (mixer)
                                 {
-                                    curln.resize_if_need(batch.caret + (si32)shadow.size(), brush.spare.spc());
+                                    curln.resize_if_needed(batch.caret + (si32)shadow.size(), brush.spare.spc());
                                 }
                                 else
                                 {
-                                    has_sixels ? curln.splice6(batch.caret, shadow, owner.sixel_accounting(cell::shaders::full), brush.spare.spc())
-                                               : curln.splice6(batch.caret, shadow,                        cell::shaders::full,  brush.spare.spc());
+                                    has_sixels ? curln.splice1(batch.caret, shadow, owner.sixel_accounting(cell::shaders::full), brush.spare.spc())
+                                               : curln.splice1(batch.caret, shadow,                        cell::shaders::full,  brush.spare.spc());
                                 }
 
                                 batch.recalc(curln, old_state);

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -7685,7 +7685,7 @@ namespace netxs::ui
         bool       insmod; // term: Insert/replace mode.
         bool       decckm; // term: Cursor keys Application(true)/ANSI(faux) mode.
         bool       deccol; // term: Allow to toggle 80/132 window width (DECCOL).
-        bool       decsdm; // term: Sixel Display Mode. On sixel output: Enable scroll(+move text cursor to the beginning of next line after image)/disable scroll(default)(+don't move text cursor and trim sixel image by the scrolling region).
+        bool       decsdm; // term: Sixel Display Mode. On sixel output: Enable scroll(default) (+move text cursor to the beginning of next line after image)/disable scroll (+don't move text cursor and trim sixel image by the scrolling region).
         bool       bpmode; // term: Bracketed paste mode.
         bool       unsync; // term: Viewport is out of sync.
         bool       invert; // term: Inverted rendering (DECSCNM).
@@ -7753,11 +7753,13 @@ namespace netxs::ui
             }
         }
         // term: Print specified block (scroll/wrap in normal; crop by the altbuf viewport).
-        auto draw_block(core const& image_buffer, auto fx)
+        auto draw_block(core const& image_buffer, auto fx, bool trim_hz = faux, bool trim_vt = faux)
         {
             if (target == &normal)
             {
-                print_block(normal, image_buffer, {}, fx);
+                auto trim_by_viewport = twod{ trim_hz ? target->panel.x : dot_mx.x,
+                                              trim_vt ? target->panel.y : dot_mx.y };
+                print_block(normal, image_buffer, trim_by_viewport, fx);
             }
             else
             {
@@ -7812,7 +7814,7 @@ namespace netxs::ui
             }
             //todo image cell accounting
             //todo respect decsdm (trim image + don't move cursor)
-            draw_block(image_buffer, cell::shaders::full);
+            draw_block(image_buffer, cell::shaders::full, true, !decsdm);
             data_in("\n\r");
         }
         // term: CSI srcTop ; srcLeft ; srcBottom ; srcRight ; srcBuffIndex ; dstTop ; dstLeft ; dstBuffIndex $ v  — Copy rectangular area (DECCRA). BuffIndex: 1..6, 1 is default index. All coords are 1-based (inclusive).

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -8652,12 +8652,22 @@ namespace netxs::ui
                 }
             }
         }
+        // term: Reset DECCRA pockets.
+        void reset_pockets()
+        {
+            for (auto& p : pocket)
+            {
+                p.each(sixel_dec_accounting());
+                p.reset_face();
+            }
+        }
         // term: Soft terminal reset (DECSTR).
         void decstr()
         {
             target->parser::flush();
             normal.clear_all();
             altbuf.clear_all();
+            reset_pockets();
             target = &normal;
             invert = faux;
             decckm = faux;

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -2993,8 +2993,8 @@ namespace netxs::ui
                 if (coord.x <= panel.x)//todo styles! || ! curln.wrapped())
                 {
                     auto n = std::min(count, panel.x - std::max(0, start.x));
-                    has_sixels ? canvas.splice<Copy>(start, n, proto, owner.sixel_accounting(fuse))
-                               : canvas.splice<Copy>(start, n, proto,                        fuse);
+                    has_sixels ? canvas.splice5<Copy>(start, n, proto, owner.sixel_accounting(fuse))
+                               : canvas.splice5<Copy>(start, n, proto,                        fuse);
                 }
                 else
                 {
@@ -3021,8 +3021,8 @@ namespace netxs::ui
                         {
                             auto dy = y_end - coord.y;
                             coord.y = y_end;
-                            has_sixels ? canvas.scroll(y_top, y_end + 1, dy, owner.sixel_accounting(cell::shaders::full), brush.spare)
-                                       : canvas.scroll(y_top, y_end + 1, dy,                        cell::shaders::full,  brush.spare);
+                            has_sixels ? canvas.scroll2(y_top, y_end + 1, dy, owner.sixel_accounting(cell::shaders::full), brush.spare)
+                                       : canvas.scroll2(y_top, y_end + 1, dy,                        cell::shaders::full,  brush.spare);
                         }
 
                         auto seek = coord.x + coord.y * panel.x;
@@ -3171,8 +3171,8 @@ namespace netxs::ui
                 seltop.y += n;
                 selend.y += n;
                 auto has_sixels = canvas.get_image_sixel();
-                has_sixels ? canvas.scroll(top, end + 1, n, owner.sixel_accounting(cell::shaders::full), cell{ '\0' }.bgc(brush.bgc()))
-                           : canvas.scroll(top, end + 1, n,                        cell::shaders::full,  cell{ '\0' }.bgc(brush.bgc())); // We use "BCE on scrolling" in altbuf mode only (vim).
+                has_sixels ? canvas.scroll2(top, end + 1, n, owner.sixel_accounting(cell::shaders::full), cell{ '\0' }.bgc(brush.bgc()))
+                           : canvas.scroll2(top, end + 1, n,                        cell::shaders::full,  cell{ '\0' }.bgc(brush.bgc())); // We use "BCE on scrolling" in altbuf mode only (vim).
             }
             // alt_screen: Horizontal tab.
             void tab(si32 n) override
@@ -5269,8 +5269,8 @@ namespace netxs::ui
                     if (coord.x <= panel.x)//todo styles! || ! curln.wrapped())
                     {
                         auto n = std::min(count, panel.x - std::max(0, start.x));
-                        has_sixels ? upbox.splice<Copy>(start, n, proto, owner.sixel_accounting(fuse))
-                                   : upbox.splice<Copy>(start, n, proto,                        fuse);
+                        has_sixels ? upbox.splice5<Copy>(start, n, proto, owner.sixel_accounting(fuse))
+                                   : upbox.splice5<Copy>(start, n, proto,                        fuse);
                     }
                     else
                     {
@@ -5480,8 +5480,8 @@ namespace netxs::ui
                     if (coord.x <= panel.x)//todo styles! || ! curln.wrapped())
                     {
                         auto n = std::min(count, panel.x - std::max(0, start.x));
-                        has_sixels ? dnbox.splice<Copy>(start, n, proto, owner.sixel_accounting(fuse))
-                                   : dnbox.splice<Copy>(start, n, proto,                        fuse);
+                        has_sixels ? dnbox.splice5<Copy>(start, n, proto, owner.sixel_accounting(fuse))
+                                   : dnbox.splice5<Copy>(start, n, proto,                        fuse);
                     }
                     else
                     {

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -3060,8 +3060,8 @@ namespace netxs::ui
                 return canvas.subline2(coord.x + coord.y * panel.x, left_cells);
             }
             // alt_screen: .
-            template<bool Copy, class Span, class Shader>
-            void _data_direct_fill(si32 count, Span const& proto, Shader fuse)
+            template<bool Copy>
+            void _data_direct_fill(si32 count, auto const& proto, auto fuse)
             {
                 auto fill = [&](auto start_iter, auto seek)
                 {
@@ -3074,8 +3074,7 @@ namespace netxs::ui
                 fill(canvas.begin(), coord.x + coord.y * panel.x);
             }
             // alt_screen: Insert new text using the specified cell shader.
-            template<class Span, class Shader>
-            void _data_insert(si32 count, Span const& proto, Shader fuse)
+            void _data_insert(si32 count, auto const& proto, auto fuse)
             {
                 auto next_x = coord.x + count;
                 if (next_x < panel.x)
@@ -5527,8 +5526,8 @@ namespace netxs::ui
                 assert(test_coord());
             }
             // scroll_buf: .
-            template<bool Copy, class Span, class Shader>
-            void _data_direct_fill(si32 count, Span const& proto, Shader fuse)
+            template<bool Copy>
+            void _data_direct_fill(si32 count, auto const& proto, auto fuse)
             {
                 auto fill = [&](auto start_iter, auto seek)
                 {
@@ -5581,8 +5580,7 @@ namespace netxs::ui
                 }
             }
             // scroll_buf: Insert text using the specified cell shader.
-            template<class Span, class Shader>
-            void _data_insert(si32 count, Span const& proto, Shader fuse)
+            void _data_insert(si32 count, auto const& proto, auto fuse)
             {
                 auto next_x = coord.x + count;
                 if (next_x < panel.x)

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -2829,7 +2829,16 @@ namespace netxs::ui
                 fx(dst, src);
             };
         }
-
+        auto sixels_inc(std::span<cell const> fragment)
+        {
+            auto has_sixels = faux;
+            std::ranges::for_each(fragment, this->sixel_inc_accounting([&](auto& c){ has_sixels = has_sixels || c.get_image_sixel(); })); //todo msvc 17.14.30 requires 'this->'
+            return has_sixels;
+        }
+        void sixels_dec(std::span<cell const> fragment)
+        {
+            std::ranges::for_each(fragment, sixel_dec_accounting());
+        }
         // term: Alternate screen buffer implementation.
         struct alt_screen
             : public bufferbase
@@ -3079,12 +3088,16 @@ namespace netxs::ui
                 if (next_x < panel.x)
                 {
                     auto left_cells = panel.x - next_x;
-                    tail_frag = _take_fragment_from_current_coord(left_cells); // Update tail_frag.
-                    _data_direct_fill<faux>(count, proto, fuse);
+                    tail_frag = _take_fragment_from_current_coord(left_cells);
+                    auto has_sixels = owner.sixels_inc(tail_frag.cells);
+
+                    _data_direct_fill<faux>(count, proto, owner.sixel_accounting(fuse));
+
                     coord.x = next_x;
                     if (tail_frag.size())
                     {
-                        _data_direct_fill<true>(tail_frag.length(), tail_frag, fuse);
+                        _data_direct_fill<true>(tail_frag.length(), tail_frag, owner.sixel_accounting(fuse));
+                        if (has_sixels) owner.sixels_dec(tail_frag.cells);
                     }
                 }
                 else
@@ -5585,13 +5598,17 @@ namespace netxs::ui
                 if (next_x < panel.x)
                 {
                     auto left_cells = panel.x - next_x;
-                    tail_frag = _take_fragment_from_current_coord(left_cells); // Update tail_frag.
-                    _data_direct_fill<faux>(count, proto, fuse);
+                    tail_frag = _take_fragment_from_current_coord(left_cells);
+                    auto has_sixels = owner.sixels_inc(tail_frag.cells);
+
+                    _data_direct_fill<faux>(count, proto, owner.sixel_accounting(fuse));
+
                     coord.x = next_x;
                     sync_coord();
                     if (tail_frag.size())
                     {
-                        _data_direct_fill<true>(tail_frag.length(), tail_frag, fuse);
+                        _data_direct_fill<true>(tail_frag.length(), tail_frag, owner.sixel_accounting(fuse));
+                        if (has_sixels) owner.sixels_dec(tail_frag.cells);
                     }
                 }
                 else
@@ -8120,8 +8137,7 @@ namespace netxs::ui
             // Take fragment.
             if (srcBuffIndex == -1) console.do_viewport_copy(fragment);
             else                    netxs::onbody(fragment, pocket[srcBuffIndex], cell::shaders::full);
-            auto has_sixels = faux;
-            fragment.each(sixel_inc_accounting([&](auto& c){ has_sixels = has_sixels || c.get_image_sixel(); }));
+            auto has_sixels = sixels_inc(fragment.pick());
             // Put fragment.
             auto coor = twod{ dstLeft, dstTop };
             if (dstBuffIndex == -1) // Dst is real buffer.
@@ -8146,7 +8162,7 @@ namespace netxs::ui
                 dst.crop(console.panel, empty_cell, sixel_dec_accounting());
                 dst.plot(fragment, sixel_accounting(cell::shaders::full));
             }
-            if (has_sixels) fragment.each(sixel_dec_accounting());
+            if (has_sixels) sixels_dec(fragment.pick());
         }
         // term: Set semantic marker (OSC 133).
         void osc_marker(view data)

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -4279,7 +4279,7 @@ namespace netxs::ui
                 if (curln.wrapped() && batch.caret > curln.length()) // Dangling cursor.
                 {
                     auto old_state = curln.get_state();
-                    curln.crop(batch.caret, brush.spare.dry());
+                    curln.grow_to(batch.caret, brush.spare.dry());
                     batch.recalc(curln, old_state);
                 }
 
@@ -4862,7 +4862,6 @@ namespace netxs::ui
                     if (!wraps || coord.x <= panel.x) // Extend the line if the cursor is inside the viewport.
                     {
                         width = batch.caret;
-                        curln.crop(width, brush.spare.dry());
                     }
                     else // Move coord.x inside viewport for wrapped lines (cursor came from another (unwrapped) line).
                     {
@@ -4870,8 +4869,8 @@ namespace netxs::ui
                         batch.caret = mapln.start + panel.x;
                         mapln.width = panel.x;
                         coord.x = panel.x;
-                        curln.crop(batch.caret, brush.spare.dry());
                     }
+                    curln.grow_to(batch.caret, brush.spare.dry());
                 }
 
                 batch.recalc(curln, old_state);
@@ -5550,7 +5549,7 @@ namespace netxs::ui
                     if (newlen > curln.length())
                     {
                         auto old_state = curln.get_state();
-                        curln.crop(newlen, brush.spare.spc());
+                        curln.grow_to(newlen, brush.spare.spc());
                         auto& mapln = index[coord.y - y_top];
                         mapln.width = newlen % panel.x;
                         batch.recalc(curln, old_state);

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -5038,7 +5038,7 @@ namespace netxs::ui
                     n = std::min(n, panel.x - coord.x);
                     auto& curln = batch.current();
                     auto old_state = curln.get_state();
-                    curln.insert(batch.caret, n, blank, panel.x);
+                    curln.insert4(batch.caret, n, blank, panel.x);
                     batch.recalc(curln, old_state); // Line front is filled by blanks. No wrapping.
                     auto  width = curln.length();
                     auto  wraps = curln.wrapped();
@@ -5062,7 +5062,7 @@ namespace netxs::ui
                 {
                     auto& curln = batch.current();
                     auto old_state = curln.get_state();
-                    curln.cutoff(batch.caret, n, blank, panel.x);
+                    curln.cutoff4(batch.caret, n, blank, panel.x);
                     batch.recalc(curln, old_state);
                 }
                 else
@@ -5248,8 +5248,8 @@ namespace netxs::ui
                 auto splice = [&](auto& cell_run, auto fuse)
                 {
                     //todo respect line alignment
-                    if (cell_run.wrapped()) curln.splice(coor, cell_run,                    fuse, brush.spc());
-                    else                    curln.splice(coor, cell_run.substr(0, panel.x), fuse, brush.spc());
+                    if (cell_run.wrapped()) curln.splice1(coor, cell_run,                    fuse, brush.spc());
+                    else                    curln.splice1(coor, cell_run.substr(0, panel.x), fuse, brush.spc());
                     coor += cell_run.height(panel.x) * panel.x;
                 };
                 if (has_sixels)
@@ -5325,8 +5325,8 @@ namespace netxs::ui
                     auto has_sixels = add_sixels || curln.get_image_sixel();
                     if (batch.caret <= panel.x || !curln.wrapped()) // case 0.
                     {
-                        has_sixels ? curln.splice<Copy>(start, count, proto, owner.sixel_accounting(fuse), brush.spare.spc())
-                                   : curln.splice<Copy>(start, count, proto,                        fuse,  brush.spare.spc());
+                        has_sixels ? curln.splice6<Copy>(start, count, proto, owner.sixel_accounting(fuse), brush.spare.spc())
+                                   : curln.splice6<Copy>(start, count, proto,                        fuse,  brush.spare.spc());
                         auto& mapln = index[coord.y];
                         assert(coord.x % panel.x == batch.caret % panel.x && mapln.index == curln.index);
                         if (coord.x > mapln.width)
@@ -5354,7 +5354,7 @@ namespace netxs::ui
                         auto curid = curln.index;
                         if (query > 0) // case 3 - complex: Cursor is outside the viewport.
                         {              // cursor overlaps some lines below and placed below the viewport.
-                            curln.resize(batch.caret, brush.spare.spc());
+                            curln.resize_if_need(batch.caret, brush.spare.spc());
                             batch.recalc(curln, old_state);
                             if (auto n = (si32)(batch.back().index - curid))
                             {
@@ -5402,7 +5402,7 @@ namespace netxs::ui
                             auto& mapln = index[coord.y];
                             if (curid == mapln.index) // case 1 - plain: cursor is inside the current paragraph.
                             {
-                                curln.resize(batch.caret, brush.spare.spc());
+                                curln.resize_if_need(batch.caret, brush.spare.spc());
                                 if (batch.caret - coord.x == mapln.start)
                                 {
                                     if (coord.x > mapln.width)
@@ -5428,11 +5428,14 @@ namespace netxs::ui
                                 auto  shadow = destln.wrapped() ? destln.substr(mapln.start + coord.x)
                                                                 : destln.substr(mapln.start + coord.x, std::min(panel.x, mapln.width) - coord.x);
 
-                                if constexpr (mixer) curln.resize(batch.caret + (si32)shadow.size(), brush.spare.spc());
+                                if constexpr (mixer)
+                                {
+                                    curln.resize_if_need(batch.caret + (si32)shadow.size(), brush.spare.spc());
+                                }
                                 else
                                 {
-                                    has_sixels ? curln.splice(batch.caret, shadow, owner.sixel_accounting(cell::shaders::full), brush.spare.spc())
-                                               : curln.splice(batch.caret, shadow,                        cell::shaders::full,  brush.spare.spc());
+                                    has_sixels ? curln.splice6(batch.caret, shadow, owner.sixel_accounting(cell::shaders::full), brush.spare.spc())
+                                               : curln.splice6(batch.caret, shadow,                        cell::shaders::full,  brush.spare.spc());
                                 }
 
                                 batch.recalc(curln, old_state);
@@ -5485,8 +5488,8 @@ namespace netxs::ui
                             } // case 2 done.
                         }
                         auto& final_run = batch.current();
-                        has_sixels ? final_run.splice<Copy>(start, count, proto, owner.sixel_accounting(fuse), brush.spare.spc())
-                                   : final_run.splice<Copy>(start, count, proto,                        fuse,  brush.spare.spc());
+                        has_sixels ? final_run.splice6<Copy>(start, count, proto, owner.sixel_accounting(fuse), brush.spare.spc())
+                                   : final_run.splice6<Copy>(start, count, proto,                        fuse,  brush.spare.spc());
                         final_run.set_image_sixel(has_sixels);
                     }
                     assert(coord.y >= 0 && coord.y < arena);
@@ -5958,7 +5961,7 @@ namespace netxs::ui
                     auto& newln = *curit;
                     auto& tmpln = *(curit - 1);
                     newln.reinitialize(tmpln.index, tmpln.get_style(), parser::brush);
-                    newln.splice(0, tmpln.substr(start), cell::shaders::full, brush.spc());
+                    newln.splice1(0, tmpln.substr(start), cell::shaders::full, brush.spc());
                     auto old_state = tmpln.get_state();
                     tmpln.trimto(start);
                     batch.recalc(tmpln, old_state);

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -2796,7 +2796,7 @@ namespace netxs::ui
         template<class P = netxs::noop>
         auto sixel_decrement_accounting(P fx = {})
         {
-            return [&, fx](cell& dst)
+            return [&, fx](auto& dst)
             {
                 _sixel_decrement_accounting(dst);
                 fx(dst);
@@ -5819,9 +5819,11 @@ namespace netxs::ui
                     i = batch.index_by_id(topid); // The index may be outdated due to the ring.
                     auto& curln = batch[i];
                     auto old_state = curln.get_state();
+                    auto has_sixels = curln.get_image_sixel();
+                    auto new_size = 0;
                     if (fresh)
                     {
-                        curln.trimto(start);
+                        new_size = start;
                     }
                     else
                     {
@@ -5830,19 +5832,27 @@ namespace netxs::ui
                         {
                             mapln.width = panel.x;
                             auto x = std::min(coor.x, panel.x); // Trim unwrapped lines by viewport.
-                            auto has_sixels = curln.get_image_sixel();
                             has_sixels ? curln.splice2<true>(start + x, panel.x - x, owner.sixel_decrement_accounting(cell::shaders::full(blank)))
                                        : curln.splice2<true>(start + x, panel.x - x,                                  cell::shaders::full(blank));
-                            curln.trimto(start + panel.x);
+                            new_size = start + panel.x;
                         }
                         else
                         {
                             mapln.width = coor.x;
-                            curln.trimto(start + coor.x);
+                            new_size = start + coor.x;
                         }
                         assert(mapln.start == 0 || curln.wrapped());
                     }
-                    batch.recalc(curln, old_state);
+                    if (new_size < curln.length())
+                    {
+                        if (has_sixels)
+                        {
+                            auto cut = curln.substr(new_size);
+                            std::ranges::for_each(cut, owner.sixel_decrement_accounting());
+                        }
+                        curln.trimto(new_size);
+                        batch.recalc(curln, old_state);
+                    }
 
                     sync_coord();
 

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -2793,17 +2793,18 @@ namespace netxs::ui
                 }
             }
         }
-        auto sixel_decrement_accounting()//(auto fx)
+        template<class P = netxs::noop>
+        auto sixel_decrement_accounting(P fx = {})
         {
-            return [&](cell const& dst)
+            return [&, fx](cell& dst)
             {
                 _sixel_decrement_accounting(dst);
-                //fx(dst);
+                fx(dst);
             };
         }
         auto sixel_accounting(auto fx)
         {
-            return [&](cell& dst, cell const& src)
+            return [&, fx](cell& dst, cell const& src)
             {
                 if (src.get_image_sixel())
                 if (auto index = src.get_image_index())
@@ -2894,7 +2895,7 @@ namespace netxs::ui
                 }
                 else return faux;
             }
-            static void _el(si32 n, core& canvas, twod coord, twod panel, cell const& blank)
+            static void _el(si32 n, core& canvas, twod coord, twod panel, auto fx)
             {
                 assert(coord.y < panel.y);
                 assert(coord.x >= 0);
@@ -2915,13 +2916,15 @@ namespace netxs::ui
                         tail += panel.x;
                         break;
                 }
-                while (head != tail) *head++ = blank;
+                std::ranges::for_each(head, tail, fx);
             }
             // alt_screen: CSI n K  Erase line (don't move cursor).
             void el(si32 n) override
             {
                 bufferbase::flush();
-                _el(n, canvas, coord, panel, brush.spc()); // ok
+                auto has_sixels = canvas.get_image_sixel();
+                has_sixels ? _el(n, canvas, coord, panel, owner.sixel_decrement_accounting(cell::shaders::full(brush.spc()))) // ok
+                           : _el(n, canvas, coord, panel,                                  cell::shaders::full(brush.spc()));
             }
             // alt_screen: CSI n @  ICH. Insert n colored blanks after cursor. No wrap. Existing chars after cursor shifts to the right. Don't change cursor pos.
             void ins(si32 n) override
@@ -2971,7 +2974,9 @@ namespace netxs::ui
                 parser::flush();
                 auto blank = brush;
                 blank.txt(c);
-                canvas.splice(coord, n, blank);
+                auto has_sixels = canvas.get_image_sixel();
+                has_sixels ? canvas.splice3(coord, n, owner.sixel_decrement_accounting(cell::shaders::full(blank)))
+                           : canvas.splice3(coord, n,                                  cell::shaders::full(blank));
             }
             // alt_screen: Proceed new text using specified cell shader.
             template<bool Copy = faux, class Span, class Shader>
@@ -4952,8 +4957,6 @@ namespace netxs::ui
             void el(si32 n) override
             {
                 bufferbase::flush();
-                //todo revise - nul() or dry()
-                //auto blank = brush.dry();
                 auto blank = brush.spc(); // ok
                 if (auto ctx = get_context(coord))
                 {
@@ -4990,8 +4993,9 @@ namespace netxs::ui
                     }
                     if (count)
                     {
-                        curln.splice<true>(start, count, blank);
-
+                        auto has_sixels = curln.get_image_sixel();
+                        has_sixels ? curln.splice2<true>(start, count, owner.sixel_decrement_accounting(cell::shaders::full(blank)))
+                                   : curln.splice2<true>(start, count,                                  cell::shaders::full(blank));
                         batch.recalc(curln, old_state);
                         width = curln.length();
                         auto& mapln = index[coord.y];
@@ -5005,7 +5009,12 @@ namespace netxs::ui
                         //print_batch(" el");
                     }
                 }
-                else alt_screen::_el(n, ctx.block, coord, panel, blank);
+                else
+                {
+                    auto has_sixels = ctx.block.get_image_sixel();
+                    has_sixels ? alt_screen::_el(n, ctx.block, coord, panel, owner.sixel_decrement_accounting(cell::shaders::full(blank)))
+                               : alt_screen::_el(n, ctx.block, coord, panel,                                  cell::shaders::full(blank));
+                }
             }
             // scroll_buf: CSI n @  ICH. Insert n colored blanks after cursor. Existing chars after cursor shifts to the right. Don't change cursor pos.
             void ins(si32 n) override
@@ -5162,7 +5171,9 @@ namespace netxs::ui
                 {
                     _fwd(-n);
                     auto& curln = batch.current();
-                    curln.splice<faux>(batch.caret, n, brush.spare.spc());
+                    auto has_sixels = curln.get_image_sixel();
+                    has_sixels ? curln.splice2<faux>(batch.caret, n, owner.sixel_decrement_accounting(cell::shaders::full(brush.spare.spc())))
+                               : curln.splice2<faux>(batch.caret, n,                                  cell::shaders::full(brush.spare.spc()));
                 }
             }
             void del(si32 n) override
@@ -5188,9 +5199,11 @@ namespace netxs::ui
                     auto& curln = batch.current();
                     auto old_state = curln.get_state();
                     //todo revise (brush != default ? see windows console)
-                    //if (c == whitespace) curln.splice<faux>(batch.caret, n, blank);
-                    //else                 curln.splice<true>(batch.caret, n, blank);
-                    curln.splice<true>(batch.caret, n, blank);
+                    //if (c == whitespace) curln.splice2<faux>(batch.caret, n, blank);
+                    //else                 curln.splice2<true>(batch.caret, n, blank);
+                    auto has_sixels = curln.get_image_sixel();
+                    has_sixels ? curln.splice2<true>(batch.caret, n, owner.sixel_decrement_accounting(cell::shaders::full(blank)))
+                               : curln.splice2<true>(batch.caret, n,                                  cell::shaders::full(blank));
                     batch.recalc(curln, old_state);
                     auto& mapln = index[coord.y];
                     auto  width = curln.length();
@@ -5198,7 +5211,12 @@ namespace netxs::ui
                     mapln.width = wraps ? std::min(panel.x, curln.length() - mapln.start)
                                         : width;
                 }
-                else ctx.block.splice(coord, n, blank);
+                else
+                {
+                    auto has_sixels = ctx.block.get_image_sixel();
+                    has_sixels ? ctx.block.splice3(coord, n, owner.sixel_decrement_accounting(cell::shaders::full(blank)))
+                               : ctx.block.splice3(coord, n,                                  cell::shaders::full(blank));
+                }
             }
             // scroll_buf: Merge curln with its neighbors.
             void _merge(line& curln, si32 oldsz, id_t curid, si32 count, bool has_sixels)
@@ -5788,7 +5806,9 @@ namespace netxs::ui
                         {
                             mapln.width = panel.x;
                             auto x = std::min(coor.x, panel.x); // Trim unwrapped lines by viewport.
-                            curln.splice<true>(start + x, panel.x - x, blank);
+                            auto has_sixels = curln.get_image_sixel();
+                            has_sixels ? curln.splice2<true>(start + x, panel.x - x, owner.sixel_decrement_accounting(cell::shaders::full(blank)))
+                                       : curln.splice2<true>(start + x, panel.x - x,                                  cell::shaders::full(blank));
                             curln.trimto(start + panel.x);
                         }
                         else
@@ -5841,7 +5861,9 @@ namespace netxs::ui
                         auto& curln = batch.item_by_id(mapln.index);
                         auto old_state = curln.get_state();
                         mapln.width = panel.x;
-                        curln.splice<true>(mapln.start, panel.x, blank);
+                        auto has_sixels = curln.get_image_sixel();
+                        has_sixels ? curln.splice2<true>(mapln.start, panel.x, owner.sixel_decrement_accounting(cell::shaders::full(blank)))
+                                   : curln.splice2<true>(mapln.start, panel.x,                                  cell::shaders::full(blank));
                         batch.recalc(curln, old_state);
                     }
                     if (from.x > 0)
@@ -5850,7 +5872,9 @@ namespace netxs::ui
                         auto& curln = batch.item_by_id(mapln.index);
                         auto old_state = curln.get_state();
                         mapln.width = std::max(mapln.width, from.x);
-                        curln.splice<true>(mapln.start, from.x, blank);
+                        auto has_sixels = curln.get_image_sixel();
+                        has_sixels ? curln.splice2<true>(mapln.start, from.x, owner.sixel_decrement_accounting(cell::shaders::full(blank)))
+                                   : curln.splice2<true>(mapln.start, from.x,                                  cell::shaders::full(blank));
                         batch.recalc(curln, old_state);
                     }
                     upbox.wipe(blank);

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -5916,7 +5916,13 @@ namespace netxs::ui
                     {
                         auto& tmpln = batch[after];
                         auto old_state = tmpln.get_state();
-                        tmpln.copy_piece(tmpln, start);
+                        auto head = tmpln.cells.begin();
+                        auto tail = head + start;
+                        if (tmpln.get_image_sixel())
+                        {
+                            std::ranges::for_each(head, tail, owner.sixel_decrement_accounting());
+                        }
+                        tmpln.cells.erase(head, tail);
                         batch.recalc(tmpln, old_state);
                         return;
                     }

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -4731,7 +4731,7 @@ namespace netxs::ui
                         auto proto = std::span{ curit, (size_t)size.x };
                         auto& curln = *batch.ring::insert(start);
                         curln.reinitialize(curid++, new_style, proto);
-                        curln.shrink(block.mark());
+                        curln.trim_blank_cells(block.mark());
                         batch.invite(curln);
                         start += batch.size - oldsz; // Due to circulation in the ring.
                         assert(start <= batch.size);
@@ -5014,7 +5014,7 @@ namespace netxs::ui
                                             : width;
 
                         //auto old_state2 = curln.get_state();
-                        //curln.shrink(blank); //todo revise: It kills wrapped lines and as a result requires the viewport to be rebuilt.
+                        //curln.trim_blank_cells(blank); //todo revise: It kills wrapped lines and as a result requires the viewport to be rebuilt.
                         //batch.recalc(curln, old_state2); //  The cursor may be misplaced when resizing because curln.length is less than batch.caret.
                         //index_rebuild();
                         //print_batch(" el");
@@ -5037,7 +5037,7 @@ namespace netxs::ui
                     n = std::min(n, panel.x - coord.x);
                     auto& curln = batch.current();
                     auto old_state = curln.get_state();
-                    curln.insert4(batch.caret, n, blank, panel.x);
+                    curln.insert_blanks(batch.caret, n, blank, panel.x);
                     batch.recalc(curln, old_state); // Line front is filled by blanks. No wrapping.
                     auto  width = curln.length();
                     auto  wraps = curln.wrapped();
@@ -5061,7 +5061,9 @@ namespace netxs::ui
                 {
                     auto& curln = batch.current();
                     auto old_state = curln.get_state();
-                    curln.cutoff4(batch.caret, n, blank, panel.x);
+                    auto has_sixels = curln.get_image_sixel();
+                    has_sixels ? curln.cutoff4(batch.caret, n, blank, panel.x, owner.sixel_accounting(cell::shaders::full))
+                               : curln.cutoff4(batch.caret, n, blank, panel.x,                        cell::shaders::full);
                     batch.recalc(curln, old_state);
                 }
                 else

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -3051,9 +3051,9 @@ namespace netxs::ui
                 }
             }
             // alt_screen: .
-            void _fragment_from_current_coord(si32 left_cells)
+            auto _take_fragment_from_current_coord(si32 left_cells)
             {
-                canvas.copy_piece(tail_frag, coord.x + coord.y * panel.x, left_cells);
+                return canvas.subline2(coord.x + coord.y * panel.x, left_cells);
             }
             // alt_screen: .
             template<bool Copy, class Span, class Shader>
@@ -3077,7 +3077,7 @@ namespace netxs::ui
                 if (next_x < panel.x)
                 {
                     auto left_cells = panel.x - next_x;
-                    _fragment_from_current_coord(left_cells); // Update tail_frag.
+                    tail_frag = _take_fragment_from_current_coord(left_cells); // Update tail_frag.
                     _data_direct_fill<faux>(count, proto, fuse);
                     coord.x = next_x;
                     if (tail_frag.size())
@@ -5541,21 +5541,21 @@ namespace netxs::ui
                 }
             }
             // scroll_buf: .
-            void _fragment_from_current_coord(si32 left_cells)
+            auto _take_fragment_from_current_coord(si32 left_cells)
             {
                 if (coord.y < y_top)
                 {
-                    upbox.copy_piece(tail_frag, coord.x + coord.y * panel.x, left_cells);
+                    return upbox.subline2(coord.x + coord.y * panel.x, left_cells);
                 }
                 else if (coord.y <= y_end)
                 {
                     auto& curln = batch.current();
                     auto  start = batch.caret;
-                    curln.copy_piece(tail_frag, start, left_cells);
+                    return curln.substr(start, left_cells);
                 }
                 else
                 {
-                    dnbox.copy_piece(tail_frag, coord.x + (coord.y - (y_end + 1)) * panel.x, left_cells);
+                    return dnbox.subline2(coord.x + (coord.y - (y_end + 1)) * panel.x, left_cells);
                 }
             }
             // scroll_buf: Insert text using the specified cell shader.
@@ -5566,7 +5566,7 @@ namespace netxs::ui
                 if (next_x < panel.x)
                 {
                     auto left_cells = panel.x - next_x;
-                    _fragment_from_current_coord(left_cells); // Update tail_frag.
+                    tail_frag = _take_fragment_from_current_coord(left_cells); // Update tail_frag.
                     _data_direct_fill<faux>(count, proto, fuse);
                     coord.x = next_x;
                     sync_coord();

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -2940,7 +2940,9 @@ namespace netxs::ui
             void dch(si32 n) override
             {
                 bufferbase::flush();
-                canvas.cutoff3(coord, n, brush.spare.spc());
+                auto has_sixels = canvas.get_image_sixel();
+                has_sixels ? canvas.cutoff3(coord, n, brush.spare.spc(), owner.sixel_accounting(cell::shaders::full))
+                           : canvas.cutoff3(coord, n, brush.spare.spc(),                        cell::shaders::full);
             }
             // alt_screen: '\x7F'  Delete letter backward.
             void _del(si32 n)
@@ -5055,7 +5057,12 @@ namespace netxs::ui
                     curln.cutoff(batch.caret, n, blank, panel.x);
                     batch.recalc(curln, old_state);
                 }
-                else ctx.block.cutoff3(coord, n, blank);
+                else
+                {
+                    auto has_sixels = ctx.block.get_image_sixel();
+                    has_sixels ? ctx.block.cutoff3(coord, n, blank, owner.sixel_accounting(cell::shaders::full))
+                               : ctx.block.cutoff3(coord, n, blank,                        cell::shaders::full);
+                }
             }
             // scroll_buf: Move internal caret by count with wrapping.
             void _fwd(si32 count)

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -2932,13 +2932,13 @@ namespace netxs::ui
                 bufferbase::flush();
                 assert(coord.y < panel.y);
                 assert(coord.x >= 0);
-                canvas.insert(coord, n, brush.spc());
+                canvas.insert2(coord, n, brush.spc());
             }
             // alt_screen: CSI n P  Delete (not Erase) letters under the cursor by defclr.
             void dch(si32 n) override
             {
                 bufferbase::flush();
-                canvas.cutoff(coord, n, brush.spare.spc());
+                canvas.cutoff3(coord, n, brush.spare.spc());
             }
             // alt_screen: '\x7F'  Delete letter backward.
             void _del(si32 n)
@@ -3155,14 +3155,14 @@ namespace netxs::ui
             // alt_screen: Clear all lines below except the current by the current brush . "ED2 Erase viewport" keeps empty lines.
             void del_below() override
             {
-                canvas.del_below(coord, brush.dry());
+                canvas.del_below2(coord, brush.dry());
             }
             // alt_screen: Clear all lines from the viewport top line to the current line by the current brush.
             void del_above() override
             {
                 auto coorx = coord.x;
                 if (coorx < panel.x) ++coord.x; // Clear the cell at the current position. See ED1 description.
-                canvas.del_above(coord, brush.dry());
+                canvas.del_above2(coord, brush.dry());
                 coord.x = coorx;
             }
             // alt_screen: Shift by n the scroll region.
@@ -3202,7 +3202,7 @@ namespace netxs::ui
                 {
                     scroll_region(0, panel.y - 1, -coord.y);
                 }
-                canvas.del_below({ 0, 1 }, brush.spare.dry());
+                canvas.del_below2({ 0, 1 }, brush.spare.dry());
                 set_coord({ coord.x, 0 });
             }
             //text get_current_line() override
@@ -5034,7 +5034,10 @@ namespace netxs::ui
                     mapln.width = wraps ? std::min(panel.x, width - mapln.start)
                                         : width;
                 }
-                else ctx.block.insert(coord, n, blank);
+                else
+                {
+                    ctx.block.insert2(coord, n, blank);
+                }
             }
             // scroll_buf: CSI n P  Delete (not Erase) letters under the cursor. Line end is filled by defclr. Length is preserved. No wrapping.
             void dch(si32 n) override
@@ -5048,7 +5051,7 @@ namespace netxs::ui
                     curln.cutoff(batch.caret, n, blank, panel.x);
                     batch.recalc(curln, old_state);
                 }
-                else ctx.block.cutoff(coord, n, blank);
+                else ctx.block.cutoff3(coord, n, blank);
             }
             // scroll_buf: Move internal caret by count with wrapping.
             void _fwd(si32 count)
@@ -5831,7 +5834,7 @@ namespace netxs::ui
                 if (coor.y < y_top)
                 {
                     assert(coor.x + coor.y * upbox.size().x < sctop * upbox.size().x);
-                    upbox.del_below(coor, blank);
+                    upbox.del_below2(coor, blank);
                     clear(dot_00);
                 }
                 else if (coor.y <= y_end)
@@ -5844,7 +5847,7 @@ namespace netxs::ui
                 {
                     coor.y -= y_end + 1;
                     assert(coor.x + coor.y * dnbox.size().x < scend * dnbox.size().x);
-                    dnbox.del_below(coor, blank);
+                    dnbox.del_below2(coor, blank);
                 }
             }
             // scroll_buf: Clear all lines from the viewport top line to the current line.
@@ -5885,7 +5888,7 @@ namespace netxs::ui
                 if (coor.y < y_top)
                 {
                     assert(coor.x + coor.y * upbox.size().x < sctop * upbox.size().x);
-                    upbox.del_above(coor, blank);
+                    upbox.del_above2(coor, blank);
                 }
                 else if (coor.y <= y_end)
                 {
@@ -5897,7 +5900,7 @@ namespace netxs::ui
                 {
                     coor.y -= y_end + 1;
                     assert(coor.x + coor.y * dnbox.size().x < scend * dnbox.size().x);
-                    dnbox.del_above(coor, blank);
+                    dnbox.del_above2(coor, blank);
                     clear(twod{ panel.x , arena - 1 });
                 }
             }

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -7801,6 +7801,7 @@ namespace netxs::ui
                 .txt(" ", 1, 1, 1, 1)
                 .set_image_index(image.index)
                 .set_image_stamp(image.stamp)
+                .set_image_sixel(true)
                 .set_image_WH(wh.x, wh.y)
                 .set_image_ontop(faux);
             image_buffer.core::size<true>(wh, brush);

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -2633,8 +2633,7 @@ namespace netxs::ui
             // bufferbase: Clear scrollback keeping current line.
     virtual void clear_scrollback() = 0;
             // bufferbase: Proceed 2d text.
-            template<class Span>
-            void data_2d(twod block_size, Span const& proto, auto print_stripe)
+            void data_2d(twod block_size, std::span<cell const> proto, auto print_stripe)
             {
                 assert(block_size.y > 1);
                 char_2d.unpack2d(proto, block_size);
@@ -2983,7 +2982,7 @@ namespace netxs::ui
             }
             // alt_screen: Proceed new text using specified cell shader.
             template<bool Copy = faux>
-            void _data(si32 count, auto const& proto, auto fuse, bool forceSixelAccounting = faux)
+            void _data(si32 count, std::span<cell const> proto, auto fuse, bool forceSixelAccounting = faux)
             {
                 assert(coord.y >= 0 && coord.y < panel.y);
 
@@ -3061,7 +3060,7 @@ namespace netxs::ui
             }
             // alt_screen: .
             template<bool Copy>
-            void _data_direct_fill(si32 count, auto const& proto, auto fuse)
+            void _data_direct_fill(si32 count, std::span<cell const> proto, auto fuse)
             {
                 auto fill = [&](auto start_iter, auto seek)
                 {
@@ -3074,7 +3073,7 @@ namespace netxs::ui
                 fill(canvas.begin(), coord.x + coord.y * panel.x);
             }
             // alt_screen: Insert new text using the specified cell shader.
-            void _data_insert(si32 count, auto const& proto, auto fuse)
+            void _data_insert(si32 count, std::span<cell const> proto, auto fuse)
             {
                 auto next_x = coord.x + count;
                 if (next_x < panel.x)
@@ -3100,7 +3099,7 @@ namespace netxs::ui
                 _del(w);
             }
             // alt_screen: Parser callback.
-            void data(si32 width, si32 height, core::body const& proto) override
+            void data(si32 width, si32 height, std::span<cell const> proto) override
             {
                 if (width)
                 {
@@ -5271,7 +5270,7 @@ namespace netxs::ui
             }
             // scroll_buf: Proceed new text using specified cell shader.
             template<bool Copy = faux>
-            void _data(si32 count, auto const& proto, auto fuse, bool forceSixelAccounting = faux)
+            void _data(si32 count, std::span<cell const> proto, auto fuse, bool forceSixelAccounting = faux)
             {
                 static constexpr auto mixer = !std::is_same_v<decltype(fuse), decltype(cell::shaders::full)>;
 
@@ -5527,7 +5526,7 @@ namespace netxs::ui
             }
             // scroll_buf: .
             template<bool Copy>
-            void _data_direct_fill(si32 count, auto const& proto, auto fuse)
+            void _data_direct_fill(si32 count, std::span<cell const> proto, auto fuse)
             {
                 auto fill = [&](auto start_iter, auto seek)
                 {
@@ -5580,7 +5579,7 @@ namespace netxs::ui
                 }
             }
             // scroll_buf: Insert text using the specified cell shader.
-            void _data_insert(si32 count, auto const& proto, auto fuse)
+            void _data_insert(si32 count, std::span<cell const> proto, auto fuse)
             {
                 auto next_x = coord.x + count;
                 if (next_x < panel.x)
@@ -5607,7 +5606,7 @@ namespace netxs::ui
                 _del(w);
             }
             // scroll_buf: Proceed new text (parser callback).
-            void data(si32 width, si32 height, core::body const& proto) override
+            void data(si32 width, si32 height, std::span<cell const> proto) override
             {
                 if (width)
                 {

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -2732,6 +2732,91 @@ namespace netxs::ui
             }
         };
 
+        template<class P = netxs::noop>
+        void sixel_run_accounting(std::span<cell> cell_run, P fx = {})
+        {
+            auto removed_image_indexes = e2::data::image::remove.param();
+            if constexpr (debugmode) log("line with sixels");
+            for (auto& c : cell_run)
+            {
+                auto index = c.get_image_index();
+                fx(c);
+                if (index)
+                {
+                    auto& count = image_ref_count[index];
+                    if constexpr (debugmode)
+                    {
+                        log("\tdtor dec image index: %% cell_count: %% -> %%", index, count, count - 1);
+                        if (count == 0)
+                        {
+                            log("Sixel image ref accounting is broken");
+                            removed_image_indexes.push_back(index);
+                            continue;
+                        }
+                    }
+                    if (--count == 0)
+                    {
+                        if constexpr (debugmode) log("\trelease sixel image index: ", index);
+                        removed_image_indexes.push_back(index);
+                    }
+                }
+            }
+            if (removed_image_indexes.size())
+            {
+                remove_sixel_images(removed_image_indexes);
+            }
+        }
+        auto _sixel_decrement_accounting(cell const& dst)
+        {
+            if (dst.get_image_sixel())
+            if (auto index = dst.get_image_index())
+            {
+                auto& count = image_ref_count[index];
+                if constexpr (debugmode)
+                {
+                    log("\tdec image index: %% cell_count: %% -> %%", index, count, count - 1);
+                    if (count == 0)
+                    {
+                        log("%%Sixel image ref accounting is broken. Image index=%%", prompt::term, index);
+                        remove_sixel_image(index, true);
+                    }
+                    else if (--count == 0)
+                    {
+                        log("\trelease sixel image index: ", index);
+                        remove_sixel_image(index, true);
+                    }
+                }
+                else if (--count == 0)
+                {
+                    if constexpr (debugmode) log("\trelease sixel image index: ", index);
+                    remove_sixel_image(index, true);
+                }
+            }
+        }
+        auto sixel_decrement_accounting()//(auto fx)
+        {
+            return [&](cell const& dst)
+            {
+                _sixel_decrement_accounting(dst);
+                //fx(dst);
+            };
+        }
+        auto sixel_accounting(auto fx)
+        {
+            return [&](cell& dst, cell const& src)
+            {
+                if (src.get_image_sixel())
+                if (auto index = src.get_image_index())
+                {
+                    auto& count = image_ref_count[index];
+                    if constexpr (debugmode) log("\tinc image index: %% cell_count: %% -> %%", index, count, count + 1);
+                    count++;
+                }
+                _sixel_decrement_accounting(dst);
+                fx(dst, src);
+            };
+        }
+
         // term: Alternate screen buffer implementation.
         struct alt_screen
             : public bufferbase
@@ -2752,9 +2837,43 @@ namespace netxs::ui
             // alt_screen: Resize viewport.
             void resize_viewport(twod new_sz, bool /*forced*/ = faux) override
             {
+                auto old_panel = panel;
                 bufferbase::resize_viewport(new_sz);
+                auto new_panel = panel;
+                auto has_sixels = canvas.get_image_sixel();
+                if (has_sixels)
+                {
+                    if (new_panel.y < old_panel.y) // Check bottom field.
+                    {
+                        auto area = rect{{ 0, new_panel.y }, { old_panel.x, old_panel.y - new_panel.y }};
+                        area.coor += canvas.coor();
+                        netxs::onrect(canvas, area, owner.sixel_decrement_accounting());
+                    }
+                    if (new_panel.x < old_panel.x) // Check right field.
+                    {
+                        auto area = rect{{ new_panel.x, 0 }, { old_panel.x - new_panel.x, std::min(old_panel.y, new_panel.y) }};
+                        area.coor += canvas.coor();
+                        netxs::onrect(canvas, area, owner.sixel_decrement_accounting());
+                    }
+                }
                 coord = std::clamp(coord, dot_00, panel - dot_11);
                 canvas.crop(panel, brush.spare.dry());
+                if (has_sixels)
+                {
+                    has_sixels = faux;
+                    auto area = canvas.area();
+                    netxs::onrect(canvas, area, [&](auto& c)
+                    {
+                        if (c.get_image_sixel())
+                        {
+                            has_sixels = true;
+                            return true;
+                        }
+                        else return faux;
+                    });
+                    if constexpr (debugmode) if (!has_sixels) log("All sixels are released");
+                    canvas.set_image_sixel(has_sixels);
+                }
             }
             // alt_screen: Return viewport height.
             si32 height() override
@@ -2860,15 +2979,17 @@ namespace netxs::ui
             {
                 assert(coord.y >= 0 && coord.y < panel.y);
 
-                auto has_sixel = proto.front().get_image_sixel();
-                canvas.or_image_sixel(has_sixel);
+                auto add_sixels = proto.front().get_image_sixel();
+                auto has_sixels = add_sixels || canvas.get_image_sixel();
+                canvas.set_image_sixel(has_sixels);
                 auto start = coord;
                 coord.x += count;
                 //todo apply line adjusting (necessity is not clear)
                 if (coord.x <= panel.x)//todo styles! || ! curln.wrapped())
                 {
                     auto n = std::min(count, panel.x - std::max(0, start.x));
-                    canvas.splice<Copy>(start, n, proto, fuse);
+                    has_sixels ? canvas.splice<Copy>(start, n, proto, owner.sixel_accounting(fuse))
+                               : canvas.splice<Copy>(start, n, proto,                        fuse);
                 }
                 else
                 {
@@ -2886,7 +3007,8 @@ namespace netxs::ui
                         auto seek = start.x + start.y * panel.x;
                         auto dest = canvas.begin() + seek;
                         auto tail = dest + count;
-                        rich::forward_fill_proc<Copy>(data, dest, tail, fuse);
+                        has_sixels ? rich::forward_fill_proc<Copy>(data, dest, tail, owner.sixel_accounting(fuse))
+                                   : rich::forward_fill_proc<Copy>(data, dest, tail,                        fuse);
                     }
                     else if (start.y <= y_end)
                     {
@@ -2894,7 +3016,8 @@ namespace netxs::ui
                         {
                             auto dy = y_end - coord.y;
                             coord.y = y_end;
-                            canvas.scroll(y_top, y_end + 1, dy, brush.spare);
+                            has_sixels ? canvas.scroll(y_top, y_end + 1, dy, owner.sixel_accounting(cell::shaders::full), brush.spare)
+                                       : canvas.scroll(y_top, y_end + 1, dy,                        cell::shaders::full,  brush.spare);
                         }
 
                         auto seek = coord.x + coord.y * panel.x;
@@ -2904,7 +3027,8 @@ namespace netxs::ui
                         auto dest = canvas.begin() + seek;
                         auto tail = dest - count;
                         auto data = proto.end();
-                        rich::reverse_fill_proc<Copy>(data, dest, tail, fuse);
+                        has_sixels ? rich::reverse_fill_proc<Copy>(data, dest, tail, owner.sixel_accounting(fuse))
+                                   : rich::reverse_fill_proc<Copy>(data, dest, tail,                        fuse);
                     }
                     else
                     {
@@ -2916,7 +3040,8 @@ namespace netxs::ui
                         auto dest = canvas.begin() + seek;
                         auto tail = canvas.end();
                         auto back = panel.x;
-                        rich::unlimit_fill_proc<Copy>(data, size, dest, tail, back, fuse);
+                        has_sixels ? rich::unlimit_fill_proc<Copy>(data, size, dest, tail, back, owner.sixel_accounting(fuse))
+                                   : rich::unlimit_fill_proc<Copy>(data, size, dest, tail, back,                        fuse);
                     }
                 }
             }
@@ -2986,7 +3111,11 @@ namespace netxs::ui
             void clear_all() override
             {
                 parser::flush();
-                canvas.wipe(brush.dry()); // ok
+                auto dry_brush = brush.dry(); // ok
+                auto has_sixels = canvas.get_image_sixel();
+                has_sixels ? owner.sixel_run_accounting(canvas, cell::shaders::full(dry_brush))
+                           : canvas.wipe(dry_brush);
+                canvas.set_image_sixel(faux);
                 set_scroll_region(0, 0);
                 bufferbase::clear_all();
             }
@@ -3036,7 +3165,9 @@ namespace netxs::ui
             {
                 seltop.y += n;
                 selend.y += n;
-                canvas.scroll(top, end + 1, n, cell{ '\0' }.bgc(brush.bgc())); // We use "BCE on scrolling" in altbuf mode only (vim).
+                auto has_sixels = canvas.get_image_sixel();
+                has_sixels ? canvas.scroll(top, end + 1, n, owner.sixel_accounting(cell::shaders::full), cell{ '\0' }.bgc(brush.bgc()))
+                           : canvas.scroll(top, end + 1, n,                        cell::shaders::full,  cell{ '\0' }.bgc(brush.bgc())); // We use "BCE on scrolling" in altbuf mode only (vim).
             }
             // alt_screen: Horizontal tab.
             void tab(si32 n) override
@@ -3497,35 +3628,10 @@ namespace netxs::ui
                 // buff: Remove specified line info from accounting and update metrics based on scroll height.
                 void _clear_line(line& l, bool deallocate)
                 {
-                    if (l.get_image_sixel())
+                    if (auto has_sixels = l.get_image_sixel())
                     {
-                        auto removed_image_indexes = e2::data::image::remove.param();
                         l.set_image_sixel(faux);
-                        if constexpr (debugmode) log("line with sixels");
-                        for (auto& c : l.cells) 
-                        {
-                            if (auto index = c.get_image_index())
-                            {
-                                if constexpr (debugmode)
-                                {
-                                    if (owner.image_ref_count[index] == 0) 
-                                    {
-                                        log("%%Sixel image ref accounting is broken. Image index=%%", prompt::term, index);
-                                        removed_image_indexes.push_back(index);
-                                        continue;
-                                    }
-                                }
-                                if (--owner.image_ref_count[index] == 0) 
-                                {
-                                    if constexpr (debugmode) log("\trelease sixel image index: ", index);
-                                    removed_image_indexes.push_back(index);
-                                }
-                            }
-                        }
-                        if (removed_image_indexes.size())
-                        {
-                            owner.remove_sixel_images(removed_image_indexes);
-                        }
+                        owner.sixel_run_accounting(l.cells);
                     }
                     l.cells.clear();
                     if (deallocate || l.cells.capacity() > 256) // Deallocate long lines (256*sizeof(cell)=10240bytes).
@@ -5095,17 +5201,34 @@ namespace netxs::ui
                 else ctx.block.splice(coord, n, blank);
             }
             // scroll_buf: Merge curln with its neighbors.
-            void _merge(line& curln, si32 oldsz, id_t curid, si32 count)
+            void _merge(line& curln, si32 oldsz, id_t curid, si32 count, bool has_sixels)
             {
                 auto coor = oldsz + panel.x - (oldsz - 1) % panel.x - 1;
                 auto iter = batch.iter_by_id(curid);
-                while (count-- > 0)
+                auto splice = [&](auto& cell_run, auto fuse)
                 {
-                    auto& cell_run = *++iter;
                     //todo respect line alignment
-                    if (cell_run.wrapped()) curln.splice(coor, cell_run                   , cell::shaders::full, brush.spc());
-                    else                    curln.splice(coor, cell_run.substr(0, panel.x), cell::shaders::full, brush.spc());
+                    if (cell_run.wrapped()) curln.splice(coor, cell_run,                    fuse, brush.spc());
+                    else                    curln.splice(coor, cell_run.substr(0, panel.x), fuse, brush.spc());
                     coor += cell_run.height(panel.x) * panel.x;
+                };
+                if (has_sixels)
+                {
+                    while (count-- > 0)
+                    {
+                        auto& cell_run = *++iter;
+                        splice(cell_run, owner.sixel_accounting(cell::shaders::full));
+                    }
+                }
+                else
+                {
+                    while (count-- > 0)
+                    {
+                        auto& cell_run = *++iter;
+                        auto run_has_sixels = cell_run.get_image_sixel();
+                        run_has_sixels ? splice(cell_run, owner.sixel_accounting(cell::shaders::full))
+                                       : splice(cell_run,                        cell::shaders::full);
+                    }
                 }
             }
             // scroll_buf: Proceed new text using specified cell shader.
@@ -5118,16 +5241,18 @@ namespace netxs::ui
                 assert(test_futures());
                 assert(test_coord());
 
-                auto has_sixel = proto.front().get_image_sixel();
+                auto add_sixels = proto.front().get_image_sixel();
                 if (coord.y < y_top)
                 {
+                    auto has_sixels = add_sixels || upbox.get_image_sixel();
                     auto start = coord;
                     coord.x += count;
                     //todo apply line adjusting (necessity is not clear)
                     if (coord.x <= panel.x)//todo styles! || ! curln.wrapped())
                     {
                         auto n = std::min(count, panel.x - std::max(0, start.x));
-                        upbox.splice<Copy>(start, n, proto, fuse);
+                        has_sixels ? upbox.splice<Copy>(start, n, proto, owner.sixel_accounting(fuse))
+                                   : upbox.splice<Copy>(start, n, proto,                        fuse);
                     }
                     else
                     {
@@ -5143,9 +5268,10 @@ namespace netxs::ui
                         auto seek = start.x + start.y * panel.x;
                         auto dest = upbox.begin() + seek;
                         auto tail = dest + count;
-                        rich::forward_fill_proc<Copy>(data, dest, tail, fuse);
+                        has_sixels ? rich::forward_fill_proc<Copy>(data, dest, tail, owner.sixel_accounting(fuse))
+                                   : rich::forward_fill_proc<Copy>(data, dest, tail,                        fuse);
                     }
-                    upbox.or_image_sixel(has_sixel);
+                    upbox.set_image_sixel(has_sixels);
                     // Note: coord can be unsync due to scroll regions.
                 }
                 else if (coord.y <= y_end)
@@ -5156,9 +5282,11 @@ namespace netxs::ui
                     batch.caret += count;
                     coord.x     += count;
                     auto old_state = curln.get_state();
+                    auto has_sixels = add_sixels || curln.get_image_sixel();
                     if (batch.caret <= panel.x || !curln.wrapped()) // case 0.
                     {
-                        curln.splice<Copy>(start, count, proto, fuse, brush.spare.spc());
+                        has_sixels ? curln.splice<Copy>(start, count, proto, owner.sixel_accounting(fuse), brush.spare.spc())
+                                   : curln.splice<Copy>(start, count, proto,                        fuse,  brush.spare.spc());
                         auto& mapln = index[coord.y];
                         assert(coord.x % panel.x == batch.caret % panel.x && mapln.index == curln.index);
                         if (coord.x > mapln.width)
@@ -5166,7 +5294,7 @@ namespace netxs::ui
                             mapln.width = coord.x;
                             batch.recalc(curln, old_state);
                         }
-                        curln.or_image_sixel(has_sixel);
+                        curln.set_image_sixel(has_sixels);
                     } // case 0 - done.
                     else
                     {
@@ -5190,7 +5318,7 @@ namespace netxs::ui
                             batch.recalc(curln, old_state);
                             if (auto n = (si32)(batch.back().index - curid))
                             {
-                                if constexpr (mixer) _merge(curln, oldsz, curid, n);
+                                if constexpr (mixer) _merge(curln, oldsz, curid, n, has_sixels);
                                 assert(n > 0);
                                 while (n-- > 0) batch.pop_back();
                             }
@@ -5255,19 +5383,24 @@ namespace netxs::ui
                             else // case 2 - fusion: cursor overlaps lines below but stays inside the viewport.
                             {
                                 auto& destln = batch.item_by_id(mapln.index);
+                                has_sixels = has_sixels || destln.get_image_sixel();
                                 //todo respect destln alignment
                                 auto  shadow = destln.wrapped() ? destln.substr(mapln.start + coord.x)
                                                                 : destln.substr(mapln.start + coord.x, std::min(panel.x, mapln.width) - coord.x);
 
                                 if constexpr (mixer) curln.resize(batch.caret + (si32)shadow.size(), brush.spare.spc());
-                                else                 curln.splice(batch.caret, shadow, cell::shaders::full, brush.spare.spc());
+                                else
+                                {
+                                    has_sixels ? curln.splice(batch.caret, shadow, owner.sixel_accounting(cell::shaders::full), brush.spare.spc())
+                                               : curln.splice(batch.caret, shadow,                        cell::shaders::full,  brush.spare.spc());
+                                }
 
                                 batch.recalc(curln, old_state);
                                 auto w = curln.length();
                                 auto spoil = (si32)(mapln.index - curid);
                                 assert(spoil > 0);
 
-                                if constexpr (mixer) _merge(curln, oldsz, curid, spoil);
+                                if constexpr (mixer) _merge(curln, oldsz, curid, spoil, has_sixels);
 
                                 auto after = batch.index() + 1;
                                 spoil = batch.remove(after, spoil);
@@ -5312,8 +5445,9 @@ namespace netxs::ui
                             } // case 2 done.
                         }
                         auto& final_run = batch.current();
-                        final_run.splice<Copy>(start, count, proto, fuse, brush.spare.spc());
-                        final_run.or_image_sixel(has_sixel);
+                        has_sixels ? final_run.splice<Copy>(start, count, proto, owner.sixel_accounting(fuse), brush.spare.spc())
+                                   : final_run.splice<Copy>(start, count, proto,                        fuse,  brush.spare.spc());
+                        final_run.set_image_sixel(has_sixels);
                     }
                     assert(coord.y >= 0 && coord.y < arena);
                     coord.y += y_top;
@@ -5323,11 +5457,13 @@ namespace netxs::ui
                     coord.y -= y_end + 1;
                     auto start = coord;
                     coord.x += count;
+                    auto has_sixels = add_sixels || dnbox.get_image_sixel();
                     //todo apply line adjusting
                     if (coord.x <= panel.x)//todo styles! || ! curln.wrapped())
                     {
                         auto n = std::min(count, panel.x - std::max(0, start.x));
-                        dnbox.splice<Copy>(start, n, proto, fuse);
+                        has_sixels ? dnbox.splice<Copy>(start, n, proto, owner.sixel_accounting(fuse))
+                                   : dnbox.splice<Copy>(start, n, proto,                        fuse);
                     }
                     else
                     {
@@ -5338,10 +5474,11 @@ namespace netxs::ui
                         auto dest = dnbox.begin() + seek;
                         auto tail = dnbox.end();
                         auto back = panel.x;
-                        rich::unlimit_fill_proc<Copy>(data, size, dest, tail, back, cell::shaders::full);
+                        has_sixels ? rich::unlimit_fill_proc<Copy>(data, size, dest, tail, back, owner.sixel_accounting(cell::shaders::full))
+                                   : rich::unlimit_fill_proc<Copy>(data, size, dest, tail, back,                        cell::shaders::full);
                     }
                     coord.y = std::min(coord.y + y_end + 1, panel.y - 1);
-                    dnbox.or_image_sixel(has_sixel);
+                    dnbox.set_image_sixel(has_sixels);
                     // Note: coord can be unsync due to scroll regions.
                 }
                 assert(test_coord());
@@ -7396,6 +7533,7 @@ namespace netxs::ui
         void remove_sixel_image(ui16 removed_image_index, bool notify)
         {
             auto images = cell::images(); // Lock.
+            image_sixel_count--;
             images.remove(removed_image_index);
             if (notify)
             {
@@ -7754,6 +7892,7 @@ namespace netxs::ui
         //utf::unordered_map<text, netxs::sptr<imagens::image>> sixel_cache; // term: Sixel cache.
         face                                                  image_buffer; // term: Image temporary buffer.
         std::array<ui64, 65536>                               image_ref_count{}; // term: Each slot contains a count of the number of cells containing an id corresponding to the slot index.
+        ui16                                                  image_sixel_count{}; // term: Registered sixel image count;
         sixel_t    sixels; // term: Sixel mode state.
         vtty       ipccon; // term: IPC connector. Should be destroyed first.
 
@@ -7761,7 +7900,6 @@ namespace netxs::ui
         template<class S, class P>
         auto print_block(S& scrollback, core const& block, twod trim_by_viewport, P fuse)
         {
-            auto cells_printed = ui64{};
             auto size = block.size();
             auto head = block.begin();
             auto tail = block.end();
@@ -7770,7 +7908,7 @@ namespace netxs::ui
             if (trim_by_viewport)
             {
                 auto crop = std::min(trim_by_viewport, coor + size) - coor;
-                if (crop.x <= 0 || crop.y <= 0) return cells_printed;
+                if (crop.x <= 0 || crop.y <= 0) return;
                 step = crop.x;
                 tail = head + size.x * crop.y;
             }
@@ -7780,7 +7918,6 @@ namespace netxs::ui
                 auto next = head + step;
                 auto cell_run = std::span(head, next);
                 scrollback.template _data<true>(step, cell_run, fuse);
-                cells_printed += step;
                 head = next + rest;
                 if (head != tail)
                 {
@@ -7792,24 +7929,21 @@ namespace netxs::ui
                     break;
                 }
             }
-            return cells_printed;
         }
         // term: Print specified block (scroll/wrap in normal; crop by the altbuf viewport).
         auto draw_block(core const& image_buffer, auto fx, bool trim_hz = faux, bool trim_vt = faux)
         {
-            auto cells_printed = ui64{};
             if (target == &normal)
             {
                 auto trim_by_viewport = twod{ trim_hz ? target->panel.x : dot_mx.x,
                                               trim_vt ? target->panel.y : dot_mx.y };
-                cells_printed = print_block(normal, image_buffer, trim_by_viewport, fx);
+                print_block(normal, image_buffer, trim_by_viewport, fx);
             }
             else
             {
                 auto& target_buffer = *(alt_screen*)target;
-                cells_printed = print_block(target_buffer, image_buffer, target->panel, fx);
+                print_block(target_buffer, image_buffer, target->panel, fx);
             }
-            return cells_printed;
         }
         // term: Place rectangle block to the scrollback buffer.
         template<class S, class P>
@@ -7858,9 +7992,13 @@ namespace netxs::ui
                 }
             }
             auto cells_expected = image_buffer.volume();
-            image_ref_count[image.index] += cells_expected;
-            auto cells_printed = draw_block(image_buffer, cell::shaders::full, true, !decsdm);
-            image_ref_count[image.index] -= cells_expected - cells_printed;
+            image_sixel_count++;
+            auto& count = image_ref_count[image.index];
+            count += cells_expected; // Insure against premature removal.
+            if constexpr (debugmode) log("print1: image index: %% cell_count: %%", image.index, count);
+            draw_block(image_buffer, cell::shaders::full, true, !decsdm);
+            count -= cells_expected;
+            if constexpr (debugmode) log("print2: image index: %% cell_count: %%", image.index, count);
             if (image_ref_count[image.index] == 0) // A case where nothing is printed.
             {
                 remove_sixel_image(image.index, faux);
@@ -9611,14 +9749,21 @@ namespace netxs::ui
         ~term()
         {
             //if (image_cache.size() || sixel_cache.size()) // Signal to wipe all image references.
-            if (image_cache.size()) // Signal to wipe all image references.
+            if (image_cache.size() || image_sixel_count) // Signal to wipe all image references.
             {
                 auto images = cell::images(); // Lock.
                 auto removed_image_indexes = e2::data::image::remove.param();
-                removed_image_indexes.reserve(image_cache.size());
+                removed_image_indexes.reserve(image_sixel_count + image_cache.size());
                 //removed_image_indexes.reserve(image_cache.size() + sixel_cache.size());
                 //for (auto cache : { &image_cache, &sixel_cache }) //todo C++23: std::views::concat(image_cache, sixel_cache)
                 //for (auto& [image_id, image_ptr] : *cache) if (image_ptr)
+                for (auto removed_index = 0u; removed_index < image_ref_count.size(); removed_index++)
+                {
+                    if (image_ref_count[removed_index])
+                    {
+                        removed_image_indexes.push_back((ui16)removed_index);
+                    }
+                }
                 for (auto& [image_id, image_ptr] : image_cache) if (image_ptr)
                 {
                     auto removed_index = image_ptr->index;
@@ -9627,7 +9772,7 @@ namespace netxs::ui
                 }
                 if (removed_image_indexes.size())
                 {
-                    base::signal(tier::general, e2::data::image::remove, removed_image_indexes);
+                    remove_sixel_images(removed_image_indexes);
                 }
             }
         }


### PR DESCRIPTION
### Changes

- Terminal #917:
  - Implement Sixel cell accounting.
  - Fix implicit Sixel image size.
  - Allow printing over Sixel images.
  - Always trim Sixel images horizontally with the viewport.