### PR TITLE
Try to fix a long-standing bug that causes a deadlock when closing a terminal window

### DIFF
--- a/src/netxs/desktopio/application.hpp
+++ b/src/netxs/desktopio/application.hpp
@@ -22,7 +22,7 @@ namespace netxs::app
 
 namespace netxs::app::shared
 {
-    static const auto version = "v2026.07.06";
+    static const auto version = "v2026.07.07";
     static const auto repository = "https://github.com/directvt/vtm";
     static const auto usr_config = "~/.config/vtm/settings.xml"s;
     static const auto sys_config = "/etc/vtm/settings.xml"s;

--- a/src/netxs/desktopio/consrv.hpp
+++ b/src/netxs/desktopio/consrv.hpp
@@ -5143,6 +5143,7 @@ struct consrv : ipc::stdcon
         if (stdinput.joinable())
         {
             if (io_log) log(prompt::vtty, "Reading thread joining", ' ', utf::to_hex_0x(stdinput.get_id()));
+            stdcon::abort(stdinput);  // On Linux: thread::join sometimes dead waits on recv() call (repro: Create multiuser session, run term with bash, run vim inside, refocus, close window by 'x').
             stdinput.join();
         }
         stdcon::cleanup();

--- a/src/netxs/desktopio/gui.hpp
+++ b/src/netxs/desktopio/gui.hpp
@@ -3515,6 +3515,7 @@ namespace netxs::gui
         virtual void layer_timer_stop(layer& s, ui32 eventid) = 0;
 
         virtual void keybd_sync_state(si32 virtcod = 0) = 0;
+        virtual void keybd_turn_layout(ui32 hkl) = 0;
         virtual void keybd_sync_layout()
         {
             auto& gear = *stream.gears;
@@ -4819,6 +4820,10 @@ namespace netxs::gui
                         keybd.syncto(gear);
                         gear.gear_id = gear.bell::id; // Restore gear id.
                         gear.touched = {};
+                        if (xlayout != keybd.xlayout) // Forcibly switch keyboard layout.
+                        {
+                            keybd_turn_layout(keybd.xlayout);
+                        }
                         stream.keybd(gear);
                     }
                 }
@@ -5900,6 +5905,13 @@ namespace netxs::gui
             }
             return (arch)latin_hkl;
         }
+        void keybd_turn_layout(ui32 hkl32)
+        {
+            auto hkl = (HKL)(arch)(si32)hkl32; // Restore negative bits if it is.
+            if constexpr (debugmode) log("The keyboard layout was forced to switch to hkl=%%", utf::to_hex(hkl));
+            ::ActivateKeyboardLayout(hkl, 0);
+            keybd_sync_layout();
+        }
         void keybd_sync_layout()
         {
             keybd_sync_state();
@@ -6319,6 +6331,7 @@ namespace netxs::gui
         void keybd_wipe_vkstat() {}
         void keybd_read_vkstat() {}
         void keybd_send_block(view /*block*/) {}
+        void keybd_turn_layout(ui32 /*hkl*/) {}
         void keybd_sync_layout() {}
         void keybd_peek_layout(si32 /*virtcod*/, si32 /*scancod*/, bool /*extflag*/, text& /*shifted*/, text& /*unshift*/, arch /*layout_id*/, bool /*apply_modifiers*/) {}
         void keybd_sync_state(si32 /*virtcod*/) {}

--- a/src/netxs/desktopio/system.hpp
+++ b/src/netxs/desktopio/system.hpp
@@ -4722,6 +4722,7 @@ namespace netxs::os
                     //{
                     //    writesyn.notify_one(); // Interrupt writing thread.
                     //    termlink->abort(termlink->stdinput); // Interrupt reading thread.
+                    //    // implemented in termlink->cleanup (on posix)
                     //}
                     attached.exchange(faux);
                     writesyn.notify_one();


### PR DESCRIPTION
### Changes

- Try to fix a long-standing bug that causes a deadlock when closing a terminal window.
  Repro:
  - Start a multi-user desktop session.
  - Run a terminal window with the bash shell.
  - Run vim in bash.
  - Refocus the terminal window.
  - Close the terminal window by clicking the cross.
- Sync keyboard layouts between multi-focused GUI windows.