### PR TITLE
Fix a long-standing crash on shuffling desktop windows

### DIFF
--- a/src/netxs/desktopio/application.hpp
+++ b/src/netxs/desktopio/application.hpp
@@ -22,7 +22,7 @@ namespace netxs::app
 
 namespace netxs::app::shared
 {
-    static const auto version = "v2026.05.19";
+    static const auto version = "v2026.05.20";
     static const auto repository = "https://github.com/directvt/vtm";
     static const auto usr_config = "~/.config/vtm/settings.xml"s;
     static const auto sys_config = "/etc/vtm/settings.xml"s;

--- a/src/netxs/desktopio/canvas.hpp
+++ b/src/netxs/desktopio/canvas.hpp
@@ -3496,11 +3496,11 @@ namespace netxs
                     {
                         src.px = dst.px;
                         src.p2 = dst.p2;
-                        if (!src.inv())
-                        {
-                            src.inv(true); // Make images semi-transparent.
-                            std::swap(src.fgc(), src.bgc());
-                        }
+                    }
+                    if (src.raw() && !src.inv())
+                    {
+                        src.inv(true); // Make images semi-transparent.
+                        std::swap(src.fgc(), src.bgc());
                     }
                     dst.mixfull(src, alpha);
                 }

--- a/src/vtm.hpp
+++ b/src/vtm.hpp
@@ -947,9 +947,7 @@ namespace netxs::app::vtm
                 {
                     if (base::holder != std::prev(world.base::subset.end()))
                     {
-                        world.base::subset.push_back(This());
-                        world.base::subset.erase(base::holder);
-                        base::holder = std::prev(world.base::subset.end());
+                        world.base::subset.splice(world.base::subset.end(), world.base::subset, base::holder);
                         if (base::hidden) // Restore if window minimized.
                         {
                             base::hidden = faux;
@@ -960,17 +958,18 @@ namespace netxs::app::vtm
                 };
                 LISTEN(tier::preview, e2::form::layout::bubble, r)
                 {
-                    auto area = base::region;
-                    auto next = base::holder;
-                    if (next != world.base::subset.end())
+                    if (base::holder != world.base::subset.end())
                     {
-                        if (++next != world.base::subset.end() && !area.trim((*next)->region))
+                        auto area = base::region;
+                        auto next = base::holder;
+                        ++next;
+                        if (next != world.base::subset.end() && !area.trim((*next)->region))
                         {
-                            //todo revise: it crashes
-                            world.base::subset.erase(base::holder);
-                            while (++next != world.base::subset.end() && !area.trim((*next)->region))
-                            { }
-                            base::holder = world.base::subset.insert(next, This());
+                            while (next != world.base::subset.end() && !area.trim((*next)->region)) // Find blocking window or top.
+                            {
+                                ++next;
+                            }
+                            world.base::subset.splice(next, world.base::subset, base::holder); // Do bubble.
                             base::strike();
                         }
                     }


### PR DESCRIPTION
### Changes

- Fix a long-standing crash on shuffling desktop windows.
- Make images in translucent windows also translucent.