### PR TITLE
Allow inline Lua expressions in settings

### DIFF
--- a/doc/settings.md
+++ b/doc/settings.md
@@ -101,6 +101,7 @@ DynamicXML is a configuration language based on the XML 1.1 syntax, but with sub
    | Aspect                | Difference
    |-----------------------|-----------
    | Element References    | Elements can reference the values or entire structures of other elements using relative or absolute paths. Any unquoted non-numeric value is treated as a reference.
+   | Inline Expressions    | Prefixing any valid element reference with a dollar sign (`$`) turns it into an Inline Script Expression. Instead of returning the raw text of the target element, the application evaluates its content via the host scripting engine at runtime.
    | Namespacing/Scoping   | Each element forms its own namespace (scope).
    | Value Concatenation   | An element's content may consist of several substrings and/or references combined using the vertical bar (`\|`) operator. For quoted substrings, the vertical bar operator may be omitted.
    | Inheritance           | Assigning references to elements makes the scopes of these elements inherited and directly accessible.
@@ -259,6 +260,10 @@ The following forms of element declaration are equivalent:
 
 ## VTM Configuration Overview
 
+### Lua Scripting Integration
+
+Within element values, an unquoted reference prefixed with a dollar sign (e.g., `... Expression='return "value"' element=$Expression ...`) is treated as a dynamic Lua statement or function body. When resolved at runtime, vtm evaluates this Lua code within a persistent Lua state. The expression must execute a return statement.
+
 ### Configuration Structure
 
 ```xml
@@ -270,9 +275,12 @@ The following forms of element declaration are equivalent:
 ...
 <config>  <!-- Global configuration. -->
     ...
-    <element1=global_variable_name/>  <!-- element1 references the value of /global_variable_name (three levels of indirection allowed). -->
-    <element2=/config/element1/>       <!-- element2 references the value of /config/element1. -->
-    <element3="/config/element1"/>     <!-- element3 contains the string value "/config/element1". -->
+    <Counter="N = (N or 0) + 1; return 'ID_' .. N"/>
+    <Element1=global_variable_name/>   <!-- Element1 references the value of /global_variable_name (three levels of indirection allowed). -->
+    <Element2=/config/Element1/>       <!-- Element2 references the value of /config/Element1. -->
+    <Element3="/config/Element1"/>     <!-- Element3 contains the string value "/config/Element1". -->
+    <Element4=$Counter/>               <!-- Element4 is evaluated by the inline script stored in Counter. -->
+    <Element5=$/config/Counter/>       <!-- Element5 is evaluated by the inline script stored in /config/Counter. -->
     ...
     <desktop>  <!-- Desktop settings. -->
         <taskbar ... >  <!-- Taskbar menu settings. -->

--- a/src/netxs/apps/term.hpp
+++ b/src/netxs/apps/term.hpp
@@ -202,11 +202,13 @@ namespace netxs::app::terminal
             });
         auto sb = layers->attach(ui::fork::ctor());
         auto vt = sb->attach(slot::_2, ui::grip<axis::Y>::ctor(scroll));
-        auto& term_bgc = term->get_color().bgc();
+        auto& term_clr = term->get_color();
+        auto& term_inv = term->get_invbit();
         auto& drawfx = term->base::field([&](auto& boss, auto& canvas, auto scrollbar_grip, auto master_len, auto master_box, auto master_pos, auto wide)
         {
             static auto box1 = "▄"sv;
             static auto box2 = ' ';
+            auto term_bgc = term_inv ? term_clr.fgc() : term_clr.bgc();
             if (ui::drawfx::visible(master_len, master_box, master_pos))
             {
                 if (wide) // Draw full scrollbar on mouse hover.
@@ -259,6 +261,7 @@ namespace netxs::app::terminal
                     parent_canvas.cage(full, borders, [&](cell& c){ c.txt(whitespace).link(bar); });
                     full -= borders;
                 }
+                auto term_bgc = term_inv ? term_clr.fgc() : term_clr.bgc();
                 auto bgc = winsz.y != 1 ? term_bgc : 0;
                 parent_canvas.fill(full, [&](cell& c){ c.fgc(c.bgc()).bgc(bgc).txt(bar).link(bar); });
             };

--- a/src/netxs/desktopio/application.hpp
+++ b/src/netxs/desktopio/application.hpp
@@ -22,7 +22,7 @@ namespace netxs::app
 
 namespace netxs::app::shared
 {
-    static const auto version = "v2026.05.18";
+    static const auto version = "v2026.05.19";
     static const auto repository = "https://github.com/directvt/vtm";
     static const auto usr_config = "~/.config/vtm/settings.xml"s;
     static const auto sys_config = "/etc/vtm/settings.xml"s;

--- a/src/netxs/desktopio/baseui.hpp
+++ b/src/netxs/desktopio/baseui.hpp
@@ -761,7 +761,7 @@ namespace netxs::ui
             netxs::events::vtm_class::list::iterator class_iterator; // base: class_metadata.objects std::list iterator.
         };
         utf::unordered_map<text, base_class> base_classes; // base: Base classes map by classname.
-        netxs::events::context_t             scripting_context; // base: Temp buffer for the list of ids of all ancestors.
+        netxs::luna::context_t               scripting_context; // base: Temp buffer for the list of ids of all ancestors.
 
         struct mfocus_node
         {

--- a/src/netxs/desktopio/canvas.hpp
+++ b/src/netxs/desktopio/canvas.hpp
@@ -2409,10 +2409,11 @@ namespace netxs
             if (uv.bg.chan.a == 0xFF) uv.bg.mix_one(c.uv.bg);
             else                      uv.bg.mix(c.uv.bg);
 
+            auto bgc = c.st.inv() ? c.uv.fg.token : c.uv.bg.token;
             if (c.st.xy())
             {
                 gc = c.gc;
-                if (c.uv.bg.token == 0) // OR'ing the shadow if bg is completely transparent.
+                if (bgc == 0) // OR'ing the shadow if bg is completely transparent.
                 {
                     st.meta_shadow_matrix(c.st);
                 }
@@ -2423,7 +2424,7 @@ namespace netxs
             }
             else
             {
-                if (c.uv.bg.token == 0) // OR'ing the shadow if bg is completely transparent.
+                if (bgc == 0) // OR'ing the shadow if bg is completely transparent.
                 {
                     st.meta_shadow(c.st);
                 }
@@ -2511,7 +2512,12 @@ namespace netxs
         {
             fuse_keep_image(c);
             if (c.id) id = c.id;
-            if (px && !c.px)
+            if (c.raw())
+            {
+                px = c.px;
+                p2 = c.p2;
+            }
+            else if (px)
             {
                 set_image_ontop(0); // Place image under the text.
             }
@@ -3315,15 +3321,40 @@ namespace netxs
                                                      : 0xFFffffff;
                 }
                 template<class D, class S>
-                inline void operator () (D& dst, S& src) const
+                inline void operator () (D& dst, S src) const
                 {
                     if (src.isnul()) return;
-                    auto& fgc = src.fgc();
-                    if (fgc.chan.a == 0x00)
+                    if (!src.inv())
                     {
-                        auto& bgc = dst.bgc();
-                        if (bgc.chan.a < 2) dst.fgc(0xFFffffff);
-                        else                dst.fgc(invert(bgc));
+                        if (src.fgc().chan.a == 0x00)
+                        {
+                            if (dst.inv())
+                            {
+                                src.inv(true);
+                                auto dst_bgc = dst.fgc();
+                                if (dst_bgc.chan.a < 2) dst.bgc(0xFFffffff);
+                                else                    dst.bgc(invert(dst_bgc));
+                            }
+                            else
+                            {
+                                auto dst_bgc = dst.bgc();
+                                if (dst_bgc.chan.a < 2) dst.fgc(0xFFffffff);
+                                else                    dst.fgc(invert(dst_bgc));
+                            }
+                        }
+                        else if (src.bgc().chan.a == 0x00)
+                        {
+                            if (dst.inv())
+                            {
+                                src.inv(true);
+                                std::swap(src.fgc(), src.bgc());
+                                src.fgc(dst.fgc());
+                            }
+                            else
+                            {
+                                src.bgc(dst.bgc());
+                            }
+                        }
                     }
                     dst.fusefull_keep_image(src);
                 }

--- a/src/netxs/desktopio/canvas.hpp
+++ b/src/netxs/desktopio/canvas.hpp
@@ -3472,7 +3472,7 @@ namespace netxs
             };
             struct invbit_t
             {
-                template<class D> inline void operator () (D& dst) const { dst.invbit(); }
+                template<class D> inline void operator () (D& dst) const { if (dst.raw()) std::swap(dst.fgc(), dst.bgc()); else dst.invbit(); }
             };
             struct disabled_t
             {

--- a/src/netxs/desktopio/canvas.hpp
+++ b/src/netxs/desktopio/canvas.hpp
@@ -3348,11 +3348,11 @@ namespace netxs
                             {
                                 src.inv(true);
                                 std::swap(src.fgc(), src.bgc());
-                                src.fgc(dst.fgc());
+                                src.fgc(argb::transparent);
                             }
                             else
                             {
-                                src.bgc(dst.bgc());
+                                src.bgc(argb::transparent);
                             }
                         }
                     }

--- a/src/netxs/desktopio/canvas.hpp
+++ b/src/netxs/desktopio/canvas.hpp
@@ -2484,7 +2484,7 @@ namespace netxs
         void mixfull(cell const& c, si32 alpha)
         {
             if (c.id) id = c.id;
-            if (c.st.xy())
+            if (c.st.xy() || c.raw())
             {
                 st = c.st;
                 gc = c.gc;
@@ -3490,7 +3490,20 @@ namespace netxs
                     : alpha{ alpha }
                 { }
                 template<class C> constexpr inline auto operator () (C brush) const { return func<C>(brush); }
-                template<class D, class S>  inline void operator () (D& dst, S& src) const { dst.mixfull(src, alpha); }
+                template<class D, class S>  inline void operator () (D& dst, S src) const
+                {
+                    if (dst.raw() && !src.raw())
+                    {
+                        src.px = dst.px;
+                        src.p2 = dst.p2;
+                        if (!src.inv())
+                        {
+                            src.inv(true); // Make images semi-transparent.
+                            std::swap(src.fgc(), src.bgc());
+                        }
+                    }
+                    dst.mixfull(src, alpha);
+                }
             };
             struct xlucent_t
             {

--- a/src/netxs/desktopio/canvas.hpp
+++ b/src/netxs/desktopio/canvas.hpp
@@ -2519,22 +2519,19 @@ namespace netxs
         // cell: Blend two cells and set id if any (fg = bg * c.fg).
         void overlay(cell const& c)
         {
-            auto bg_opaque = uv.bg.chan.a == 0xFF;
-            if (c.st.xy() || c.st.und())
+            uv.fg = uv.bg;
+            if (uv.bg.chan.a == 0xFF)
             {
-                uv.fg = uv.bg;
-                if (bg_opaque) uv.fg.mix_one(c.uv.fg);
-                else           uv.fg.mix(c.uv.fg);
+                uv.fg.mix_one(c.uv.fg);
+                uv.bg.mix_one(c.uv.bg);
             }
             else
             {
-                if (uv.fg.chan.a == 0xFF) uv.fg.mix_one(c.uv.bg);
-                else                      uv.fg.mix(c.uv.bg);
+                uv.fg.mix(c.uv.fg);
+                uv.bg.mix(c.uv.bg);
             }
             gc = c.gc;
             st = c.st;
-            if (bg_opaque) uv.bg.mix_one(c.uv.bg);
-            else           uv.bg.mix(c.uv.bg);
             px = c.px;
             p2 = c.p2;
             if (c.id) id = c.id;

--- a/src/netxs/desktopio/controls.hpp
+++ b/src/netxs/desktopio/controls.hpp
@@ -5,29 +5,8 @@
 
 #include "input.hpp"
 
-namespace netxs::events
+namespace netxs
 {
-    text script_ref::to_string(context_t& context)
-    {
-        auto crop = text{};
-        for (auto ptr : context | std::views::reverse)
-        {
-            crop += utf::bytes2shades(view{ (char*)&ptr, sizeof(void*) });
-            crop += '-';
-        }
-        if (crop.size())
-        {
-            crop.pop_back();
-            auto id = ((ui::base*)context.back())->id;
-            crop += " " + std::to_string(id);
-        }
-        else
-        {
-            crop += " 0";
-        }
-        return crop;
-    }
-
     // luna: Get any text from the stack by index.
     text luna::vtmlua_torawstring(lua_State* lua, si32 idx, bool extended)
     {
@@ -417,7 +396,24 @@ namespace netxs::events
         auto ok = luna::run_with_gear_wo_return(proc);
         luna::set_return(ok);
     }
-    text luna::run(context_t& context, view script_body, auto&& param)
+    text luna::run(view script_body)
+    {
+        auto error = ::luaL_loadbuffer(lua, script_body.data(), script_body.size(), "inlined script body")
+                  || ::lua_pcall(lua, 0, 1, 0);
+        auto result = text{};
+        if (error)
+        {
+            result = ::lua_tostring(lua, -1);
+            log("%%inlined script compilation failed:\n%body%\n%msg%\n", prompt::lua, ansi::hi(ansi::add(script_body).numerate_lines(blacklt)), ansi::err(result));
+        }
+        else if (::lua_gettop(lua))
+        {
+            result = luna::vtmlua_torawstring(lua, -1);
+        }
+        ::lua_settop(lua, 0);
+        return result;
+    }
+    text luna::run(luna::context_t& context, view script_body, auto&& param)
     {
         using T = std::decay_t<decltype(param)>;
         //if constexpr (debugmode) log("%%script:\n%pads%%script%", prompt::lua, prompt::pads, ansi::hi(script_body));
@@ -646,7 +642,29 @@ namespace netxs::events
     {
         if (lua) ::lua_close(lua);
     }
-
+}
+namespace netxs::events
+{
+    text script_ref::to_string(luna::context_t& context)
+    {
+        auto crop = text{};
+        for (auto ptr : context | std::views::reverse)
+        {
+            crop += utf::bytes2shades(view{ (char*)&ptr, sizeof(void*) });
+            crop += '-';
+        }
+        if (crop.size())
+        {
+            crop.pop_back();
+            auto id = ((ui::base*)context.back())->id;
+            crop += " " + std::to_string(id);
+        }
+        else
+        {
+            crop += " 0";
+        }
+        return crop;
+    }
     script_ref::script_ref(auth& indexer, std::reference_wrapper<ui::base> boss_ref, sptr<std::pair<ui64, text>> script_body_ptr)
         : indexer{ indexer },
           boss_ref{ boss_ref },
@@ -666,7 +684,8 @@ namespace netxs::events
           e2_timer_tick_id{ ui::e2::timer::tick.id },
           _null_gear_sptr{ auth::create<input::hids>(*this) },
           active_gear_ref{ *_null_gear_sptr },
-          anykey_event{ get_kbchord_hint(input::key::kmap::any_key) }
+          anykey_event{ get_kbchord_hint(input::key::kmap::any_key) },
+          config{ luafx }
     {
         if (use_timer)
         {

--- a/src/netxs/desktopio/events.hpp
+++ b/src/netxs/desktopio/events.hpp
@@ -4,27 +4,8 @@
 #pragma once
 
 #include "geometry.hpp"
-#include "lua.hpp"
 #include "xml.hpp"
 
-//todo Workaround for i386 linux targets, https://sourceware.org/bugzilla/show_bug.cgi?id=31775
-#if defined(__i386__) && defined(__linux__) && !defined(__ANDROID__)
-    extern long double fmodl(long double a, long double b);
-    double fmod(double a, double b) { return fmodl(a, b); }
-    //float  fmod(float  a, float  b) { return fmodl(a, b); }
-#endif
-
-namespace netxs
-{
-    namespace ui
-    {
-        struct base;
-    }
-    namespace input
-    {
-        struct hids;
-    }
-}
 
 namespace netxs::events
 {
@@ -139,50 +120,7 @@ namespace netxs::events
     }
     template<hint Group, auto Count> constexpr auto subset = _instantiate<Group>(std::make_index_sequence<Count>{});
 
-    using context_t = std::vector<void*>;
-    struct auth;
-
-    // events: Lua scripting.
-    struct luna
-    {
-        auth&      indexer; // luna: .
-        lua_State* lua; // luna: .
-
-        static text vtmlua_torawstring(     lua_State* lua, si32 idx, bool extended = faux);
-        static si32 vtmlua_object2string(   lua_State* lua);
-        static si32 vtmlua_log(             lua_State* lua);
-        static si32 vtmlua_call_method(     lua_State* lua);
-        static si32 vtmlua_run_with_indexer(lua_State* lua, auto proc);
-        static si32 vtmlua_terminal_index(  lua_State* lua);
-        static si32 vtmlua_vtm_call(        lua_State* lua);
-        static si32 vtmlua_vtm_index(       lua_State* lua);
-        static si32 vtmlua_vtm_subindex(    lua_State* lua);
-        static si32 vtmlua_cfg_subindex(    lua_State* lua);
-        static si32 vtmlua_push_value(      lua_State* lua, auto&& v);
-        si32 push_value(auto&& v);
-        void set_return(auto... args);
-        void set_return_array(txts const& str_list);
-        si32 args_count();
-        void read_args(si32 index, auto add_item);
-        auto get_args_or(si32 idx, auto fallback = {});
-        void set_gear(input::hids& gear);
-        void reset_gear();
-        input::hids& get_gear();
-        bool run_with_gear_wo_return(auto proc);
-        void run_with_gear(auto proc);
-        template<class Arg = noop>
-        text run(context_t& context, view script_body, Arg&& param = {});
-        template<class Arg = noop>
-        text run_script(ui::base& object, view script_body, Arg&& param = {});
-        void run_ext_script(ui::base& object, auto& script);
-        si32 get_table_size();
-        bool push_function_id(view script_body);
-        void precompile_function(sptr<std::pair<ui64, text>>& script_body_ptr);
-        void remove_function(sptr<std::pair<ui64, text>>& script_body_ptr);
-
-        luna(auth& indexer);
-        ~luna();
-    };
+    using context_t = netxs::luna::context_t;
 
     struct script_ref
     {
@@ -922,16 +860,4 @@ namespace netxs
     using netxs::events::hook;
     using netxs::events::wook;
     using netxs::events::script_ref;
-}
-namespace std
-{
-    template<>
-    struct less<netxs::events::context_t>
-    {
-        using context_t = netxs::events::context_t;
-        bool operator () (context_t const& l, context_t const& r) const
-        {
-            return std::lexicographical_compare(l.begin(), l.end(), r.begin(), r.end());
-        }
-    };
 }

--- a/src/netxs/desktopio/terminal.hpp
+++ b/src/netxs/desktopio/terminal.hpp
@@ -7971,7 +7971,7 @@ namespace netxs::ui
         bool       decsdm; // term: Sixel Display Mode. On sixel output: faux: Enable scroll (+move text cursor to the beginning of next line after image). True: Disable scroll (+don't move text cursor and trim sixel image by the scrolling region).
         bool       bpmode; // term: Bracketed paste mode.
         bool       unsync; // term: Viewport is out of sync.
-        bool       invert; // term: Inverted rendering (DECSCNM).
+        bool       invbit; // term: Inverted rendering (DECSCNM).
         bool       styled; // term: Line style reporting.
         bool       io_log; // term: Stdio logging.
         bool       selalt; // term: Selection form (rectangular/linear).
@@ -8699,7 +8699,7 @@ namespace netxs::ui
             altbuf.clear_all();
             reset_pockets();
             target = &normal;
-            invert = faux;
+            invbit = faux;
             decckm = faux;
             bpmode = faux;
             altscr = defcfg.def_alt_on;
@@ -8722,7 +8722,7 @@ namespace netxs::ui
                     }
                     break;
                 case 5:    // Inverted rendering (DECSCNM).
-                    invert = true;
+                    invbit = true;
                     break;
                 case 6:    // Enable origin mode (DECOM).
                     target->decom = true;
@@ -8845,7 +8845,7 @@ namespace netxs::ui
                     }
                     break;
                 case 5:    // Inverted rendering (DECSCNM).
-                    invert = faux;
+                    invbit = faux;
                     break;
                 case 6:    // Disable origin mode (DECOM).
                     target->decom = faux;
@@ -9528,6 +9528,10 @@ namespace netxs::ui
         {
             return defclr;
         }
+        auto& get_invbit() // DECSCNM
+        {
+            return invbit;
+        }
         void set_color(cell brush)
         {
             auto& console = *target;
@@ -9928,7 +9932,7 @@ namespace netxs::ui
               decsdm{ faux },
               bpmode{ faux },
               unsync{ faux },
-              invert{ faux },
+              invbit{ faux },
               styled{ faux },
               io_log{ defcfg.def_io_log },
               selalt{ defcfg.def_selalt },
@@ -10599,7 +10603,10 @@ namespace netxs::ui
                     if (defclr.bga() != 0xFF) parent_canvas.fill(rect{ caret.coor(), dot_11 }, [&](cell& c){ c.fgc(console.brush.fgc()); }); // Prefill the cursor cell placeholder in the case of transparent background.
                     console.output(parent_canvas);
                 }
-                if (invert) parent_canvas.fill(cell::shaders::invbit);
+                if (invbit) // DECSCNM.
+                {
+                    parent_canvas.fill(cell::shaders::invbit);
+                }
 
                 if (oversz.b > 0) // Shade the viewport bottom oversize (futures).
                 {

--- a/src/netxs/desktopio/xml.hpp
+++ b/src/netxs/desktopio/xml.hpp
@@ -5,6 +5,88 @@
 
 #include "canvas.hpp"
 
+//todo find better place for netxs::luna (luna.hpp?)
+#include "lua.hpp"
+
+//todo Workaround for i386 linux targets, https://sourceware.org/bugzilla/show_bug.cgi?id=31775
+#if defined(__i386__) && defined(__linux__) && !defined(__ANDROID__)
+    extern long double fmodl(long double a, long double b);
+    double fmod(double a, double b) { return fmodl(a, b); }
+    //float  fmod(float  a, float  b) { return fmodl(a, b); }
+#endif
+
+namespace netxs::events
+{
+    struct auth;
+}
+namespace netxs
+{
+    namespace ui
+    {
+        struct base;
+    }
+    namespace input
+    {
+        struct hids;
+    }
+    // Lua scripting sandbox.
+    struct luna
+    {
+        using auth = netxs::events::auth;
+        using context_t = std::vector<void*>;
+
+        auth&      indexer; // luna: .
+        lua_State* lua; // luna: .
+
+        static text vtmlua_torawstring(     lua_State* lua, si32 idx, bool extended = faux);
+        static si32 vtmlua_object2string(   lua_State* lua);
+        static si32 vtmlua_log(             lua_State* lua);
+        static si32 vtmlua_call_method(     lua_State* lua);
+        static si32 vtmlua_run_with_indexer(lua_State* lua, auto proc);
+        static si32 vtmlua_terminal_index(  lua_State* lua);
+        static si32 vtmlua_vtm_call(        lua_State* lua);
+        static si32 vtmlua_vtm_index(       lua_State* lua);
+        static si32 vtmlua_vtm_subindex(    lua_State* lua);
+        static si32 vtmlua_cfg_subindex(    lua_State* lua);
+        static si32 vtmlua_push_value(      lua_State* lua, auto&& v);
+        si32 push_value(auto&& v);
+        void set_return(auto... args);
+        void set_return_array(txts const& str_list);
+        si32 args_count();
+        void read_args(si32 index, auto add_item);
+        auto get_args_or(si32 idx, auto fallback = {});
+        void set_gear(input::hids& gear);
+        void reset_gear();
+        input::hids& get_gear();
+        bool run_with_gear_wo_return(auto proc);
+        void run_with_gear(auto proc);
+        text run(view script_body);
+        template<class Arg = noop>
+        text run(context_t& context, view script_body, Arg&& param = {});
+        template<class Arg = noop>
+        text run_script(ui::base& object, view script_body, Arg&& param = {});
+        void run_ext_script(ui::base& object, auto& script);
+        si32 get_table_size();
+        bool push_function_id(view script_body);
+        void precompile_function(sptr<std::pair<ui64, text>>& script_body_ptr);
+        void remove_function(sptr<std::pair<ui64, text>>& script_body_ptr);
+
+        luna(auth& indexer);
+        ~luna();
+    };
+}
+namespace std
+{
+    template<>
+    struct less<netxs::luna::context_t>
+    {
+        bool operator () (netxs::luna::context_t const& l, netxs::luna::context_t const& r) const
+        {
+            return std::lexicographical_compare(l.begin(), l.end(), r.begin(), r.end());
+        }
+    };
+}
+
 namespace netxs::xml
 {
     template<class T>
@@ -633,8 +715,8 @@ namespace netxs::xml
         struct parser
         {
             static constexpr auto view_find_start       = "<"sv;
-            static constexpr auto view_token_first      = " \t\r\n\v\f!\"#$%&'()*+<=>?@[\\]^`{|}~;,/-.0123456789"sv; // Element name cannot contain any of [[:whitespaces:]!"#$%&'()*+,/;<=>?@[\]^`{|}~], and cannot begin with "-", ".", or a numeric digit.
-            static constexpr auto view_token_delims     = " \t\r\n\v\f!\"#$%&'()*+<=>?@[\\]^`{|}~;,/"sv;
+            static constexpr auto view_token_first      = " \t\r\n\v\f!\"#%&'()*+<=>?@[\\]^`{|}~;,/-.0123456789"sv; // Element name cannot begin with any of [[:whitespaces:]!"#%&'()*+,/;<=>?@[\]^`{|}~], and cannot begin with "-", ".", or a numeric digit.
+            static constexpr auto view_token_delims     = " \t\r\n\v\f!\"#%&'()*+<=>?@[\\]^`{|}~;,/"sv;
             static constexpr auto view_reference_delims = " \t\r\n\v\f!\"#$%&'()*+<=>?@[\\]^`{|}~;,"sv;
             static constexpr auto view_digit_delims     = " \t\r\n\v\f!\"$%&'()*+<=>?@[\\]^`{|}~/"sv; // Allow '-' (-1), '#' in digits (#rgb). Also allow ';' and ',' between digits: (123;456).
             static constexpr auto view_comment_begin    = "<!--"sv;
@@ -1493,20 +1575,26 @@ namespace netxs::xml
         using sptr = xml::document::sptr;
         using list = std::list<xml::document::sptr>;
 
-        xml::document document; // settings: XML document.
-        vect tmpbuff; // settings: Temp buffer.
-        list context; // settings: Current working context stack (reference context).
+        luna&            luafx; // settings: Lua sandbox.
+        xml::document    document; // settings: XML document.
+        vect             tmpbuff; // settings: Temp buffer.
+        list             context; // settings: Current working context stack (reference context).
         std::deque<qiew> reference_path_array; // settings: Temp buffer for path segments.
 
-        settings() = default;
-        settings(view utf8_xml)
-            : document{ utf8_xml }
+        settings(luna& luafx)
+            :  luafx{ luafx }
         { }
-        settings(settings const& config)
-            : document{ config.document.page.utf8() }
+        settings(luna& luafx, view utf8_xml)
+            :  luafx{ luafx    },
+            document{ utf8_xml }
         { }
-        settings(xml::document&& document)
-            : document{ std::move(document) }
+        settings(luna& luafx, settings const& config)
+            :  luafx{ luafx                       },
+            document{ config.document.page.utf8() }
+        { }
+        settings(luna& luafx, xml::document&& document)
+            :  luafx{ luafx               },
+            document{ std::move(document) }
         { }
 
         void swap(settings& s)
@@ -1663,14 +1751,28 @@ namespace netxs::xml
                 auto kind = value_placeholder->kind;
                 if (kind == document::type::tag_reference || kind == document::type::raw_reference)
                 {
-                    auto& reference_name = value_placeholder->utf8;
+                    auto reference_name = qiew{ value_placeholder->utf8 };
+                    auto lua_expression = reference_name && reference_name.front() == '$'; // Inlined lua expression.
+                    if (lua_expression)
+                    {
+                        reference_name.pop_front();
+                    }
                     if (!value_placeholder->busy)
                     {
                         auto ctx = push_context(item_ptr);
                         value_placeholder->busy = 1;
                         if (auto base_item_ptr = settings::find_context_ptr(reference_name))
                         {
-                            settings::_take_value(base_item_ptr, value);
+                            if (lua_expression)
+                            {
+                                auto script_body = text{};
+                                settings::_take_value(base_item_ptr, script_body);
+                                value += luafx.run(script_body);
+                            }
+                            else
+                            {
+                                settings::_take_value(base_item_ptr, value);
+                            }
                         }
                         else
                         {

--- a/src/vtm.cpp
+++ b/src/vtm.cpp
@@ -271,9 +271,9 @@ int main(int argc, char* argv[])
     }
     else if (whoami == type::lsfont)
     {
-        auto config = xml::settings{};
-        app::shared::load::settings(config, cliopt, faux);
-        auto gui_config = app::shared::get_gui_config(config);
+        auto& indexer = ui::tui_domain();
+        app::shared::load::settings(indexer.config, cliopt, faux);
+        auto gui_config = app::shared::get_gui_config(indexer.config);
         if (auto fcache = gui::fonts{ gui_config.font_names, gui_config.font_axes, gui_config.cell_height })
         {
             fcache.log_fonts(detail);
@@ -281,9 +281,9 @@ int main(int argc, char* argv[])
     }
     else if (whoami == type::config)
     {
-        auto config = xml::settings{};
-        app::shared::load::settings(config, cliopt, true);
-        log(prompt::resultant_settings, "\n", config);
+        auto& indexer = ui::tui_domain();
+        app::shared::load::settings(indexer.config, cliopt, true);
+        log(prompt::resultant_settings, "\n", indexer.config);
     }
     else if (whoami == type::logmon)
     {
@@ -407,8 +407,8 @@ int main(int argc, char* argv[])
     }
     else
     {
-        auto config = xml::settings{};
-        app::shared::load::settings(config, cliopt);
+        auto& indexer = ui::tui_domain();
+        app::shared::load::settings(indexer.config, cliopt);
         auto client = os::ipc::socket::open<os::role::client, faux>(prefix, denied);
         auto signal = ptr::shared<os::fire>(os::process::started(prefix)); // Signaling that the server is ready for incoming connections.
 
@@ -417,7 +417,7 @@ int main(int argc, char* argv[])
         else if (whoami == type::client && !client)
         {
             log("%%New desktop session for [%userid%]", prompt::main, userid.first);
-            auto [success, successor] = os::process::fork(system, prefix, config.settings::utf8());
+            auto [success, successor] = os::process::fork(system, prefix, indexer.config.settings::utf8());
             if (successor)
             {
                 whoami = type::server;
@@ -440,9 +440,8 @@ int main(int argc, char* argv[])
                 auto cwd = os::env::cwd();
                 auto cmd = script;
                 auto win = os::dtvt::gridsz;
-                auto gui = app::shared::get_gui_config(config);
+                auto gui = app::shared::get_gui_config(indexer.config);
                 userinit.send(client, userid.first, os::dtvt::vtmode, env, cwd, cmd, win);
-                ui::tui_domain().config.swap(config);
                 app::shared::splice(client, gui);
                 return 0;
             }
@@ -451,7 +450,7 @@ int main(int argc, char* argv[])
 
         if (whoami == type::daemon)
         {
-            auto [success, successor] = os::process::fork(system, prefix, config.settings::utf8(), script);
+            auto [success, successor] = os::process::fork(system, prefix, indexer.config.settings::utf8(), script);
             if (successor)
             {
                 whoami = type::server;
@@ -485,8 +484,6 @@ int main(int argc, char* argv[])
         signal.reset();
 
         namespace e2 = ui::e2;
-        auto& indexer = ui::tui_domain();
-        indexer.config.swap(config);
         auto lock = indexer.unique_lock();
         auto desktop = app::vtm::hall::ctor(server);
         desktop->autorun();

--- a/src/vtm.hpp
+++ b/src/vtm.hpp
@@ -1988,9 +1988,9 @@ namespace netxs::app::vtm
                                     parent_canvas.fill(user_name, cell::shaders::contrast);
                                     usergate.fill_pointer(gear, parent_canvas);
                                     // Draw a color focus mark next to the cursor.
-                                    auto area = rect{{ coor.x + user_name.size().x + 1, coor.y }, dot_11 };
+                                    auto area = rect{{ coor.x + user_name.size().x, coor.y }, dot_11 };
                                     gear_color.fgc(hids::get_color(gear.gear_index));
-                                    parent_canvas.fill(area, cell::shaders::skipnulls(gear_color)); // Use skipnulls to be transparent for images.
+                                    parent_canvas.fill(area, cell::shaders::contrast(gear_color)); // Use contrast to be transparent for images.
                                 }
                             }
                         }

--- a/src/vtm.hpp
+++ b/src/vtm.hpp
@@ -1158,8 +1158,8 @@ namespace netxs::app::vtm
                     {
                         auto head = patch.begin();
                         auto tail = patch.end();
-                        auto fragment = settings{ fallback.appcfg.cfg.size() ? fallback.appcfg.cfg
-                                                                             : (*head++)->snapshot() };
+                        auto fragment = settings{ config.luafx, fallback.appcfg.cfg.size() ? fallback.appcfg.cfg
+                                                                                           : (*head++)->snapshot() };
                         while (head != tail)
                         {
                             auto& p = *head++;
@@ -1403,7 +1403,7 @@ namespace netxs::app::vtm
                                                         utf8_xml += "\"/>";
                                                     });
                                                     log("%%Run %%", prompt::host, ansi::hi(utf::debase437(utf8_xml)));
-                                                    auto appconf = settings{ utf8_xml };
+                                                    auto appconf = settings{ config.luafx, utf8_xml };
                                                     auto item_ptr = appconf.document.root_ptr;
                                                     auto menuid = config.settings::take_value_from(item_ptr, attr::id, ""s);
                                                     auto taskbar_context = config.settings::push_context(path::taskbar);


### PR DESCRIPTION
### Changes

- Allow inline Lua expressions in settings. #891
- Allow images to be visible through translucent windows.
- Terminal:
  - Fix DECSCNM.

There is now a way to evaluate attribute values ​​in settings using Lua:

- `settings.xml`
  ```xml
  <config>
    <desktop>
      <taskbar>
        <Pwsh='N = (N or 0) + 1; return "Pwsh"..N'/>
        <item id=$Pwsh          type="dtvt" title="pwsh" cmd="$0 -r term pwsh"/>
        <item id=$Pwsh|" Video" type="dtvt" cmd="$0 -r term pwsh -c \"while ($true){ wsl -e bash -c 'mpv --vo=sixel --no-terminal /mnt/d/sdn/Desktop/RWVW2821.MP4' }\"" />
        <item id=$Pwsh|" dtvt"  type="dtvt" title="pwsh" cmd="$0 -r dtvt $0 -r term pwsh"/>
      </taskbar>
    </desktop>
  </config>
  ```

## DynamicXML
### Differences from Classical XML 1.1
...

3. #### Dynamic Features: References and Templates

   | Aspect                | Difference
   |-----------------------|-----------
   | Element References    | Elements can reference the values or entire structures of other elements using relative or absolute paths. Any unquoted non-numeric value is treated as a reference.
   | Script Expressions    | Prefixing any valid element reference with a dollar sign (`$`) turns it into an Inline Script Expression. Instead of returning the raw text of the target element, the application evaluates its content via the host scripting engine at runtime (e.g., Lua, JavaScript, or a custom interpreter).

...

>  Note: DynamicXML strictly defines how paths with the `$` prefix are traversed and resolved within the document tree. However, the syntax of the script code itself and the underlying runtime engine remain completely abstract and implementation-specific to the consuming application.

...

## VTM Configuration Overview

### Lua Scripting Integration

Within element values, an unquoted reference prefixed with a dollar sign (e.g., `... Expression='return "value"' element=$Expression ...`) is treated as a dynamic Lua statement or function body. When resolved at runtime, vtm evaluates this Lua code within a persistent Lua state. The expression must execute a return statement.